### PR TITLE
fixed #179 関連画面のコメントを編集した際の改行機能

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -2875,7 +2875,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 						var commentInfoContent = commentInfoBlock.find('.commentInfoContent');
 						var commentEditStatus = commentInfoBlock.find('[name="editStatus"]');
 						var commentReason = commentInfoBlock.find('[name="editReason"]');
-						commentInfoContent.html(data.commentcontent);
+						commentInfoContent.html(data.commentcontent.replace(/\r?\n/g, '<br>'));
 						commentReason.html(data.reasontoedit);
 						modifiedTime.text(data.modifiedtime);
 						modifiedTime.attr('title',data.modifiedtimetitle)


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #179 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->

> 関連のコメント一覧画面で、コメントの編集を行うときだけ改行が削除されて更新されたように見える
> ※概要画面では発生しない

##  原因 / Cause
<!-- バグの原因を記述 -->

> `JavaScriptの問題で、返ってきた値の\nを<br>に置換していない。`

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
layouts/v7/modules/Vtiger/resources/Detail.js:2881 のコードを置換

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84700230/125733818-6d5caf57-541b-43b9-a0e9-c1c55c639140.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
コメントができるモジュール全て

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [✔] 自らテストを行った
- [✔] 不必要な変更が無い
- [✔] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->