### PR TITLE
ドキュメントの保存・表示を修正

### DIFF
--- a/include/ListView/ListViewController.php
+++ b/include/ListView/ListViewController.php
@@ -295,7 +295,7 @@ class ListViewController {
 									'" >'.textlength_check($value).
 									'</a>';
 						} elseif ($downloadType == 'I') {
-							$value = '<a href="'.$value.'"'.
+							$value = '<a onclick="event.stopPropagation()" href="'.$value.'" target="_blank"'.
 									' title="'.$value.
 									'" >'.textlength_check($value).
 									'</a>';

--- a/include/ListView/ListViewController.php
+++ b/include/ListView/ListViewController.php
@@ -294,6 +294,11 @@ class ListViewController {
 									' title="'.	getTranslatedString('LBL_DOWNLOAD_FILE',$module).	
 									'" >'.textlength_check($value).
 									'</a>';
+						} elseif ($downloadType == 'I') {
+							$value = '<a href="'.$value.'"'.
+									' title="'.$value.
+									'" >'.textlength_check($value).
+									'</a>';
 						} else {
 							$value = ' --';
 						}

--- a/layouts/v7/modules/Documents/CreateDocument.tpl
+++ b/layouts/v7/modules/Documents/CreateDocument.tpl
@@ -169,7 +169,11 @@
 									</td>
 									{if $FIELD_MODEL->get('uitype') neq '83'}
 										<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
+										{if $FILE_LOCATION_TYPE neq 'W'}
+											{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) type = "E"}
+										{else}
 											{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+										{/if}
 										</td>
 									{/if}
 								{/if}

--- a/layouts/v7/modules/Vtiger/uitypes/FileLocationType.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/FileLocationType.tpl
@@ -10,7 +10,11 @@
  ********************************************************************************/
 -->*}
 {strip}
-{assign var=FIELD_VALUES value=$FIELD_MODEL->getFileLocationType()}
+{if $type eq "E"}
+  {assign var=FIELD_VALUES value=$FIELD_MODEL->getFileLocationType2()}
+{else}
+  {assign var=FIELD_VALUES value=$FIELD_MODEL->getFileLocationType()}
+{/if}
 <select class="select2" name="{$FIELD_MODEL->getFieldName()}">
 {foreach item=TYPE key=KEY from=$FIELD_VALUES}
 	<option value="{$KEY}" {if $FIELD_MODEL->get('fieldvalue') eq $KEY} selected {/if}>{vtranslate($TYPE, $MODULE)}</option>

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -1093,6 +1093,10 @@ class Vtiger_Field_Model extends Vtiger_Field {
 		return array('I'=> vtranslate('LBL_INTERNAL','Documents'), 'E'=> vtranslate('LBL_EXTERNAL','Documents'));
 	}
 
+	public function getFileLocationType2() {
+		return array('E'=> vtranslate('LBL_EXTERNAL','Documents'),'I'=> vtranslate('LBL_INTERNAL','Documents'));
+	}
+
 	/**
 	 * Function returns list of Currencies available in the system
 	 * @return <Array>

--- a/modules/Vtiger/uitypes/DocumentsFileUpload.php
+++ b/modules/Vtiger/uitypes/DocumentsFileUpload.php
@@ -31,10 +31,14 @@ class Vtiger_DocumentsFileUpload_UIType extends Vtiger_Base_UIType {
 				if($fileLocationType == 'I') {
 					$db = PearDatabase::getInstance();
 					$fileIdRes = $db->pquery('SELECT attachmentsid FROM vtiger_seattachmentsrel WHERE crmid = ?', array($recordId));
-					$fileId = $db->query_result($fileIdRes, 0, 'attachmentsid');
+					$fileId = $db->query_result($fileIdRes, 0, 'attachmentsid');					
+					$matchPattern = "^[\w]+:\/\/^";
+					preg_match($matchPattern, $value, $matches);
 					if($fileId){
 						$value = '<a href="index.php?module=Documents&action=DownloadFile&record='.$recordId.'&fileid='.$fileId.'"'.
 									' title="'.	vtranslate('LBL_DOWNLOAD_FILE', 'Documents').'" >'.$value.'</a>';
+					} else if (!empty ($matches[0])){
+						$value = '<a href="'.$value.'" target="_blank" title="'. vtranslate('LBL_DOWNLOAD_FILE', 'Documents').'" >'.textlength_check($value).'</a>';
 					}
 				} else {
 					$value = '<a href="'.$value.'" target="_blank" title="'. vtranslate('LBL_DOWNLOAD_FILE', 'Documents').'" >'.textlength_check($value).'</a>';


### PR DESCRIPTION
## 問題

- 外部リンクを保存したときにリストにURLが表示されない
- 詳細画面に表示されるURLがハイパーリンクにならない

## 状況

ダウンロード種別は内部アップロード・外部リンクともにデフォルトで内部

|        |  ダウンロード種別-内部  |  ダウンロード種別-外部  |
| ---- | ---- | ---- |
|  内部アップロード  |  正常  |  保存時に自動でダウンロード種別-内部に変更  |
|  外部リンク  |  ﾘｽﾄにURLなし・詳細がﾊｲﾊﾟｰﾘﾝｸにならない  |  正常  |

## 修正

- 「外部リンク」ならダウンロード種別-外部がデフォルトで選択されるように変更

- 外部リンクでダウンロード種別-内部だとリストのファイル名と詳細画面のファイルのURLがハイパーリンクにならない問題を修正

