### PR TITLE
#160 カレンダーの関連の顧客担当者が時間を変更すると減る問題を修正

### DIFF
--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -34,6 +34,9 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 		$recurringEditMode = $request->get('recurringEditMode');
 		$is_allday = $request->get('allday');
 
+		//Contactsを更新しないようにフラグを作成
+		$_REQUEST['isDragDrop'] = 1;
+
 		$actionname = 'EditView';
 		$response = new Vtiger_Response();
 		try {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #160 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  ,ドラッグで時間幅を変更すると,カレンダーに紐付けられた顧客担当者が減る

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  プルリクエスト #55 でドラッグアンドドロップで活動の時間の場所を変更した際に,顧客担当者を更新しないフラグを作ったが,リサイズの際は別の関数で処理していた.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. リサイズの関数でも顧客担当者を更新しないフラグを作った.

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->