### PR TITLE
#33 一覧リストの｢その他｣ボタンを押したあと上部メニューを押すと重なってしまう不具合を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -701,6 +701,7 @@ Vtiger.Class('Vtiger_Index_Js', {
 		jQuery('.app-modules-dropdown-container').hover(function(e) {
 			var dropdownContainer = jQuery(e.currentTarget);
 			jQuery('.dropdown').removeClass('open');
+			jQuery('.listViewMassActions').removeClass('open');
 			if(dropdownContainer.length) {
 				//Fix for Responsive layout Sub Menu in mobile devices
 				var appModulesDropdown = dropdownContainer.find('.app-modules-dropdown');


### PR DESCRIPTION
close #33 
## 概要
#33 参照
## 修正
上部メニューが開いたときに｢その他｣ボタンのドロップダウンが消えるように変更