### PR TITLE
#116 概要画面で関連項目を編集する際,ウィンドウの幅が一定の範囲の場合表示が崩れる不具合を修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -250,3 +250,16 @@ div.detailview-content.container-fluid span.value img {
   margin-top: 10px;
   float: left;
 }
+/* 概要画面の関連項目 */
+.summaryView .input-group.editElement {
+  min-width: auto;
+}
+.summaryView .input-group.editElement .referencefield-wrapper {
+  width: 100% ;
+}
+.summaryView .input-group.editElement .referencefield-wrapper .input-group {
+  min-width: auto;
+}
+.summaryView .input-group.editElement .referencefield-wrapper .input-group .inputElement {
+  width: 100% ;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #116 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  概要画面で関連項目を編集する際,ウィンドウの幅が一定の範囲の場合表示が崩れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  minwidthの設定により,幅が狭まったときにはみ出てしまう

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  minwidthをautoや100%に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/114128227-d5d93e00-9936-11eb-9d04-811b8f10a75b.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
summaryView内部

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->