### PR TITLE
モジュールを関連から遷移した場合、左サイドバーのメニューがMARKETINGのものになる不具合修正

### DIFF
--- a/modules/Vtiger/views/Basic.php
+++ b/modules/Vtiger/views/Basic.php
@@ -51,7 +51,11 @@ abstract class Vtiger_Basic_View extends Vtiger_Footer_View {
 		$supportGroup = $menuGroupedByParent['SUPPORT'];
 		unset($menuGroupedByParent['SUPPORT']);
 		$menuGroupedByParent['SUPPORT'] = $supportGroup;
-        $parentApp = $request->get('app');
+		$parentApp = $request->get('app');
+		// もしリンクにカテゴリーが定義されていなかった場合、所属カテゴリーの一つを表示する
+		if(empty($parentApp)){
+			$parentApp = $this->getFirstModuleCategory($selectedModule, $menuGroupedByParent);
+		}
 
 		foreach ($menuGroupedByParent as $parentCategory => $menuList) {
 			if($parentCategory == 'ANALYTICS' || $parentCategory == 'SETTINGS') continue;
@@ -94,6 +98,20 @@ abstract class Vtiger_Basic_View extends Vtiger_Footer_View {
 		if($display) {
 			$this->preProcessDisplay($request);
 		}
+	}
+
+	/**
+	 * モジュール名から所属カテゴリーを一つ取得する
+	 */
+	protected function getFirstModuleCategory($selectedModule, $menuGroupedByParent){
+		foreach ($menuGroupedByParent as $category => $modules) {
+			foreach ($modules as $moduleName => $moduleModel) {
+				if($selectedModule == $moduleName){
+					return $category;
+				}
+			}
+		}
+		return "";
 	}
 
 	protected function preProcessTplName(Vtiger_Request $request) {

--- a/modules/Vtiger/views/Basic.php
+++ b/modules/Vtiger/views/Basic.php
@@ -104,10 +104,11 @@ abstract class Vtiger_Basic_View extends Vtiger_Footer_View {
 	 * モジュール名から所属カテゴリーを一つ取得する
 	 */
 	protected function getFirstModuleCategory($selectedModule, $menuGroupedByParent){
-		foreach ($menuGroupedByParent as $category => $modules) {
-			foreach ($modules as $moduleName => $moduleModel) {
+		$appMenuList = Vtiger_MenuStructure_Model::getAppMenuList();
+		foreach ($appMenuList as $parentCategory) {
+			foreach ($menuGroupedByParent[$parentCategory] as $moduleName => $moduleModel) {
 				if($selectedModule == $moduleName){
-					return $category;
+					return $parentCategory;
 				}
 			}
 		}


### PR DESCRIPTION
## 不具合

- 例えば、顧客企業の関連から製品に飛んだ場合、販売管理のカテゴリーのサイドバーになるはずがマーケティングのカテゴリーになる
- 別カテゴリーのモジュールでもマーケティングになる
![image](https://user-images.githubusercontent.com/53038605/101328181-0b035000-38b3-11eb-8f9a-fad5367e0f6f.png)

## 解決

- リンク先のモジュールが属するカテゴリーのサイドバーが表示されるように修正
- 複数のカテゴリーに属するモジュール(顧客企業など)の場合、左側に表示されるカテゴリーを優先
