### PR TITLE
カレンダー画面で終日予定をドラッグすると、終日チェックが外れない件を修正。

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1279,7 +1279,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			'activitytype': event.activitytype,
 			'secondsDelta': delta.asSeconds(),
 			'view': view.name,
-			'userid': event.userid
+			'userid': event.userid,
+			'allday': event.allDay,
 		};
 
 		if (event.recurringcheck) {
@@ -1306,7 +1307,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			'activitytype': event.activitytype,
 			'secondsDelta': delta.asSeconds(),
 			'view': view.name,
-			'userid': event.userid
+			'userid': event.userid,
+			'allday': event.allDay,
 		};
 
 		if (event.recurringcheck) {

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -478,6 +478,7 @@ function insertIntoRecurringTable(& $recurObj)
 					$inviteRecord->set('invitees_array', $invitees_array);
 					$inviteRecord->set('is_not_invitees_update', true);
 					$inviteRecord->set('mode', 'edit');
+					$inviteRecord->set('is_allday', $this->is_allday);
 					$inviteRecord->save();
 				} else {
 					$inviteRecord->getModule()->deleteRecord($inviteRecord);
@@ -504,6 +505,7 @@ function insertIntoRecurringTable(& $recurObj)
 				$inviteRecord->set('invitees_array', $invitees_array);
 				$inviteRecord->set('assigned_user_id', $inviteeid);
 				$inviteRecord->set('is_not_invitees_update', true);
+				$inviteRecord->set('is_allday', $this->is_allday);
 				$inviteRecord->save();
 			}
 		}

--- a/modules/Calendar/RepeatEvents.php
+++ b/modules/Calendar/RepeatEvents.php
@@ -210,6 +210,7 @@ class Calendar_RepeatEvents {
 						continue;
 					}
 					$recordModel = Vtiger_Record_Model::getInstanceById($recordId);
+					$recordModel->set("is_allday", $focus->is_allday); //recordModulにis_alldayが無いので追加
 					$recordModel->set('mode', 'edit');
 					if($focus->column_fields['recurringEditMode'] == 'future' && $recordModel->get('date_start') >= $eventStartDate) {
 						$startDateTimestamp = strtotime($startDate);
@@ -329,6 +330,9 @@ class Calendar_RepeatEvents {
 					$new_focus->column_fields['date_start'] = $startDate;
 				} else if($key == 'due_date') {
 					$new_focus->column_fields['due_date']   = $endDate;
+				} else if($key == 'is_allday') {
+					$new_focus->is_allday                   = $value;
+					$new_focus->column_fields[$key]         = $value;
 				} else {
 					$new_focus->column_fields[$key]         = $value;
 				}

--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -41,10 +41,6 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 				$result = array('ispermitted'=>false,'error'=>false);
 				$response->setResult($result);
 			} else {
-				//招待情報を設定する。
-				$inviteesstring = implode(";",array_keys(Events_Util_Helper::getInvitees($recordId)));
-				$_REQUEST['inviteesid'] = $inviteesstring;
-
 				$result = array('ispermitted'=>true,'error'=>false);
 				$record = Vtiger_Record_Model::getInstanceById($recordId, $moduleName);
 				$record->set('mode','edit');
@@ -197,10 +193,6 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 				$result = array('ispermitted'=>false);
 				$response->setResult($result);
 			} else {
-				//招待情報を設定する。
-				$inviteesstring = implode(";",array_keys(Events_Util_Helper::getInvitees($recordId)));
-				$_REQUEST['inviteesid'] = $inviteesstring;
-
 				$result = array('ispermitted'=>true);
 				$record = Vtiger_Record_Model::getInstanceById($recordId, $moduleName);
 				$record->set('mode','edit');

--- a/modules/Calendar/views/Edit.php
+++ b/modules/Calendar/views/Edit.php
@@ -159,6 +159,12 @@ Class Calendar_Edit_View extends Vtiger_Edit_View {
 
 		$viewer->assign('RECORD_STRUCTURE_MODEL', $recordStructureInstance);
 		$viewer->assign('RECORD_STRUCTURE', $recordStructureInstance->getStructure());
+		// is_alldayはRecordStructure内で処理できないため、手動で追加する
+		if(!empty($request->get("is_allday"))){
+			if($request->get("is_allday") == "on"){
+				$viewer->assign('IS_ALLDAY', true);
+			}
+		}
 
 		$viewer->assign('MODULE', $moduleName);
 		$viewer->assign('CURRENTDATE', date('Y-n-j'));

--- a/modules/Events/actions/Save.php
+++ b/modules/Events/actions/Save.php
@@ -84,6 +84,11 @@ class Events_Save_Action extends Calendar_Save_Action {
 			$focus =  CRMEntity::getInstance('Events');
 			//get all the stored data to this object
 			$focus->column_fields = new TrackableObject($recordModel->getData());
+			if($recordModel->get('is_allday')){
+				$focus->is_allday = true;
+			}else{
+				$focus->is_allday = false;
+			}
 			try {
 				Calendar_RepeatEvents::repeatFromRequest($focus, $recurObjDb);
 			} catch (DuplicateException $e) {


### PR DESCRIPTION
非終日から終日にドラッグした際に開始時刻と終了時刻を0時に設定するように修正。
終日から非終日にドラッグした際に終了時刻を開始時刻から2時間後に設定するように修正。