### PR TITLE
#123 カスタム項目で関連の活動を作成した際に動作しない不具合を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -1201,7 +1201,13 @@ Vtiger.Class('Vtiger_Index_Js', {
 	getReferencedModuleName : function(parentElement) {
 		var referenceModuleElement = jQuery('input[name="popupReferenceModule"]',parentElement).length ?
 			jQuery('input[name="popupReferenceModule"]',parentElement) : jQuery('input.popupReferenceModule',parentElement);
-		return referenceModuleElement.val();
+		var customInfoFlag = jQuery('input[name="popupReferenceModule"]', parentElement).parents().find('div[data-block="LBL_CUSTOM_INFORMATION"]').length;
+		// カスタム項目の関連(カレンダー)のクイック作成はTODO(Calendar)でなく活動(Events)とする
+		if (customInfoFlag && referenceModuleElement.val() == "Calendar") {
+			return "Events"
+		} else {
+			return referenceModuleElement.val()
+		}
 	},
 
 	/*

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -383,19 +383,11 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 		for($i=0; $i<$numOfRows; $i++) {
 			$moduleName = $db->query_result($result, $i, 'name');
 			$modulesList[$moduleName] = vtranslate($moduleName, $moduleName);
-			//Calendar needs to be shown as TODO so we are translating using Layout editor specific translations
-			if ($moduleName == 'Calendar') {
-				$modulesList[$moduleName] = vtranslate($moduleName, 'Settings:LayoutEditor');
-			}
 		}
 		// Usersの追加
 		$modulesList["Users"] = vtranslate("Users", "Users");
-
-		// If calendar is disabled we should not show events module too
-		// in layout editor
-		if(!array_key_exists('Calendar', $modulesList)) {
-			unset($modulesList['Events']);
-		}
+		// カスタム項目の関連ではカレンダーとして活動(Events)ではなくTODO(Calendar)を用いる
+		unset($modulesList['Events']);
 		return $modulesList;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #123 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カスタム項目で関連の活動を作成しても,関連を選択できず保存できない.

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 関連項目には活動(Events)とTODO(Calendar)が存在するが,vtiger_tabのpresenceにより活動(Events)が無効化されている
2. presenceのチェックを外すとエラーはなくなるが,保存しても表示されない(別のバグ？)

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_tabのpresenceを書き換える方法は影響範囲が読めないため,活動(Events)を非表示にし,TODO(Calendar)をカレンダーとして一元化した.(関連としての機能は活動もTODOも保存できるため影響なし)
2. クイック作成はTODOではなく活動を優先し,表示されるようにした.(親要素からカスタム項目を判定)

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/120974790-820a9a00-c7ab-11eb-841c-f64c7ba65f09.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目設定画面
編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->