### PR TITLE
#43 項目編集のスイッチの翻訳とスタイルを修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -142,7 +142,7 @@
 								<label class="checkbox">
 									<input type="checkbox" class ='cursorPointer bootstrap-switch' id="fieldPresence" name="presence" {if $FIELD_MODEL->isViewable()} checked {/if}
 										{if $FIELD_MODEL->isActiveOptionDisabled()} readonly="readonly" {/if} {if $FIELD_MODEL->isMandatory()} readonly="readonly" {/if}
-										data-on-text="Yes" data-off-text="No" value="{$FIELD_MODEL->get('presence')}"/>
+										data-on-text="{vtranslate('LBL_YES', $QUALIFIED_MODULE)}" data-off-text="{vtranslate('LBL_NO', $QUALIFIED_MODULE)}" value="{$FIELD_MODEL->get('presence')}"/>
 								</label>
 							</div>
 						</div>

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1863,7 +1863,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 								thisInstance.showFieldEditModel(data, blockId, container);
 								data.find('[name="fieldType"]').trigger('change');
 								jQuery('#fieldPresence').bootstrapSwitch();
-								jQuery('#fieldPresence').bootstrapSwitch('handleWidth', '27px');
+								jQuery('#fieldPresence').bootstrapSwitch('handleWidth', '40px');
 								jQuery('#fieldPresence').bootstrapSwitch('labelWidth', '25px');
 
 								jQuery('#fieldPresence').on('switchChange.bootstrapSwitch', function (e) {
@@ -2084,7 +2084,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					thisInstance.registerAddCustomBlockEvent();
 					thisInstance.registerFieldSequenceSaveClick();
 					jQuery("input[name='collapseBlock']").bootstrapSwitch();
-					jQuery("input[name='collapseBlock']").bootstrapSwitch('handleWidth', '27px');
+					jQuery("input[name='collapseBlock']").bootstrapSwitch('handleWidth', '40px');
 					jQuery("input[name='collapseBlock']").bootstrapSwitch('labelWidth', '25px');
 					thisInstance.registerSwitchActionOnFieldProperties();
 					thisInstance.registerAddCustomField();


### PR DESCRIPTION
## 概要
モジュール設定→項目設定のスイッチが崩れていた・翻訳が入っていなかった

## 修正
bootstrap-switchのサイズの変更とvtransrateを追加
![image](https://user-images.githubusercontent.com/53038605/107919655-0ba11c80-6faf-11eb-8bff-8d6f05353f9a.png)
![image](https://user-images.githubusercontent.com/53038605/107919792-355a4380-6faf-11eb-9b37-e51354ce097b.png)

closes #43
