### PR TITLE
fiexd #183 「ユーザー名の変更」モーダルの新ユーザー名が翻訳されていない

### DIFF
--- a/includes/runtime/LanguageHandler.php
+++ b/includes/runtime/LanguageHandler.php
@@ -88,7 +88,11 @@ class Vtiger_Language_Handler {
 	 * @param <String> $module - module scope in which the translation need to be check
 	 * @return <String> - translated string
 	 */
-	public static function getJSTranslatedString($language, $key, $module = '') {
+	public static function getJSTranslatedString($key, $module = '', $language = '') {
+		if (empty($language)) {
+			$language = self::getLanguage();
+		}
+
 		$moduleStrings = array();
 
 		$module = str_replace(':', '.', $module);

--- a/languages/ja_jp/Users.php
+++ b/languages/ja_jp/Users.php
@@ -260,6 +260,7 @@ $languageStrings = array(
 	'LBL_CHANGE_USERNAME' => 'ユーザー名の変更',
 	'LBL_USERNAME_CHANGED' => 'ユーザー名の変更が完了しました',
 	'ERROR_CHANGE_USERNAME' => 'ユーザー名の変更に失敗しました',
+	'New Username' => '新しいユーザー名',
 
 	'LBL_RESTORE_USER_FAILED' => 'ユーザーの復元を失敗しました。既に同じユーザー名のユーザーが登録されています。',
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #183 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 「ユーザー名の変更」モーダルの新ユーザー名が翻訳されていない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. vJSTranslate()経由でgetJSTranslatedString()に渡される引数が常に誤った値となっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->

1. getJSTranslatedString()の引数順を変更し、言語が指定されなかった場合はgetTranslatedString()メソッド同様、自動で言語を取得するよう修正
2. New Usernameの日本語訳を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84055994/120952283-ae132480-c785-11eb-97d1-58fb42ceea18.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
「ユーザー名の変更」モーダルウィンドウ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
