### PR TITLE
#158画面幅が狭いときドキュメントのアップロードモーダルが崩れる箇所の修正

### DIFF
--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -4036,14 +4036,14 @@ th {
 ********************************************/
 .dragdrop-dotted {
   border: 2px dashed #C0C0C0;
-  min-width: 300px;
+  min-width: 265px;
   width: auto;
   color: #C0C0C0;
   text-align: center;
   vertical-align: middle;
   padding-top: 2%;
   margin-bottom: 10px;
-  height: 150px;
+  padding-bottom: 20px;
 }
 .dragdrop-solid {
   border-style: solid;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #158 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画面幅が狭いとき(iPhone5/SE等)ドキュメントのアップロードモーダルが崩れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. cssでmin-widthが300px、hightが150pxで指定されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. min-widthを265px、padding-bottomを20pxと指定

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/75693720/125910184-06839ac1-650d-4492-9add-34d4dbfa8219.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
アップロードモーダルの枠幅
.dragdrop-dottedを適用している箇所

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->