### PR TITLE
#114 レポート及びドキュメントモジュールのリスト表示画面で幅を狭くするとフォルダとリストの表示が偏る不具合を修正

### DIFF
--- a/layouts/v7/modules/Reports/resources/List.js
+++ b/layouts/v7/modules/Reports/resources/List.js
@@ -481,7 +481,6 @@ Vtiger_List_Js("Reports_List_Js",{
 
 	registerFolderScroll : function() {
 		app.helper.showVerticalScroll(jQuery('.list-menu-content'), {
-			setHeight: 450,
 			autoExpandScrollbar: true,
 			scrollInertia: 200,
 			autoHideScrollbar: true

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -264,3 +264,9 @@ div.detailview-content.container-fluid span.value img {
 .summaryView .input-group.editElement .referencefield-wrapper .input-group .inputElement {
   width: 100% ;
 }
+@media (max-width: 991px) {
+  .main-container-Documents #sidebar-essentials.sidebar-essentials,
+  .main-container-Reports #sidebar-essentials.sidebar-essentials {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #114

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートのリスト表示画面で幅を狭くするとフォルダとリストの表示が偏る
2. ドキュメントのリスト表示画面で幅を狭くするとフォルダとリストの表示が偏る

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  画面幅が狭くなり,サイドバーが上部に移動しても,widthが固定値のままであった
2. レポートのみ,サイドバーのheightがjqueryで固定されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. widthが991px以下のときサイドバーのwidthを100%に変更
2. レポートのサイドバーのheightの固定を解除

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
- レポート
![image](https://user-images.githubusercontent.com/53038605/114157661-d5ed3400-995e-11eb-978c-49e42bed8879.png)
- ドキュメント
![image](https://user-images.githubusercontent.com/53038605/114157553-b524de80-995e-11eb-97a1-827281b1e867.png)



## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポートとドキュメントのリスト表示画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->