### PR TITLE
fixed: #201 カレンダーにて上部終日エリアをクリックした場合に就実フラグが付き、00:00をクリックしてもつかないよう修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1096,7 +1096,13 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		startTimeElement.val(startDateTime.format(vtUtils.getMomentTimeFormat()));
 		vtUtils.registerEventForDateFields(startDateElement);
 		vtUtils.registerEventForTimeFields(startTimeElement);
-		if(startDateTime.format(vtUtils.getMomentTimeFormat()) == '00:00' || startDateTime.format(vtUtils.getMomentTimeFormat()) == '12:00 AM') {
+		/**
+			終日エリア、月次カレンダーをクリックした場合は、終日フラグにチェックを入れる
+			経緯：これまでは00:00である、または12:00 AMであるを判定基準に使っていたため、00:00をクリックしたときに終日フラグが付いてしまっていた
+			
+			※tartDateTime._ambigTime: カレンダーの上部終日エリアを押したときtrueになる
+		*/
+		if(startDateTime._ambigTime) {
 			alldayElement.attr('checked', true);
 			Calendar_Edit_Js.changeAllDay();
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #201 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーの00:00を押したときに、終日フラグにチェックが付いてしまっていた

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 00:00 または 12:00 AMの場合に終日フラグがOnになるように設定していたため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 引数として渡ってくるstartDateTime Object内の_ambigTimeプロパティを参照するように修正
※_ambigTimeプロパティは曖昧な時間かどうかの判定を行っており、終日は曖昧な予定として表現されている

## 影響範囲  / Affected Area
カレンダー表示部分をクリックしたとき
カレンダーの予定をクリックして編集画面を表示するとき

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->