### PR TITLE
環境変数にDBのルートユーザーID、PWが入っている場合、インストーラーでの入力をスキップするように修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       FREVOCRM_INSTALLER_DB_USER: "root"
       FREVOCRM_INSTALLER_DB_PASSWORD: "docker"
       FREVOCRM_INSTALLER_DB_NAME: "frevocrm"
+      FREVOCRM_INSTALLER_DB_ROOT_USER: "root"
+      FREVOCRM_INSTALLER_DB_ROOT_PASSWORD: "docker"
       # Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
       XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
   db:

--- a/layouts/v7/modules/Install/Step4.tpl
+++ b/layouts/v7/modules/Install/Step4.tpl
@@ -63,18 +63,18 @@
 							<tr>
 								<td colspan="2">
 									<label>
-										<input type="checkbox" name="create_db"/>
+										<input type="checkbox" name="create_db" {$IS_CREATE_NEW_DB}/>
 										<span>{vtranslate('LBL_CREATE_NEW_DB','Install')}</span>
 									</label>
 								</td>
 							</tr>
-							<tr class="hide" id="root_user">
+							<tr class="{if empty($IS_CREATE_NEW_DB)}hide{else}{/if}" id="root_user">
 								<td>{vtranslate('LBL_ROOT_USERNAME', 'Install')}<span class="no">*</span></td>
-								<td><input type="text" value="" name="db_root_username"></td>
+								<td><input type="text" value="{$DB_ROOT_USER}" name="db_root_username"></td>
 							</tr>
-							<tr class="hide" id="root_password">
+							<tr class="{if empty($IS_CREATE_NEW_DB)}hide{else}{/if}" id="root_password">
 								<td>{vtranslate('LBL_ROOT_PASSWORD', 'Install')}</td>
-								<td><input type="password" value="" name="db_root_password"></td>
+								<td><input type="password" value="{$DB_ROOT_PASSWORD}" name="db_root_password"></td>
 							</tr>
 						</tbody>
 					</table>

--- a/modules/Install/models/Utils.php
+++ b/modules/Install/models/Utils.php
@@ -185,6 +185,7 @@ class Install_Utils_Model {
 				
 				$parameters['admin_password'] = $vtconfig['adminPwd'];
 				$parameters['admin_email']    = $vtconfig['adminEmail'];
+				$parameters['is_create_new_db'] = '';
 			}
 		}
 
@@ -201,6 +202,15 @@ class Install_Utils_Model {
 		}
 		if(empty($parameters['db_name']) && !empty($_ENV['FREVOCRM_INSTALLER_DB_NAME'])){
 			$parameters['db_name'] = $_ENV['FREVOCRM_INSTALLER_DB_NAME'];
+		}
+		if(empty($parameters['db_root_user']) && !empty($_ENV['FREVOCRM_INSTALLER_DB_ROOT_USER'])){
+			$parameters['db_root_user'] = $_ENV['FREVOCRM_INSTALLER_DB_ROOT_USER'];
+			if(!empty($parameters['db_root_user'])){
+				$parameters['is_create_new_db'] = 'checked="checked"';
+			}
+		}
+		if(empty($parameters['db_root_password']) && !empty($_ENV['FREVOCRM_INSTALLER_DB_ROOT_PASSWORD'])){
+			$parameters['db_root_password'] = $_ENV['FREVOCRM_INSTALLER_DB_ROOT_PASSWORD'];
 		}
 		
 		return $parameters;

--- a/modules/Install/views/Index.php
+++ b/modules/Install/views/Index.php
@@ -107,6 +107,9 @@ class Install_Index_view extends Vtiger_View_Controller {
 		$viewer->assign('DB_USERNAME', $defaultParameters['db_username']);
 		$viewer->assign('DB_PASSWORD', $defaultParameters['db_password']);
 		$viewer->assign('DB_NAME', $defaultParameters['db_name']);
+		$viewer->assign('DB_ROOT_USER', $defaultParameters['db_root_user']);
+		$viewer->assign('DB_ROOT_PASSWORD', $defaultParameters['db_root_password']);
+		$viewer->assign('IS_CREATE_NEW_DB', $defaultParameters['is_create_new_db']);
 		$viewer->assign('ADMIN_NAME', $defaultParameters['admin_name']);
 		$viewer->assign('ADMIN_LASTNAME', $defaultParameters['admin_lastname']);
 		$viewer->assign('ADMIN_PASSWORD', $defaultParameters['admin_password']);


### PR DESCRIPTION
##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  初期インストール時に特定の環境変数が入っている場合に、自動で入力済みの状態にする

## 影響範囲  / Affected Area
インストール時のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
