### PR TITLE
カレンダーのリスト表示でステータスを絞り込むとき、ピックリストの値がTODO・予定の区別がつかない問題を修正

### DIFF
--- a/layouts/v7/modules/Calendar/uitypes/StatusPickListFieldSearchView.tpl
+++ b/layouts/v7/modules/Calendar/uitypes/StatusPickListFieldSearchView.tpl
@@ -19,7 +19,11 @@
 	{assign var=EVENT_STATUS_FIELD_MODEL value=$EVENTS_MODULE_MODEL->getField('eventstatus')}
 	{assign var=EVENT_STAUTS_PICKLIST_VALUES value=$EVENT_STATUS_FIELD_MODEL->getPicklistValues()}
 	{foreach item=PICKLIST_LABEL key=PICKLIST_KEY from=$EVENT_STAUTS_PICKLIST_VALUES}
+	{if $PICKLIST_LABEL == vtranslate('Planned',"Calendar")}
+		{$EVENT_STAUTS_PICKLIST_VALUES[$PICKLIST_KEY]='('|cat:vtranslate('SINGLE_Calendar',"Calendar")|cat:'/'|cat:vtranslate('SINGLE_Events',"Calendar")|cat:')'|cat:$PICKLIST_LABEL}
+	{else}
 		{$EVENT_STAUTS_PICKLIST_VALUES[$PICKLIST_KEY]='('|cat:vtranslate('SINGLE_Events',"Calendar")|cat:')'|cat:$PICKLIST_LABEL}
+	{/if}
 	{/foreach}
 	{assign var=PICKLIST_VALUES value=array_merge($PICKLIST_VALUES, $EVENT_STAUTS_PICKLIST_VALUES)}
 	{assign var=SEARCH_VALUES value=explode(',',$SEARCH_INFO['searchValue'])}

--- a/layouts/v7/modules/Calendar/uitypes/StatusPickListFieldSearchView.tpl
+++ b/layouts/v7/modules/Calendar/uitypes/StatusPickListFieldSearchView.tpl
@@ -10,11 +10,17 @@
 {strip}
 	{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
 	{assign var=PICKLIST_VALUES value=$FIELD_INFO['picklistvalues']}
+	{foreach item=PICKLIST_LABEL key=PICKLIST_KEY from=$PICKLIST_VALUES}
+		{$PICKLIST_VALUES[$PICKLIST_KEY]='('|cat:vtranslate('SINGLE_Calendar',"Calendar")|cat:')'|cat:$PICKLIST_LABEL}
+	{/foreach}
 	{assign var=FIELD_INFO value=Vtiger_Util_Helper::toSafeHTML(Zend_Json::encode($FIELD_INFO))}
 
 	{assign var=EVENTS_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Events')}
 	{assign var=EVENT_STATUS_FIELD_MODEL value=$EVENTS_MODULE_MODEL->getField('eventstatus')}
 	{assign var=EVENT_STAUTS_PICKLIST_VALUES value=$EVENT_STATUS_FIELD_MODEL->getPicklistValues()}
+	{foreach item=PICKLIST_LABEL key=PICKLIST_KEY from=$EVENT_STAUTS_PICKLIST_VALUES}
+		{$EVENT_STAUTS_PICKLIST_VALUES[$PICKLIST_KEY]='('|cat:vtranslate('SINGLE_Events',"Calendar")|cat:')'|cat:$PICKLIST_LABEL}
+	{/foreach}
 	{assign var=PICKLIST_VALUES value=array_merge($PICKLIST_VALUES, $EVENT_STAUTS_PICKLIST_VALUES)}
 	{assign var=SEARCH_VALUES value=explode(',',$SEARCH_INFO['searchValue'])}
 	<div class="select2_search_div">


### PR DESCRIPTION
## 不具合

カレンダーのリスト表示でステータスを絞り込もうとするとTODOと予定の値が一緒に出る
closes #19 

## 修正

｢(TODO)完了｣、｢(活動)完了｣のように前に種別を表示するように変更