### PR TITLE
docker-compose.ymlのPHPコンテナも常時自動起動するような設定に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
         context: '.'
         dockerfile: ./docker/php/Dockerfile
+    restart: always
     volumes:
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
       - ./:/var/www/html:cached


### PR DESCRIPTION
mysqlのコンテナは常時起動する設定になっているが、apache+phpのコンテナは常時起動しない設定になっていたため、docker-compose.ymlを変更しました。