### PR TITLE
#32 関連項目としてユーザーモジュールを選択できるように修正

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -2400,7 +2400,16 @@ class CRMEntity {
 					$matrix->addDependency($tab_name, $crmentityRelModuleFieldTable);
 
 					if ($queryPlanner->requireTable($crmentityRelModuleFieldTable, $matrix)) {
-						$relquery.= " LEFT JOIN vtiger_crmentity AS $crmentityRelModuleFieldTable ON $crmentityRelModuleFieldTable.crmid = $tab_name.$field_name AND vtiger_crmentityRel$module$field_id.deleted=0";
+						// Usersを関連にした場合、vtiger_crmentityをJoinするとレコードがないため、vtiger_usersを一度JOINする
+						if($rel_mod == "Users"){
+							// vtiger_crmentityの代わりとして動かすため、
+							//   - vtiger_users.id as `crmid` として振る舞わせる
+							//   - deleted = 0となっていた箇所は、vtiger_users.status = 'Active'で判定する
+							// [TODO] Usersの場合、通常のレコードとは異なり過去のユーザーも見せたいのであれば、この判定は無く必要がある
+							$relquery.= " LEFT JOIN (select u.*, u.id as `crmid` from vtiger_users u) AS $crmentityRelModuleFieldTable ON $crmentityRelModuleFieldTable.id = $tab_name.$field_name AND vtiger_crmentityRel$module$field_id.status='Active'";
+						}else{
+							$relquery.= " LEFT JOIN vtiger_crmentity AS $crmentityRelModuleFieldTable ON $crmentityRelModuleFieldTable.crmid = $tab_name.$field_name AND vtiger_crmentityRel$module$field_id.deleted=0";
+						}
 					}
 
 					$calendarFlag = false;

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -164,6 +164,7 @@ $languageStrings = array(
 	'LBL_ADVANCE_SEARCH' => 'Advanced',
 	'LBL_LOADING_PLEASE_WAIT' => 'Loading, Please wait.',
 	'LBL_PLEASE_SELECT_MODULE' => 'Please select any module to search',
+	'LBL_CANT_SELECT_THE_OTHER_MODULE_WITH_USERS_FOR_RELFIELD' => ' cannot be selected at the same time as other modules.',
 
 	//DropDown Category
 	'LBL_USERS' => 'Users',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -166,6 +166,7 @@ $languageStrings = array(
 	'LBL_ADVANCE_SEARCH' => '詳細',
 	'LBL_LOADING_PLEASE_WAIT' => '読み込み中です。少々お待ちください。',
 	'LBL_PLEASE_SELECT_MODULE' => 'モジュールを選択してから検索してください。',
+	'LBL_CANT_SELECT_THE_OTHER_MODULE_WITH_USERS_FOR_RELFIELD' => 'は、他のモジュールと同時に選択できません',
 
 	//DropDown Category
 	'LBL_USERS' => 'ユーザ',

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -115,7 +115,7 @@
 								</div>
 							</div>
 						</div>
-						<div class="form-group supportedType relationModules hide">
+						<div class="form-group supportedType relationModules clearfix hide">
 							<label class="control-label fieldLabel col-sm-5">
 								{vtranslate('SELECT_MODULE', $QUALIFIED_MODULE)}
 								&nbsp;<span class="redColor">*</span>
@@ -126,6 +126,7 @@
 										<option value="{$RELATION_MODULE_NAME}">{$TRANS_RELATION_MODULE_NAME}</option>
 									{/foreach}
 								</select>
+								<p class="related_field_caution">{vtranslate('Users', 'Vtiger')}{vtranslate('LBL_CANT_SELECT_THE_OTHER_MODULE_WITH_USERS_FOR_RELFIELD', 'Vtiger')}</p>
 							</div>
 						</div>
 					{/if}

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -601,6 +601,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		vtUtils.showSelect2ElementView(form.find('[name="pickListValues"]'), select2params);
 
 		this.registerFieldTypeChangeEvent(form);
+		this.registerRelationFieldValidationEvent(form);
 		data.find('.fieldTypesList').trigger('change');
 
 		var params = {
@@ -837,6 +838,29 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		}
 		return aDeferred.promise();
 	},
+
+	/**
+	 * Function to register validation event for relation field 
+	 * @param {*} form 
+	 */
+	registerRelationFieldValidationEvent: function(form) {
+		$(form).on('change', '.relationModule', function(){
+			var values = $(this).val();
+			if(values){
+				var usersIndex = values.indexOf('Users');
+				var hasUsers = (usersIndex != -1) ? true : false;
+				var valuesCount = values.length;
+				if(valuesCount > 1 && hasUsers){
+					var changedArray = values.splice(usersIndex, 1);
+					$(this).val(values); 
+					setTimeout(function(){
+						$('.relationModule').trigger('change');
+					},100);
+				}
+			}
+		});
+	},
+
 	/**
 	 * Function to register change event for fieldType while adding custom field
 	 */

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -388,6 +388,9 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 				$modulesList[$moduleName] = vtranslate($moduleName, 'Settings:LayoutEditor');
 			}
 		}
+		// Usersの追加
+		$modulesList["Users"] = vtranslate("Users", "Users");
+
 		// If calendar is disabled we should not show events module too
 		// in layout editor
 		if(!array_key_exists('Calendar', $modulesList)) {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -217,3 +217,10 @@ div.detailview-content.container-fluid span.value img {
       text-align: left;
   }
 }
+/*
+ * カスタム項目編集画面
+ */
+.related_field_caution{
+  margin-top: 10px;
+  float: left;
+}


### PR DESCRIPTION
#32 の課題について、選択肢に表示することと、レポートで表示されなかった問題を合わせて修正
コミットの中に混ぜてますが、 `CRMEntity.php  getReportsUiType10Query() `内の以下のコードについて、
```php
if ($queryPlanner->requireTable($crmentityRelModuleFieldTable, $matrix)) {
    // Usersを関連にした場合、vtiger_crmentityをJoinするとレコードがないため、vtiger_usersを一度JOINする
    if($rel_mod == "Users"){
        // vtiger_crmentityの代わりとして動かすため、
        //   - vtiger_users.id as `crmid` として振る舞わせる
        //   - deleted = 0となっていた箇所は、vtiger_users.status = 'Active'で判定する
        // [TODO] Usersの場合、通常のレコードとは異なり過去のユーザーも見せたいのであれば、この判定は無く必要がある
        $relquery.= " LEFT JOIN (select u.*, u.id as `crmid` from vtiger_users u) AS $crmentityRelModuleFieldTable ON $crmentityRelModuleFieldTable.id = $tab_name.$field_name AND vtiger_crmentityRel$module$field_id.status='Active'";
    }else{
        $relquery.= " LEFT JOIN vtiger_crmentity AS $crmentityRelModuleFieldTable ON $crmentityRelModuleFieldTable.crmid = $tab_name.$field_name AND vtiger_crmentityRel$module$field_id.deleted=0";
    }
}
```
`vtiger_crmentity.deleted = 0`を確認する箇所なので、上記修正で問題ないと思いますが影響範囲は追いきれてません。  
また、TODOとして記載してある箇所、現在はいないユーザーのレポート上での振る舞いについても確認していただければ。