### PR TITLE
JPGファイルがアップロードできない問題を修正

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -24,10 +24,10 @@ RUN set -xe; \
       docker-php-ext-install zip \
     && docker-php-ext-install bcmath gettext mbstring mysqli pdo pdo_mysql zip \
     && docker-php-ext-configure mbstring --disable-mbregex \
-    # gd
+    # gd exif
     && docker-php-ext-install -j$(nproc) iconv \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-install -j$(nproc) gd exif \
     # for imap
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install -j$(nproc) imap

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -7,6 +7,7 @@ post_max_size = 32M
 upload_max_filesize = 32M
 max_execution_time = 60
 display_errors = Off
+short_open_tag = Off
 
 [Date]
 date.timezone = "Asia/Tokyo"


### PR DESCRIPTION
### 不具合
JPGファイルをアップロードしようとするとエラーが発生する
Fixes #24 

### 修正

- dockerfileに exif を追加
- php.iniにshort_open_tag=offを追加