### PR TITLE
#192 レポートで日付項目に対して「空である」「空ではない」の条件を指定した際にSQLエラーにならないように修正

### DIFF
--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -1374,6 +1374,8 @@ class ReportRun extends CRMEntity {
 						} else if ($comparator == 'ny') {
 							if ($fieldInfo['uitype'] == '10' || isReferenceUIType($fieldInfo['uitype']))
 								$fieldvalue = "(" . $selectedfields[0] . "." . $selectedfields[1] . " IS NOT NULL AND " . $selectedfields[0] . "." . $selectedfields[1] . " != '' AND " . $selectedfields[0] . "." . $selectedfields[1] . "  != '0')";
+							else if($fieldDataType == "date" || $fieldDataType == "datetime")
+								$fieldvalue = $selectedfields[0] . "." . $selectedfields[1] . " IS NOT NULL";
 							else
 								$fieldvalue = "(" . $selectedfields[0] . "." . $selectedfields[1] . " IS NOT NULL AND " . $selectedfields[0] . "." . $selectedfields[1] . " != '')";
 						}elseif ($comparator == 'y' || ($comparator == 'e' && (trim($value) == "NULL" || trim($value) == ''))) {
@@ -1382,6 +1384,8 @@ class ReportRun extends CRMEntity {
 							}
 							if ($fieldInfo['uitype'] == '10' || isReferenceUIType($fieldInfo['uitype']))
 								$fieldvalue = "(" . $selectedfields[0] . "." . $selectedfields[1] . " IS NULL OR " . $selectedfields[0] . "." . $selectedfields[1] . " = '' OR " . $selectedfields[0] . "." . $selectedfields[1] . " = '0')";
+							else if($fieldDataType == "date" || $fieldDataType == "datetime")
+								$fieldvalue = $selectedfields[0] . "." . $selectedfields[1] . " IS NULL";
 							else
 								$fieldvalue = "(" . $selectedfields[0] . "." . $selectedfields[1] . " IS NULL OR " . $selectedfields[0] . "." . $selectedfields[1] . " = '')";
 						} elseif ($selectedfields[0] == 'vtiger_inventoryproductrel') {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #192 

##  不具合の内容 / Bug
1. レポートで日付項目に対して「空である」「空ではない」の条件を指定した際にレコードが正しく出力されない

##  原因 / Cause
1. MySQL8の仕様変更に伴うSQLエラー

##  変更内容 / Details of Change
1. 日付項目に対する「空である」「空ではない」の条件で「=''」「!=''」の条件が付かないように修正

## 影響範囲  / Affected Area
レポートの出力内容、出力件数

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
なし