### PR TITLE
fixed #205 TODO表示画面で一度閉じると検索条件が破棄される不具合を修正

### DIFF
--- a/layouts/v7/modules/Calendar/TaskManagement.tpl
+++ b/layouts/v7/modules/Calendar/TaskManagement.tpl
@@ -39,6 +39,7 @@
 							{assign var=PICKLIST_VALUES value=$FIELD_INFO['picklistvalues']}
 							{assign var=FIELD_INFO value=Vtiger_Util_Helper::toSafeHTML(Zend_Json::encode($FIELD_INFO))}
 							{assign var=SEARCH_VALUES value=explode(',',$SEARCH_INFO['searchValue'])}
+							<input type="hidden" id="hidden_session_taskfilter" value='{$TASK_FILTERS_JSON}'>
 							<select class="select2 listSearchContributor" name="{$FIELD_MODEL->get('name')}" multiple data-fieldinfo='{$FIELD_INFO|escape}'>
 								{foreach item=PICKLIST_LABEL key=PICKLIST_KEY from=$PICKLIST_VALUES}
 									<option {if $PICKLIST_KEY|in_array:$TASK_FILTERS['status']}selected{/if} value="{$PICKLIST_KEY}">{$PICKLIST_LABEL}</option>

--- a/layouts/v7/modules/Calendar/resources/TaskManagement.js
+++ b/layouts/v7/modules/Calendar/resources/TaskManagement.js
@@ -548,11 +548,21 @@ Vtiger_Index_Js("Vtiger_TaskManagement_Js",{},{
 	initializeTaskStatus : function(){
 		var container = this.getOverlayContainer();
 		var taskStatus = container.find('select[name="taskstatus"]');
+		// sessionに保存しているtaskfilterをjs側で取得する
+		var sessionTaskStatus = JSON.parse($('#hidden_session_taskfilter').val());
+
 		if(taskStatus.length > 0){
-			taskStatus.find('[value="Not Started"]').attr('selected', "selected");
-			taskStatus.find('[value="In Progress"]').attr('selected', "selected");
-			taskStatus.find('[value="Pending Input"]').attr('selected', "selected");
-			taskStatus.find('[value="Planned"]').attr('selected', "selected");
+			if(Array.isArray(sessionTaskStatus.status)){
+				// 保持しているtaskfilterの内容を事前にselectedな状態にしておく
+				sessionTaskStatus.status.forEach(function(element){
+					taskStatus.find('[value="'+element+'"]').attr('selected', "selected");
+				});
+			}else{
+				taskStatus.find('[value="Not Started"]').attr('selected', "selected");
+				taskStatus.find('[value="In Progress"]').attr('selected', "selected");
+				taskStatus.find('[value="Pending Input"]').attr('selected', "selected");
+				taskStatus.find('[value="Planned"]').attr('selected', "selected");
+			}
 			vtUtils.showSelect2ElementView(taskStatus);
 			this.loadContents();
 		}

--- a/modules/Calendar/views/TaskManagement.php
+++ b/modules/Calendar/views/TaskManagement.php
@@ -36,7 +36,9 @@ class Calendar_TaskManagement_View extends Vtiger_Index_View {
 		$viewer->assign('OWNER_FIELD', $ownerField);
 
 		$viewer->assign('USER_MODEL', Users_Record_Model::getCurrentUserModel());
-		$viewer->assign('TASK_FILTERS', $this->getFiltersFromSession());
+		$filter = $this->getFiltersFromSession();
+		$viewer->assign('TASK_FILTERS', $filter);
+		$viewer->assign('TASK_FILTERS_JSON', json_encode($filter));
 		$module = Vtiger_Module_Model::getInstance($moduleName);
 		$field = Vtiger_Field_Model::getInstance('taskpriority', $module);
 		$priorities = $field->getPicklistValues();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #205 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 右上のTODOの看板表示画面で、検索条件を入れた後閉じる
2. 二度目の表示のときに、検索条件が保持されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Javascriptで表示時に常に固定の4選択肢が表示されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. セッションに保持しているデータをJS側に渡し、その選択肢を初期取得するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
TODOのこの画面のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->