### PR TITLE
フィルターのデフォルト設定の不具合の修正

### DIFF
--- a/modules/CustomView/CustomView.php
+++ b/modules/CustomView/CustomView.php
@@ -95,23 +95,18 @@ class CustomView extends CRMEntity {
 		if (empty($_REQUEST['viewname'])) {
 			if (isset($_SESSION['lvs'][$module]["viewname"]) && $_SESSION['lvs'][$module]["viewname"] != '') {
 				$viewid = $_SESSION['lvs'][$module]["viewname"];
-			} elseif ($this->setdefaultviewid != "") {
+			} elseif ($this->setdefaultviewid != "") { //？？
 				$viewid = $this->setdefaultviewid;
-			} else {
-				$defcv_result = $adb->pquery("select default_cvid from vtiger_user_module_preferences where userid = ? and tabid =?", array($current_user->id, getTabid($module)));
+			} else { //デフォルトリスト判別
+				$defcv_result = $adb->pquery("SELECT ump.default_cvid from vtiger_customview cv left join vtiger_user_module_preferences ump on cv.cvid = ump.default_cvid where ump.userid = ? and ump.tabid = ?", array($current_user->id, getTabid($module)));
 				if ($adb->num_rows($defcv_result) > 0) {
 					$viewid = $adb->query_result($defcv_result, 0, 'default_cvid');
 				} else {
-					$query = "select cvid from vtiger_customview where setdefault=1 and entitytype=? order by viewname";
-					$cvresult = $adb->pquery($query, array($module));
-					if ($adb->num_rows($cvresult) > 0) {
-						$viewid = $adb->query_result($cvresult, 0, 'cvid');
-					} else
-						$viewid = '';
+					$viewid = ''; //all表示
 				}
 			}
 
-			if ($viewid == '' || $viewid == 0 || $this->isPermittedCustomView($viewid, $now_action, $module) != 'yes') {
+			if ($viewid == '' || $viewid == 0 || $this->isPermittedCustomView($viewid, $now_action, $module) != 'yes') { //ここでall
 				$query = "select cvid from vtiger_customview where viewname='All' and entitytype=? order by viewname";
 				$cvresult = $adb->pquery($query, array($module));
 				$viewid = $adb->query_result($cvresult, 0, 'cvid');
@@ -130,6 +125,7 @@ class CustomView extends CRMEntity {
 			if ($this->isPermittedCustomView($viewid, $now_action, $this->customviewmodule) != 'yes')
 				$viewid = 0;
 		}
+		
 		$_SESSION['lvs'][$module]["viewname"] = $viewid;
 		return $viewid;
 	}

--- a/modules/CustomView/CustomView.php
+++ b/modules/CustomView/CustomView.php
@@ -92,21 +92,25 @@ class CustomView extends CRMEntity {
 		if(!$now_action) {
 			$now_action = vtlib_purify($_REQUEST['view']);
 		}
+		/*
+		表示するリストを決める. 優先度は以下の通り1～4.
+		1(前回のセッションで開いていたリスト), 2(デフォルトチェックボックスに✓が入れられたリスト), 3(DBでデフォルトに設定されているリスト), 4(All)
+		*/
 		if (empty($_REQUEST['viewname'])) {
 			if (isset($_SESSION['lvs'][$module]["viewname"]) && $_SESSION['lvs'][$module]["viewname"] != '') {
 				$viewid = $_SESSION['lvs'][$module]["viewname"];
-			} elseif ($this->setdefaultviewid != "") { //？？
+			} elseif ($this->setdefaultviewid != "") {
 				$viewid = $this->setdefaultviewid;
-			} else { //デフォルトリスト判別
+			} else {
 				$defcv_result = $adb->pquery("SELECT ump.default_cvid from vtiger_customview cv left join vtiger_user_module_preferences ump on cv.cvid = ump.default_cvid where ump.userid = ? and ump.tabid = ?", array($current_user->id, getTabid($module)));
 				if ($adb->num_rows($defcv_result) > 0) {
 					$viewid = $adb->query_result($defcv_result, 0, 'default_cvid');
 				} else {
-					$viewid = ''; //all表示
+					$viewid = '';
 				}
 			}
 
-			if ($viewid == '' || $viewid == 0 || $this->isPermittedCustomView($viewid, $now_action, $module) != 'yes') { //ここでall
+			if ($viewid == '' || $viewid == 0 || $this->isPermittedCustomView($viewid, $now_action, $module) != 'yes') {
 				$query = "select cvid from vtiger_customview where viewname='All' and entitytype=? order by viewname";
 				$cvresult = $adb->pquery($query, array($module));
 				$viewid = $adb->query_result($cvresult, 0, 'cvid');

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -316,10 +316,10 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			}
 
 			//共有リスト以外のsetdefaultを全て0にし, デフォルト設定したリストのみ1にする
-			$updateSql = 'UPDATE vtiger_customview SET setdefault = 0 WHERE entitytype = ? and userid = ? and status = 1';
+			$updateSql = 'UPDATE vtiger_customview SET setdefault = 0 WHERE status = "1" and entitytype = ? and userid = ?';
 			$updateParams = array($moduleName, $currentUserModel->getId());
 			$db->pquery($updateSql, $updateParams);
-			$updateSql = 'UPDATE vtiger_customview SET setdefault = 1 WHERE cvid = ?';
+			$updateSql = 'UPDATE vtiger_customview SET setdefault = "1" WHERE cvid = ?';
 			$updateParams = array($cvId);
 			$db->pquery($updateSql, $updateParams);
 		} else {
@@ -327,8 +327,8 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$deleteParams = array($currentUserModel->getId(), $moduleModel->getId(), $cvId);
 			$db->pquery($deleteSql, $deleteParams);
 
-			//共有リスト以外の全てのチェックボックスを外す
-			$updateSql = 'UPDATE vtiger_customview SET setdefault = 0 WHERE status = 1 and entitytype = ? and userid = ?';
+			//共有リスト以外のチェックボックスを外す
+			$updateSql = 'UPDATE vtiger_customview SET setdefault = 0 WHERE status = "1" and entitytype = ? and userid = ?';
             $updateParams = array($moduleName, $currentUserModel->getId());
             $db->pquery($updateSql, $updateParams);
 		}

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -99,15 +99,15 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				return false;
 			}
 		}
-		//check_cvid_idを取得してログイン中のユーザーと比較
-		//異なる場合falseを返す
+		//setdefault値(1/0)を元にture/falseを決めていたため✓が複数入るバグが発生
+		//そこで上の条件に加え, ログイン中ユーザーidとDBのuseridが一致するかの条件を追加
 		global $adb;
-        $query = "SELECT ump.userid as check_cvid_id from vtiger_customview cv left join vtiger_user_module_preferences ump on cv.cvid = ump.default_cvid WHERE cvid=?";
+        $query = "SELECT ump.userid as check_userid from vtiger_customview cv left join vtiger_user_module_preferences ump on cv.cvid = ump.default_cvid WHERE cvid=?";
         $queryParams = Array($this->get('cvid'));
         $result = $adb->pquery($query, $queryParams);
         $rows = $adb->num_rows($result);
         for ($i = 0; $i < $rows; $i++) {
-            $ump_userid[] = $adb->query_result($result, $i, 'check_cvid_id');
+            $ump_userid[] = $adb->query_result($result, $i, 'check_userid');
             if($this->get('setdefault') == 1 && $currentUserModel->getId() == $ump_userid[$i]){
                 return true;
             }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #78 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1, 2, 3はリストのチェックボックスのバグ、4はデフォルトで(ログイン時に)表示されるリストのバグ

1. リストのチェックボックスが複数選択できる
2. 共有リスト作成者がその共有リストをデフォルトに設定した際, 他のユーザーのチェックボックスにも✓が入ってしまう
3. 更新を押さないとチェックボックスの変更が反映されない
4. どのチェックボックスにも✓が入っていなかった場合の挙動がおかしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. vtiger_customviewのsetdefault値がリセットされていなかった。
2. 共有リストのsetdefault値が全ユーザーに影響を及ぼしていた
3. **未解決**部分的にリロードすることで解決すると思われる。#230 で登録済み
4. getViewId()でデフォルトのリストを決定しているが、setdefault値で判定していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. チェックボックスに✓が入った場合、共有リスト以外のsetdefault値を0にした後、指定のsetdefault値を1にする。
チェックボックスから✓がとられた場合、共有リスト以外のsetdefault値を0にする。
2. vtiger_customviewとvtiger_user_module_preferencesを比較し、ログイン中のユーザーidとDBのuseridが一致する場合に✓を入れる
3. **未解決**
4. 2と同様の変更をgetViewId()に加えた。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リストのチェックボックスとデフォルトのリスト表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
[チェックリスト](https://thinkingreed.sharepoint.com/sites/tr-doc/Shared%20Documents/51_F-RevoCRM/30_%E3%83%86%E3%82%B9%E3%83%88%E4%BB%95%E6%A7%98%E6%9B%B8/7.3/%2378_%E3%83%AA%E3%82%B9%E3%83%88%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%9C%E3%83%83%E3%82%AF%E3%82%B9%E3%81%AE%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D.xlsx?d=wfd3906cfca8c4abcafdfdf1f48470a3a)