### PR TITLE
fiexd #121 活動の招待メールに添付されるiCalendarファイルのTIMEZONEをUTCからAsia/Tokyoに修正

### DIFF
--- a/modules/Calendar/CalendarCommon.php
+++ b/modules/Calendar/CalendarCommon.php
@@ -230,11 +230,22 @@ function generateIcsAttachment($record) {
     $lastName = $userModel->entity->column_fields['last_name'];
     $email = $userModel->entity->column_fields['email1'];
     $fp = fopen('test/upload/'.$fileName.'.ics', "w");
+
+    // add timezone
+    fwrite($fp, "BEGIN:VTIMEZONE\n");
+    fwrite($fp, "TZID:Asia/Tokyo\n");
+    fwrite($fp, "BEGIN:STANDARD\n");
+    fwrite($fp, "TZOFFSETFROM:+0900\n");
+    fwrite($fp, "TZOFFSETTO:+0900\n");
+    fwrite($fp, "DTSTART:19700101T000000\n");
+    fwrite($fp, "END:STANDARD\n");
+    fwrite($fp, "END:VTIMEZONE\n");
+
     fwrite($fp, "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\n");
     fwrite($fp, "ORGANIZER;CN=".$lastName." ".$firstName.":MAILTO:".$email."\n");
-    fwrite($fp, "DTSTART:".date('Ymd\THis\Z', strtotime($record['st_date_time']))."\n");
-    fwrite($fp, "DTEND:".date('Ymd\THis\Z', strtotime($record['end_date_time']))."\n");
-    fwrite($fp, "DTSTAMP:".date('Ymd\THis\Z')."\n");
+    fwrite($fp, "DTSTART;TZID=Asia/Tokyo:".date('Ymd\THis', strtotime($record['st_date_time']))."\n");
+    fwrite($fp, "DTEND;TZID=Asia/Tokyo:".date('Ymd\THis', strtotime($record['end_date_time']))."\n");
+    fwrite($fp, "DTSTAMP;TZID=Asia/Tokyo:".date('Ymd\THis')."\n");
     fwrite($fp, "DESCRIPTION:".$record['description']."\nLOCATION:".$record['location']."\n");
     fwrite($fp, "STATUS:CONFIRMED\nSUMMARY:".$record['subject']."\nEND:VEVENT\nEND:VCALENDAR");
     fclose($fp);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #121 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動の招待メールに添付されるiCalendarファイルのTIMEZONE設定がZ（UTC）となっている

##  原因 / Cause
<!-- バグの原因を記述 -->
1. カレンダー等からリクエストを受け取った時点で日時はJSTとなっている
2. ics（iCalendar）ファイル生成時、DTSTART/DTENDの値に1. で受け取った日時にZを付与しており、JSTの日時をUTCとして扱ってしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. icsファイル生成時、TIMEZONEの設定を行い、JST（UTC+09:00）としてDTSTART/DTENDを設定するよう「修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
**予定情報**
![image](https://user-images.githubusercontent.com/84055994/118465445-dbe3eb00-b73c-11eb-880a-a246ea83c0cf.png)
**icsファイル**
![image](https://user-images.githubusercontent.com/84055994/118465228-a5a66b80-b73c-11eb-931c-fda087b5e18e.png)
**Outlookインポート画面**
![image](https://user-images.githubusercontent.com/84055994/118465581-fb7b1380-b73c-11eb-86b8-b4fc83361cee.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
予定の作成、予定の変更時、招待者に送付されるメール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->