### PR TITLE
fixed #79 プロジェクトタスク「終了日」のクイック作成をデフォルトで有効になるように修正

### DIFF
--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -74,6 +74,9 @@ require_once ("scripts/54_Update_SidebarWidget.php");
 // 日本語を追加
 require_once ("scripts/56_Add_JapaneseLanguage.php");
 
+// プロジェクトタスクの終了日をクリッククリエイトに追加
+$db->query('update vtiger_field set quickcreate = 0 where tabid = 41 and fieldname = "enddate"');
+
 // メニュー設定
 // FRMenuSetting::apply(array(
 //     'Accounts',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #79

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. （不具合ではないが）初期インストール時にプロジェクトタスクの終了日がクイック作成の項目に入っていない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 指定されていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インストール最後に呼ばれるスクリプトに処理を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
プロジェクトタスクの「終了日」項目のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->