### PR TITLE
#200 カレンダーの設定を12時間表記にすると、終日フラグが入らない箇所の修正。12:00 AM ～ 12:30 AMでも終日フラグが入…

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1096,7 +1096,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		startTimeElement.val(startDateTime.format(vtUtils.getMomentTimeFormat()));
 		vtUtils.registerEventForDateFields(startDateElement);
 		vtUtils.registerEventForTimeFields(startTimeElement);
-		if(startDateTime.format(vtUtils.getMomentTimeFormat()) == '00:00') {
+		if(startDateTime.format(vtUtils.getMomentTimeFormat()) == '00:00' || startDateTime.format(vtUtils.getMomentTimeFormat()) == '12:00 AM') {
 			alldayElement.attr('checked', true);
 			Calendar_Edit_Js.changeAllDay();
 		}


### PR DESCRIPTION
…ってしまうバグを発見

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #200 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーの設定を12時間表記にすると、週次カレンダー上部の「終日エリア」から予定を作成するときに、終日フラグが入らない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 終日フラグが開始時間が"00:00"であるか否かで判定されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 開始時間が"00:00"or "12:00 AM"であるかで判定するように変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
* 00:00～もしくは12:00 AM～の予定にも終日フラグが入っている #201

<!-- その他、特記すべき事項を記述 -->