### PR TITLE
fixed #161 システム設定画面のヘッダー修正

### DIFF
--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -8028,12 +8028,3 @@ a.btnReport:hover {
   overflow: auto;
 }
 /*# sourceMappingURL=style.css.map */
-
-/* 右上のメニューが表示されない場合、スマートフォンでヘッダーのスタイルが崩れる不具合修正 */
-@media (max-width: 768px) { 
-  .app-nav .module-action-bar .navbar-right{
-  float: right;
-  height: auto;
-  max-height: 42px;
-  }
-  }

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -8028,3 +8028,12 @@ a.btnReport:hover {
   overflow: auto;
 }
 /*# sourceMappingURL=style.css.map */
+
+/* 右上のメニューが表示されない場合、スマートフォンでヘッダーのスタイルが崩れる不具合修正 */
+@media (max-width: 768px) { 
+  .app-nav .module-action-bar .navbar-right{
+  float: right;
+  height: auto;
+  max-height: 42px;
+  }
+  }

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -442,3 +442,12 @@ button#advanceIntiateSave + input {
 #reportDetails table tr td.summaryHead {
     border-bottom: 0;
 }
+
+/* 右上のメニューが表示されない場合、スマートフォンでヘッダーのスタイルが崩れる不具合修正 */
+@media (max-width: 768px) { 
+  .app-nav .module-action-bar .navbar-right{
+  float: right;
+  height: auto;
+  max-height: 42px;
+  }
+  }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #161 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. システム設定画面のホームで画面幅を狭くするとヘッダーがずれて概要の文字が隠れる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ヘッダーの高さが42pxで固定されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ヘッダーの高さを自動調節できるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84700230/129131956-9190bbd6-b2f7-477a-a189-9a117135c0e9.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [✔] 自らテストを行った
- [✔] 不必要な変更が無い
- [✔] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->