### PR TITLE
#172 コメントに自身が設定しているサムネイル画像（プロフィール画像）が表示されない不具合の修正

### DIFF
--- a/modules/ModComments/models/Record.php
+++ b/modules/ModComments/models/Record.php
@@ -119,13 +119,13 @@ class ModComments_Record_Model extends Vtiger_Record_Model {
 				$recordModel = Vtiger_Record_Model::getInstanceById($customer);
 				$imageDetails = $recordModel->getImageDetails();
 				if(!empty($imageDetails)) {
-					return $imageDetails[0]['path'].'_'.$imageDetails[0]['name'];
+					return $imageDetails[0]['url'];
 				} else
 					return vimage_path('CustomerPortal.png');
 			} else {
 				$imagePath = $commentor->getImageDetails();
 				if (!empty($imagePath[0]['name'])) {
-					return $imagePath[0]['path'] . '_' . $imagePath[0]['name'];
+					return $imagePath[0]['url'];
 				}
 			}
 		} elseif ($isMailConverterType) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #172 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  コメントのサムネイルが表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  画像のパスが間違っている(画像の名前がvtiger_attachmentsのstorednameになっていなかった)

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  nameからパスを生成せず,予め配列に格納されているurlを用いる

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/120138593-bad9ca80-c211-11eb-9b7f-b3082396f46c.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
コメント機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->