### PR TITLE
#28 日報の一覧画面で提出先が検索できない不具合の修正

### DIFF
--- a/modules/Migration/schema/731_to_732.php
+++ b/modules/Migration/schema/731_to_732.php
@@ -14,4 +14,31 @@ if (defined('VTIGER_UPGRADE')) {
 
 	//課税計算の手数料額をnullから0円に変更
 	$db->query("UPDATE vtiger_inventorycharges SET value = 0 WHERE value IS NULL;");
+
+	// 日報モジュールの提出先のuitypeを10、V~Mに変更する
+	$db->query("
+		UPDATE vtiger_field, vtiger_tab 
+		SET uitype = 10
+		WHERE vtiger_tab.tabid = vtiger_field.tabid 
+			and vtiger_field.fieldname = 'reports_to_id'
+			and vtiger_tab.name = 'Dailyreports'
+	");
+	// type of dataもV~となるようにする
+	// すでに必須から外されているケースを考慮し、適切に更新できるようにする
+	$db->query("
+		UPDATE vtiger_field, vtiger_tab 
+		SET typeofdata = 'V~M'
+		WHERE vtiger_tab.tabid = vtiger_field.tabid 
+			and vtiger_field.fieldname = 'reports_to_id'
+			and vtiger_field.typeofdata LIKE '%~M'
+			and vtiger_tab.name = 'Dailyreports'
+	");
+	$db->query("
+		UPDATE vtiger_field, vtiger_tab 
+		SET typeofdata = 'V~O'
+		WHERE vtiger_tab.tabid = vtiger_field.tabid 
+			and vtiger_field.fieldname = 'reports_to_id'
+			and vtiger_field.typeofdata LIKE '%~O'
+			and vtiger_tab.name = 'Dailyreports'
+	");
 }


### PR DESCRIPTION
#28 の修正です。

原因は以下でした。
- uitype53の項目（担当）が、1モジュールに複数あると本Issueのような現象が起きます。

これを回避するために、SQLでvtiger_fieldの該当項目を10に変更し、検索用にtypeofdataも'V~M'or'V~O'となるようなMigrationスクリプトを追加しました。

制約事項として、マイグレーションを動かす必要がありますが、v7.3.2相当のタイミングで動くようにしているので、一度もう動かしているユーザーさんは手動でSQLを実行して貰う必要があります。