### PR TITLE
fiexd #181 「ユーザー名の変更」がパスワードがエラーで保存出来ない

### DIFF
--- a/layouts/v7/modules/Users/ChangeUsername.tpl
+++ b/layouts/v7/modules/Users/ChangeUsername.tpl
@@ -27,26 +27,6 @@
                                 <input type="text" name="new_username" data-rule-required="true" data-rule-illegal="true"/>
                             </div>
                         </div>
-
-                        <div class="form-group">
-                            <label class="control-label fieldLabel col-sm-5">
-                                {vtranslate('LBL_NEW_PASSWORD', $MODULE)}&nbsp;
-                                <span class="redColor">*</span>
-                            </label>
-                            <div class="controls col-xs-6">
-                                <input type="password" name="new_password" data-rule-required="true"/>
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <label class="control-label fieldLabel col-sm-5">
-                                {vtranslate('LBL_CONFIRM_PASSWORD', $MODULE)}&nbsp;
-                                <span class="redColor">*</span>
-                            </label>
-                            <div class="controls col-xs-6">
-                                <input type="password" name="confirm_password" data-rule-required="true"/>
-                            </div>
-                        </div>
                     </div>
                 </div>
                 {include file='ModalFooter.tpl'|@vtemplate_path:$MODULE}

--- a/layouts/v7/modules/Users/resources/Detail.js
+++ b/layouts/v7/modules/Users/resources/Detail.js
@@ -160,27 +160,6 @@ Vtiger_Detail_Js("Users_Detail_Js",{
 					var params = {
 						submitHandler : function(form) {
 							var form = jQuery(form);
-							var new_password = form.find('[name="new_password"]');
-							var confirm_password = form.find('[name="confirm_password"]');
-							var params = {
-								position: {
-									my: 'bottom left',
-									at: 'top left',
-									container : form
-								},
-							};
-							if (new_password.val() !== confirm_password.val()) {
-								vtUtils.showValidationMessage(new_password, app.vtranslate('JS_REENTER_PASSWORDS'), params);
-								vtUtils.showValidationMessage(confirm_password, app.vtranslate('JS_REENTER_PASSWORDS'), params);
-								return false;
-							}else if(!app.helper.checkStrengthPassword(new_password)) {
-								vtUtils.showValidationMessage(new_password, app.vtranslate('JS_INVALID_STRENGTH_PASSWORDS'), params);
-								return false;
-							}else {
-								vtUtils.hideValidationMessage(new_password);
-								vtUtils.hideValidationMessage(confirm_password);
-							}
-							
 							Users_Detail_Js.changeUserName(form);
 						}
 					};
@@ -197,8 +176,6 @@ Vtiger_Detail_Js("Users_Detail_Js",{
 	
 	changeUserName: function (form) {
 		var newUsername = form.find('[name="new_username"]');
-		var new_password = form.find('[name="new_password"]');
-		var confirm_password = form.find('[name="confirm_password"]');
 		var userid = form.find('[name="userid"]');
 
 		app.helper.showProgress(app.vtranslate('JS_PLEASE_WAIT'));
@@ -208,8 +185,6 @@ Vtiger_Detail_Js("Users_Detail_Js",{
 			action: 'SaveAjax',
 			mode: 'changeUsername',
 			newUsername: newUsername.val(),
-			newPassword: new_password.val(),
-			confirmPassword: confirm_password.val(),
 			userid: userid.val()
 		};
 		vtUtils.hideValidationMessage(newUsername);

--- a/modules/Users/actions/SaveAjax.php
+++ b/modules/Users/actions/SaveAjax.php
@@ -252,7 +252,7 @@ class Users_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 		$response = new Vtiger_Response();
 		$userId = $request->get('userid');
 
-		$status = Users_Record_Model::changeUsername($request->get('newUsername'), $request->get('newPassword'), $request->get('oldPassword'), $userId);
+		$status = Users_Record_Model::changeUsernameOnly($request->get('newUsername'), $userId);
 		if($status['success']) {
 			$response->setResult($status['message']);
 		}else{


### PR DESCRIPTION
「ユーザー名の変更」モーダルから「新しいパスワード」「パスワードの確認」入力欄を削除

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #181 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザ詳細画面「その他」の「ユーザー名の変更」から変更を行うと、パスワードがエラーで保存が出来ない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 新しいパスワード入力欄のJSバリデーションにおいて、new_passwordフィールドの値に対してバリデーションを行うべきところが、new_passwordフィールド要素そのものに対してバリデーションを実施していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ユーザー名の変更時はパスワード入力を求めないよう修正
※パスワード変更は同一画面の「ユーザー名の変更」メニューの直下に存在するため、そちらで対応可能

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84055994/120951831-b454d100-c784-11eb-9cfc-7dee564d7bc0.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
「ユーザー名の変更」モーダルウィンドウ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->