### PR TITLE
共有カレンダーのマイグループの初期値をすべてのユーザーからcurrentUserのみに変更

### DIFF
--- a/layouts/v7/modules/Calendar/AddUserCalendar.tpl
+++ b/layouts/v7/modules/Calendar/AddUserCalendar.tpl
@@ -24,7 +24,7 @@
                 <div class="controls fieldValue col-sm-6">
                     <select class="select2" name="usersList" style="min-width: 250px;">
                         {foreach key=USER_ID item=USER_NAME from=$SHAREDUSERS}
-                            {if $SHAREDUSERS_INFO[$USER_ID]['visible'] == '0'}
+                            {if $SHAREDUSERS_INFO[$USER_ID]['visible'] != '1'}
                                 <option value="{$USER_ID}" data-calendar-group="false">{$USER_NAME}</option>
                             {/if}
                         {/foreach}

--- a/layouts/v7/modules/Calendar/CalendarSharedUsers.tpl
+++ b/layouts/v7/modules/Calendar/CalendarSharedUsers.tpl
@@ -44,7 +44,7 @@
 			</li>
 			{assign var=INVISIBLE_CALENDAR_VIEWS_EXISTS value='false'}
 			{foreach key=ID item=USER from=$SHAREDUSERS}
-				{if $SHAREDUSERS_INFO[$ID]['visible'] != '0'}
+				{if $SHAREDUSERS_INFO[$ID]['visible'] == '1'}
 					<li class="activitytype-indicator calendar-feed-indicator" style="background-color: {$SHAREDUSERS_INFO[$ID]['color']};">
 						<span class="userName textOverflowEllipsis" title="{$USER}">
 							{$USER}

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -1062,7 +1062,8 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 
 		$query = "SELECT distinct vtiger_users.first_name,vtiger_users.last_name, vtiger_users.id as userid
 			FROM vtiger_sharedcalendar RIGHT JOIN vtiger_users ON vtiger_sharedcalendar.userid=vtiger_users.id and status= 'Active'
-			WHERE sharedid=? OR (vtiger_users.status='Active' AND vtiger_users.calendarsharedtype='public');";
+			LEFT OUTER JOIN vtiger_shareduserinfo ON vtiger_shareduserinfo.shareduserid = vtiger_users.id
+			WHERE vtiger_users.status='Active' AND vtiger_users.calendarsharedtype='public' AND vtiger_shareduserinfo.userid=? AND vtiger_shareduserinfo.visible = 1;";
 		$result = $adb->pquery($query, array($id));
 		$rows = $adb->num_rows($result);
 


### PR DESCRIPTION
Closes #13

## 概要

表示するユーザーはすべてマイグループに手動で追加するように変更した。
"visible"は初期値でNULLであり、NULLの"visible"は「カレンダーの追加」で初めて1になり、削除されると0になる。

## 修正
"visible"が0とNULLのときカレンダーが表示されないように修正
"visible"が0とNULLのときカレンダーが追加できるように修正
ページ遷移せずにページ内でマイグループを表示した際に正常に表示されるように修正



