### PR TITLE
エクスポートするPDFファイルの企業名が正常に入らない問題を修正

### DIFF
--- a/modules/Vtiger/actions/MassPDFExport.php
+++ b/modules/Vtiger/actions/MassPDFExport.php
@@ -74,12 +74,16 @@ class Vtiger_MassPDFExport_Action extends Vtiger_Mass_Action
                     $uitype4value = $recordModel->get($uitype4fieldname);
                 }
                 $accountname = "";
-                if($recordModel->get("account_id")){
-                    $accountname = Vtiger_Functions::getCRMRecordLabel($recordModel->get("account_id"));
+                if($recordModel->get("account_id") || $recordModel->get("vendor_id")){
+                    if($moduleName == "PurchaseOrder"){
+                        $accountname = Vtiger_Functions::getCRMRecordLabel($recordModel->get("vendor_id"));
+                    } else {
+                        $accountname = Vtiger_Functions::getCRMRecordLabel($recordModel->get("account_id"));
+                    }
                 }
                 $filename = $accountname."_".$templateName."(".Vtiger_Functions::getCRMRecordLabel($recordModel->getId()).")_".$uitype4value.'.pdf';
                 file_put_contents($uploadfilepath . $filename, $returnPDF, FILE_APPEND);
-                $pdfarray[] = $uploadfilepath . $filename;
+                $pdfarray[] = ["filepath" => $uploadfilepath.$filename, "filename" => $filename];
             }
         }
 
@@ -98,10 +102,10 @@ class Vtiger_MassPDFExport_Action extends Vtiger_Mass_Action
 
         // zipに追加
         setlocale(LC_ALL, 'ja_JP.UTF-8');
-        foreach ($pathAry as $filepath) {
-            $filename = basename($filepath);
-            $zip->addFile($filepath, mb_convert_encoding($filename, 'CP932', 'UTF-8'));
-            unlink($filepath);
+        foreach ($pathAry as $filePathAndName) {
+            $filename = $filePathAndName["filename"];
+            $zip->addFile($filePathAndName["filepath"], mb_convert_encoding($filename, 'CP932', 'UTF-8'));
+            unlink($filePathAndName["filepath"]);
         }
         $zip->save();
 


### PR DESCRIPTION
##  関連Issue / Related Issue
なし

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFをエクスポートする際にファイル名の頭の企業名が正常に入らない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ファイルパスからファイル名を取るbasename関数が正常に働かない
2. 発注モジュールの宛名は顧客企業名でなく発注先名である

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  ファイル名を連想配列でファイルパスとともに引数に渡すように変更
2. 発注モジュールの場合,発注先名を用いるように変更

## 影響範囲  / Affected Area
- PDFエクスポート機能
- 請求モジュール
- 受注モジュール
- 発注先モジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- basename関数が正常に働かないのはsetlocale関数でのロケール設定が正常にできていない可能性あり