### PR TITLE
docker環境にxdebug3がインストールされるように修正し、README.mdを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,37 @@ cp -r frevocrm.20201001/storage/* frevocrm/storage/
 # コマンド例
 rm -r frevocrm.20170118
 ```
+
+## 開発環境の構築
+Dockerで構築する為、[docker/README.md](./docker/README.md)を参照してください。  
+
+### xdebug
+xdebug3がインストール済みです。
+`docker-compose.yml` の以下の部分を修正してください
+```yml
+# Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
+# XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
+XDEBUG_CONFIG: "mode=debug client_host=host.docker.internal client_port=9003 start_with_request=yes"
+```
+
+vscodeをご利用の場合は、以下のように `.vscode/launch.json`を修正してください。
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+       "name": "F-RevoCRM XDebug:9003",
+       "type": "php",
+       "request": "launch",
+       "port": 9003, 
+       "pathMappings": {
+          "/var/www/html": "${workspaceRoot}"
+       }
+      }
+  ]
+ }
+```
+
 ## 更新履歴
 
 ### F-RevoCRM7.3.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,13 @@ services:
     ports:
       - 80:80
     environment:
-      - FREVOCRM_INSTALLER_DB_HOST=db
-      - FREVOCRM_INSTALLER_DB_PORT=3306
-      - FREVOCRM_INSTALLER_DB_USER=root
-      - FREVOCRM_INSTALLER_DB_PASSWORD=docker
-      - FREVOCRM_INSTALLER_DB_NAME=frevocrm
-
+      FREVOCRM_INSTALLER_DB_HOST: "db"
+      FREVOCRM_INSTALLER_DB_PORT: "3306"
+      FREVOCRM_INSTALLER_DB_USER: "root"
+      FREVOCRM_INSTALLER_DB_PASSWORD: "docker"
+      FREVOCRM_INSTALLER_DB_NAME: "frevocrm"
+      # Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
+      XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
   db:
     build:
       context: "."
@@ -27,11 +28,11 @@ services:
       - db-store:/var/lib/mysql
       - db-log-store:/var/log/mysql
     environment:
-      - MYSQL_DATABASE=frevocrm
-      - MYSQL_USER=docker
-      - MYSQL_PASSWORD=docker
-      - MYSQL_ROOT_PASSWORD=docker
-      - TZ=Asia/Tokyo
+      MYSQL_DATABASE: "frevocrm"
+      MYSQL_USER: "docker"
+      MYSQL_PASSWORD: "docker"
+      MYSQL_ROOT_PASSWORD: "docker"
+      TZ: "Asia/Tokyo"
     ports:
       - 3306:3306
 volumes:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -31,3 +31,5 @@ RUN set -xe; \
     # for imap
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install -j$(nproc) imap
+RUN pecl install xdebug \
+  && docker-php-ext-enable xdebug

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -11,3 +11,10 @@ short_open_tag = Off
 
 [Date]
 date.timezone = "Asia/Tokyo"
+
+[xdebug]
+xdebug.mode=debug
+xdebug.start_with_request = yes
+; host.docker.internalはdockerのhostマシンのIPを解決してくれる。
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003


### PR DESCRIPTION
開発を行うにあたって、デバッグツールが無いのは不便だったため追加しました。
docker-compose.yml上では、xdebugは無効に設定しているので、手動で実行設定にしない限りは動きません。