### PR TITLE
fixed #66 PDFTemplatesでサイドバー上部のカテゴリアイコンが表示されない不具合の修正

### DIFF
--- a/layouts/v7/modules/PDFTemplates/partials/SidebarHeader.tpl
+++ b/layouts/v7/modules/PDFTemplates/partials/SidebarHeader.tpl
@@ -11,7 +11,7 @@
  
 <div class="col-sm-12 col-xs-12 app-indicator-icon-container app-{$SELECTED_MENU_CATEGORY}">
     <div class="row" title="{vtranslate($MODULE,$MODULE)}">
-        <span class="app-indicator-icon fa vicon-pdftemplates"></span>
+        <span class="app-indicator-icon fa fa-wrench"></span>
     </div>
 </div>
     


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #66 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFテンプレートを開いたときの左のカテゴリーアイコンが表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 誤ったclassが指定されている

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. classの変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- pdf template表示時のみ
- cssのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->