### PR TITLE
fixed #194 プロジェクトからPJマイルストーンを作るときに自動で反映されるように修正

### DIFF
--- a/modules/Migration/models/Module.php
+++ b/modules/Migration/models/Module.php
@@ -49,6 +49,7 @@ class Migration_Module_Model extends Vtiger_Module_Model {
 						array('731' => '7.3.1'),
 						array('732' => '7.3.2'),
 						array('733' => '7.3.3'),
+						array('734' => '7.3.4'),
 		);
 		return $versions;
 	}

--- a/modules/Migration/schema/733_to_734.php
+++ b/modules/Migration/schema/733_to_734.php
@@ -1,0 +1,27 @@
+<?php
+/*+********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+	global $current_user, $adb;
+	$db = PearDatabase::getInstance();
+
+    // プロジェクトマイルストーンをプロジェクトから作るときに、自動でプロジェクトが含まれるように修正
+    // projectidのfieldid
+    $f_result = $db->query('select f.fieldid from vtiger_field f left join vtiger_tab t on f.tabid = t.tabid where t.name = "ProjectMilestone" and f.fieldname = "projectid" limit 1');
+    $f_count = $db->num_rows($f_result);
+    // relation_id
+    $r_result = $db->query('select relation_id from vtiger_relatedlists where name = "get_dependents_list" and label = "Project Milestone" limit 1');
+    $r_count = $db->num_rows($r_result);
+    if($f_count > 0 && $r_count > 0){
+        $fieldid = $db->query_result($f_result, 0, 'fieldid');
+        $relation_id = $db->query_result($r_result, 0, 'relation_id');
+        $db->pquery('update vtiger_relatedlists set relationfieldid = ? where relation_id = ?', array($fieldid, $relation_id));
+    }
+}

--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -74,6 +74,9 @@ require_once ("scripts/54_Update_SidebarWidget.php");
 // 日本語を追加
 require_once ("scripts/56_Add_JapaneseLanguage.php");
 
+// プロジェクトマイルストーンを関連メニューから追加する際、プロジェクトを引き継いで作成できるようにする
+$db->query('update vtiger_relatedlists set relationfieldid = "598" where relation_id = 174');
+
 // メニュー設定
 // FRMenuSetting::apply(array(
 //     'Accounts',

--- a/vtigerversion.php
+++ b/vtigerversion.php
@@ -10,7 +10,7 @@
 
 $patch_version = '20210609'; // -ve timestamp before release, +ve timestamp after release.
 $modified_database = '';
-$vtiger_current_version = '7.3.3';
+$vtiger_current_version = '7.3.4';
 $_SESSION['vtiger_version'] = $vtiger_current_version;
 
 ?>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #194 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. プロジェクトからプロジェクトタスクを作成すると、関連に自動で入らない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 関連用のフィールドが指定されていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インストール時に `vtiger_relatedlists` にfieldidを追加
2. マイグレーションで `vtiger_relatedlists` にfieldidを追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
該当の関連周り

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
今回の修正で、vtigerversion.phpにv7.3.4を記載しました。