### PR TITLE
fixed: #234 顧客企業の概要画面で、活動が特定条件で重複する不具合の修正

### DIFF
--- a/modules/Accounts/models/Module.php
+++ b/modules/Accounts/models/Module.php
@@ -344,6 +344,7 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 		$numOfRows = $db->num_rows($result);
 
 		$groupsIds = Vtiger_Util_Helper::getGroupsIdsForUsers($currentUser->getId());
+		$crmidCache = array();
 		$activities = array();
 		for($i=0; $i<$numOfRows; $i++) {
 			$newRow = $db->query_result_rowdata($result, $i);
@@ -371,6 +372,10 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 
 			$model->setData($newRow);
 			$model->setId($newRow['crmid']);
+			if(in_array($newRow['crmid'], $crmidCache)){
+				continue;
+			}
+			$crmidCache[] = $newRow['crmid'];
 			$activities[] = $model;
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #234

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動に企業とその企業に関連した担当者を登録すると、企業の概要画面活動一覧が二重に表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. UNIONでつないだQUERYがDistinctできていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 暫定対応ではあるが、同一のCRMIDの場合に表示しない対応とする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
顧客企業の概要画面、活動一覧部分

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
一応暫定対応としますが、LIMIT周りには問題ないはずです（追加取得のときに二重表示されるバグが残っている）