### PR TITLE
fiexd #140 ドキュメントのアップロードモーダルをデバイスの横幅に応じてレイアウトするよう修正

### DIFF
--- a/layouts/v7/modules/Documents/CreateDocument.tpl
+++ b/layouts/v7/modules/Documents/CreateDocument.tpl
@@ -9,7 +9,7 @@
 
 {strip}
 <div class="modal-dialog modelContainer">
-	<div class="modal-content" style="width:675px;">
+	<div class="modal-content">
 	{assign var=HEADER_TITLE value={vtranslate('LBL_NEW_DOCUMENT', $MODULE)}}
 	{include file="ModalHeader.tpl"|vtemplate_path:$MODULE TITLE=$HEADER_TITLE}
 	<div class="modal-body">
@@ -33,71 +33,58 @@
 						{/if}
 					{/if}
 
-					<table class="massEditTable table no-border">
-						<tr>
-							{assign var="FIELD_MODEL" value=$FIELD_MODELS['notes_title']}
-							<td class="fieldLabel col-lg-2">
-								<label class="muted pull-right">
-									{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
-									{if $FIELD_MODEL->isMandatory() eq true}
-										<span class="redColor">*</span>
-									{/if}
-								</label>
-							</td>
-							<td class="fieldValue col-lg-4" colspan="3">
-								{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
-							</td>
-						</tr>
-
-						<tr>
-							{if $FILE_LOCATION_TYPE eq 'W'}
-								<input type="hidden" name='filelocationtype' value="I" />
-								{assign var="FIELD_MODEL" value=$FIELD_MODELS['notecontent']}
-								{if $FIELD_MODELS['notecontent']}
-									<td class="fieldLabel col-lg-2">
-										<label class="muted pull-right">
-											{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
-											{if $FIELD_MODEL->isMandatory() eq true}
-												<span class="redColor">*</span>
-											{/if}
-										</label>
-									</td>
-									<td class="fieldValue col-lg-4" colspan="3">
-										{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
-									</td>
-								{/if}
-							{else if $FILE_LOCATION_TYPE eq 'E'}
-								<input type="hidden" name='filelocationtype' value="E" />
-								{assign var="FIELD_MODEL" value=$FIELD_MODELS['filename']}
+					<div class="createDocumentContent">
+						<table class="massEditTable table no-border">
+							<tr>
+								{assign var="FIELD_MODEL" value=$FIELD_MODELS['notes_title']}
 								<td class="fieldLabel col-lg-2">
 									<label class="muted pull-right">
-										{vtranslate('LBL_FILE_URL', $MODULE)}&nbsp;
-										<span class="redColor">*</span>
+										{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
+										{if $FIELD_MODEL->isMandatory() eq true}
+											<span class="redColor">*</span>
+										{/if}
 									</label>
 								</td>
 								<td class="fieldValue col-lg-4" colspan="3">
-									<input type="text" class="inputElement {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_MODEL->getFieldName()}"
-									value="{$FIELD_MODEL->get('fieldvalue')}" data-rule-required="true" data-rule-url="true"/>
+									{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
 								</td>
-							{/if}
-						</tr>
+							</tr>
 
-						<tr>
-							{assign var="FIELD_MODEL" value=$FIELD_MODELS['assigned_user_id']}
-							<td class="fieldLabel col-lg-2">
-								<label class="muted pull-right">
-									{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
-									{if $FIELD_MODEL->isMandatory() eq true}
-										<span class="redColor">*</span>
+							<tr>
+								{if $FILE_LOCATION_TYPE eq 'W'}
+									<input type="hidden" name='filelocationtype' value="I" />
+									{assign var="FIELD_MODEL" value=$FIELD_MODELS['notecontent']}
+									{if $FIELD_MODELS['notecontent']}
+										<td class="fieldLabel col-lg-2">
+											<label class="muted pull-right">
+												{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
+												{if $FIELD_MODEL->isMandatory() eq true}
+													<span class="redColor">*</span>
+												{/if}
+											</label>
+										</td>
+										<td class="fieldValue col-lg-4" colspan="3">
+											{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+										</td>
 									{/if}
-								</label>
-							</td>
-							<td class="fieldValue col-lg-4">
-								{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
-							</td>
+								{else if $FILE_LOCATION_TYPE eq 'E'}
+									<input type="hidden" name='filelocationtype' value="E" />
+									{assign var="FIELD_MODEL" value=$FIELD_MODELS['filename']}
+									<td class="fieldLabel col-lg-2">
+										<label class="muted pull-right">
+											{vtranslate('LBL_FILE_URL', $MODULE)}&nbsp;
+											<span class="redColor">*</span>
+										</label>
+									</td>
+									<td class="fieldValue col-lg-4" colspan="3">
+										<input type="text" class="inputElement {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_MODEL->getFieldName()}"
+										value="{$FIELD_MODEL->get('fieldvalue')}" data-rule-required="true" data-rule-url="true"/>
+									</td>
+								{/if}
+							</tr>
 
-							{assign var="FIELD_MODEL" value=$FIELD_MODELS['folderid']}
-							{if $FIELD_MODELS['folderid']}
+							<tr>
+								{assign var="FIELD_MODEL" value=$FIELD_MODELS['assigned_user_id']}
 								<td class="fieldLabel col-lg-2">
 									<label class="muted pull-right">
 										{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
@@ -109,77 +96,92 @@
 								<td class="fieldValue col-lg-4">
 									{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
 								</td>
-							{/if}
-						</tr>
-						<tr>
-							{assign var=HARDCODED_FIELDS value=','|explode:"filename,assigned_user_id,folderid,notecontent,notes_title"}
-							{assign var=COUNTER value=0}
-							{foreach key=FIELD_NAME item=FIELD_MODEL from=$FIELD_MODELS}
-								{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
-									{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
-									{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
-									{assign var="referenceListCount" value=count($referenceList)}
-									{if $FIELD_MODEL->get('uitype') eq "19"}
-										{if $COUNTER eq '1'}
-											<td></td><td></td></tr><tr>
-											{assign var=COUNTER value=0}
+
+								{assign var="FIELD_MODEL" value=$FIELD_MODELS['folderid']}
+								{if $FIELD_MODELS['folderid']}
+									<td class="fieldLabel col-lg-2">
+										<label class="muted pull-right">
+											{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;
+											{if $FIELD_MODEL->isMandatory() eq true}
+												<span class="redColor">*</span>
+											{/if}
+										</label>
+									</td>
+									<td class="fieldValue col-lg-4">
+										{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+									</td>
+								{/if}
+							</tr>
+							<tr>
+								{assign var=HARDCODED_FIELDS value=','|explode:"filename,assigned_user_id,folderid,notecontent,notes_title"}
+								{assign var=COUNTER value=0}
+								{foreach key=FIELD_NAME item=FIELD_MODEL from=$FIELD_MODELS}
+									{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
+										{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
+										{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
+										{assign var="referenceListCount" value=count($referenceList)}
+										{if $FIELD_MODEL->get('uitype') eq "19"}
+											{if $COUNTER eq '1'}
+												<td></td><td></td></tr><tr>
+												{assign var=COUNTER value=0}
+											{/if}
 										{/if}
-									{/if}
-									{if $COUNTER eq 2}
-									</tr><tr>
-										{assign var=COUNTER value=1}
-									{else}
-										{assign var=COUNTER value=$COUNTER+1}
-									{/if}
-									<td class='fieldLabel col-lg-2'>
-										{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
-											{if $isReferenceField eq "reference"}
-												{if $referenceListCount > 1}
-													{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
-													{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
-													{if !empty($REFERENCED_MODULE_STRUCT)}
-														{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
+										{if $COUNTER eq 2}
+										</tr><tr>
+											{assign var=COUNTER value=1}
+										{else}
+											{assign var=COUNTER value=$COUNTER+1}
+										{/if}
+										<td class='fieldLabel col-lg-2'>
+											{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
+												{if $isReferenceField eq "reference"}
+													{if $referenceListCount > 1}
+														{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
+														{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
+														{if !empty($REFERENCED_MODULE_STRUCT)}
+															{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
+														{/if}
+														<span class="pull-right">
+															<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
+																{foreach key=index item=value from=$referenceList}
+																	<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
+																{/foreach}
+															</select>
+														</span>
+													{else}
+														<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
 													{/if}
-													<span class="pull-right">
-														<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
-															{foreach key=index item=value from=$referenceList}
-																<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
-															{/foreach}
-														</select>
-													</span>
-												{else}
-													<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
-												{/if}
-											{else if $FIELD_MODEL->get('uitype') eq '83'}
-												{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
-												{if $TAXCLASS_DETAILS}
-													{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
-													{if $taxCount eq 0}
-														{if $COUNTER eq 2}
-															{assign var=COUNTER value=1}
-														{else}
-															{assign var=COUNTER value=2}
+												{else if $FIELD_MODEL->get('uitype') eq '83'}
+													{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
+													{if $TAXCLASS_DETAILS}
+														{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
+														{if $taxCount eq 0}
+															{if $COUNTER eq 2}
+																{assign var=COUNTER value=1}
+															{else}
+																{assign var=COUNTER value=2}
+															{/if}
 														{/if}
 													{/if}
+												{else}
+													{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
 												{/if}
-											{else}
-												{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
-											{/if}
-											{if $isReferenceField neq "reference"}</label>{/if}
-									</td>
-									{if $FIELD_MODEL->get('uitype') neq '83'}
-										<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
-										{if $FILE_LOCATION_TYPE neq 'W'}
-											{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) type = "E"}
-										{else}
-											{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
-										{/if}
+												{if $isReferenceField neq "reference"}</label>{/if}
 										</td>
+										{if $FIELD_MODEL->get('uitype') neq '83'}
+											<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
+											{if $FILE_LOCATION_TYPE neq 'W'}
+												{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) type = "E"}
+											{else}
+												{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+											{/if}
+											</td>
+										{/if}
 									{/if}
-								{/if}
-							{/foreach}
-						</tr>
-					</table>
+								{/foreach}
+							</tr>
+						</table>
+					</div>
 				</form>
 			</div>
 		</div>

--- a/layouts/v7/modules/Documents/UploadDocument.tpl
+++ b/layouts/v7/modules/Documents/UploadDocument.tpl
@@ -10,7 +10,7 @@
 {strip}
 	<div class="modal-dialog modelContainer">
 		{assign var=HEADER_TITLE value={vtranslate('LBL_UPLOAD_TO_VTIGER', $MODULE)}}
-		<div class="modal-content" style="width:675px;">
+		<div class="modal-content">
 			<form class="form-horizontal recordEditView" name="upload" method="post" action="index.php">
 				{include file="ModalHeader.tpl"|vtemplate_path:$MODULE TITLE=$HEADER_TITLE}
 				<div class="modal-body">

--- a/layouts/v7/modules/Documents/resources/Documents.js
+++ b/layouts/v7/modules/Documents/resources/Documents.js
@@ -429,7 +429,6 @@ Vtiger.Class('Documents_Index_Js', {
 	registerCreateDocumentModalEvents : function(container) {
 		container.find('form').vtValidate();
 		if(container.find('input[name="type"]').val() === 'W') {
-			container.find('.modelContainer').css('width','750px');
 			//change id of text area to workaround multiple instances of ckeditor on same element
 			this.applyEditor(
 				container.find('#Documents_editView_fieldName_notecontent')

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -264,3 +264,32 @@ div.detailview-content.container-fluid span.value img {
 .summaryView .input-group.editElement .referencefield-wrapper .input-group .inputElement {
   width: 100% ;
 }
+/**
+ * ドキュメントアップロードモーダル
+ **/
+ @media all and (min-width: 0px) and (max-width: 830px) {
+  .createDocumentContent > table.table > tbody > tr > td,
+  .createDocumentContent > table.table > tbody > tr > th,
+  .createDocumentContent > table.table > tfoot > tr > td,
+  .createDocumentContent > table.table > tfoot > tr > th,
+  .createDocumentContent > table.table > thead > tr > td,
+  .createDocumentContent > table.table > thead > tr > th,
+  .uploadview-content > .uploadcontrols > #upload > table.table > tbody > tr > td,
+  .uploadview-content > .uploadcontrols > #upload > table.table > tbody > tr > th,
+  .uploadview-content > .uploadcontrols > #upload > table.table > tfoot > tr > td,
+  .uploadview-content > .uploadcontrols > #upload > table.table > tfoot > tr > th,
+  .uploadview-content > .uploadcontrols > #upload > table.table > thead > tr > td,
+  .uploadview-content > .uploadcontrols > #upload > table.table > thead > tr > th {
+    display: block;
+    min-width: 100%!important;
+  }
+  .createDocumentContent > table.table td.fieldLabel > label,
+  .uploadview-content > .uploadcontrols > #upload > table.table td.fieldLabel > label {
+    float: left !important;
+  }
+  .createDocumentContent > table.table td.fieldValue .inputElement,
+  .uploadview-content > .uploadcontrols > #upload > table.table td.fieldValue .inputElement {
+    width: 100%;
+    float: none !important;
+  }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #140 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画面幅が狭いとき、ドキュメントのアップロードモーダルのレイアウトが崩れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 該当モーダルのdivに対し、直接width要素が指定されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 該当モーダルのdivからwidth要素を削除
2. 該当モーダルにCSSを適用し、画面幅が狭いときは改行して表示されるよう修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84055994/118094597-e5521800-b409-11eb-995a-7acd2603939e.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ドキュメントのアップロードモーダル
外部ドキュメントの登録モーダル

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->