### PR TITLE
fixed #67 その他からコメントを表示するとアイコンが小さくなる不具合の修正

### DIFF
--- a/layouts/v7/modules/EmailTemplates/ListViewActions.tpl
+++ b/layouts/v7/modules/EmailTemplates/ListViewActions.tpl
@@ -45,7 +45,7 @@
                 {if $commentAction}
                     <button type="button" class="btn btn-default" id="{$MODULE}_listView_massAction_{$commentAction->getLabel()}" 
                             onclick="Vtiger_List_Js.triggerMassAction('{$commentAction->getUrl()}')" title="{vtranslate('LBL_COMMENT', $MODULE)}">
-                        <i class="fa fa-comment"></i>
+                        <i class="fa fa-comment" style="font-size: 24px"></i>
                     </button>
                 {/if}
                 

--- a/layouts/v7/modules/PDFTemplates/ListViewActions.tpl
+++ b/layouts/v7/modules/PDFTemplates/ListViewActions.tpl
@@ -45,7 +45,7 @@
                 {if $commentAction}
                     <button type="button" class="btn btn-default" id="{$MODULE}_listView_massAction_{$commentAction->getLabel()}" 
                             onclick="Vtiger_List_Js.triggerMassAction('{$commentAction->getUrl()}')" title="{vtranslate('LBL_COMMENT', $MODULE)}">
-                        <i class="fa fa-comment"></i>
+                        <i class="fa fa-comment" style="font-size: 24px"></i>
                     </button>
                 {/if}
                 

--- a/layouts/v7/modules/Vtiger/ListViewActions.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewActions.tpl
@@ -42,7 +42,7 @@
                 {if $commentAction}
                     <button type="button" class="btn btn-default" id="{$MODULE}_listView_massAction_{$commentAction->getLabel()}" 
                             onclick="Vtiger_List_Js.triggerMassAction('{$commentAction->getUrl()}')" title="{vtranslate('LBL_COMMENT', $MODULE)}" disabled="disabled">
-                        <i class="fa fa-comment"></i>
+                        <i class="fa fa-comment" style="font-size: 24px"></i>
                     </button>
                 {/if}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #67 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 詳細画面の関連メニューのその他からコメントを表示すると、コメントのアイコンが小さい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. スタイル指定の記述漏れ

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. style属性の追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
その他からコメントを表示したときのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->