### PR TITLE
#83 システム設定の画面幅が小さくなるとフィールドラベルが右寄せになる不具合を修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -221,8 +221,9 @@ div.detailview-content.container-fluid span.value img {
 @media all and (min-width: 0px) and (max-width: 830px) {
   .detailview-table .fieldLabel,
   .recordEditView .fieldLabel,
-  .summaryView .fieldLabel{
-      text-align: left;
+  .summaryView .fieldLabel,
+  .detailViewInfo.userPreferences .table.detailview-table .fieldLabel{
+    text-align: left;
   }
 }
 .settingsIndexPage .settingsSummary a {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #83

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. システム設定の画面幅が小さくなるとフィールドラベルが右寄せになる

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  画面幅が狭まるとラベルとバリューは二段重ねになるが,ラベルのスタイルが右寄せのままであり, #41 の変更の一部がusersに適用されていなかった.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 画面幅が830以下ではラベルを左寄せ

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/114133266-bf37e480-9940-11eb-8706-8eb8714b61ed.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
usersモジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->