### PR TITLE
#10 カレンダーの関連の顧客担当者が編集時に消える問題を修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -173,24 +173,27 @@ class Activity extends CRMEntity {
 		}
 
 		$recordId = intval($this->id);
-		if(isset($_REQUEST['contactidlist']) && $_REQUEST['contactidlist'] != '') {
-			$adb->pquery( 'DELETE from vtiger_cntactivityrel WHERE activityid = ?', array($recordId));
 
-			$contactIdsList = explode (';', $_REQUEST['contactidlist']);
-			$count = count($contactIdsList);
-            $params=array();
-			$sql = 'INSERT INTO vtiger_cntactivityrel VALUES ';
-			for($i=0; $i<$count; $i++) {
-				$contactIdsList[$i] = intval($contactIdsList[$i]);
-				$sql .= " (?, ?)";
-				array_push($params,$contactIdsList[$i],$recordId);
-				if ($i != $count - 1) {
-					$sql .= ',';
+		//ドラッグ&ドロップ時にはContactsは変更されずcontactidlistを得られないので関連を更新しない
+		if(empty($_REQUEST['isDragDrop'])){
+			if(isset($_REQUEST['contactidlist']) && $_REQUEST['contactidlist'] != '') {
+				$adb->pquery( 'DELETE from vtiger_cntactivityrel WHERE activityid = ?', array($recordId));
+				$contactIdsList = explode (';', $_REQUEST['contactidlist']);
+				$count = count($contactIdsList);
+				$params=array();
+				$sql = 'INSERT INTO vtiger_cntactivityrel VALUES ';
+				for($i=0; $i<$count; $i++) {
+					$contactIdsList[$i] = intval($contactIdsList[$i]);
+					$sql .= " (?, ?)";
+					array_push($params,$contactIdsList[$i],$recordId);
+					if ($i != $count - 1) {
+						$sql .= ',';
+					}
 				}
+				$adb->pquery($sql, $params);
+			} else if ($_REQUEST['contactidlist'] == '' && $insertion_mode == "edit") {
+				$adb->pquery('DELETE FROM vtiger_cntactivityrel WHERE activityid = ?', array($recordId));
 			}
-			$adb->pquery($sql, $params);
-		} else if ($_REQUEST['contactidlist'] == '' && $insertion_mode == "edit") {
-			$adb->pquery('DELETE FROM vtiger_cntactivityrel WHERE activityid = ?', array($recordId));
 		}
 
 		//Insert into cntactivity rel

--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -167,6 +167,9 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 		$recurringEditMode = $request->get('recurringEditMode');
 		$actionname = 'EditView';
 
+		//ドラッグ&ドロップ時にContactsを更新しないようにフラグを作成
+		$_REQUEST['isDragDrop'] = 1;
+
 		$response = new Vtiger_Response();
 		try {
 			if(isPermitted($moduleName, $actionname, $recordId) === 'no'){


### PR DESCRIPTION
close #10 
## 概要

1. 関連に顧客担当者が複数登録された活動を作成する
1. 活動の日時をドラッグして変更する
1. 活動をクリックして編集画面を開く
1. 顧客担当者が消える

## 原因

ドラッグ&ドロップ時には$_REQUESTに顧客担当者の情報が存在しないので顧客担当者がいないものとして扱われてしまう

## 修正

* ドラッグ&ドロップ時に$_REQUESTにフラグを追加
* フラグがある場合、顧客担当者を更新しないように修正