### PR TITLE
fixed #169 見積の合計金額と出力したPDFファイルの合計金額が合うよう修正

### DIFF
--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -468,12 +468,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		if($tax_percent == '' || $tax_percent == 'NULL')
 			$tax_percent = 0;
 		$taxamount = ($subTotal-$finalDiscount)*$tax_percent/100;
-        list($before_dot, $after_dot) = explode('.', $taxamount);
-        if($after_dot[$no_of_decimal_places] == 5) {
-            $taxamount = round($taxamount, $no_of_decimal_places, PHP_ROUND_HALF_DOWN); 
-        } else {
-            $taxamount = number_format($taxamount, $no_of_decimal_places,'.','');
-        }
+		$taxamount = number_format($taxamount, $no_of_decimal_places,'.','');
 
 		$taxId = $tax_details[$tax_count]['taxid'];
 		$taxDetails[$taxId]['taxname']		= $tax_name;
@@ -505,13 +500,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 				$amount = (float)$amount + (float)$taxDetails[$id]['amount'];
 			}
 			$taxAmount = ((float)$amount * (float)$taxInfo['percentage']) / 100;
-			list($beforeDot, $afterDot) = explode('.', $taxAmount);
-
-			if ($afterDot[$no_of_decimal_places] == 5) {
-				$taxAmount = round($taxAmount, $no_of_decimal_places, PHP_ROUND_HALF_DOWN);
-			} else {
-				$taxAmount = number_format($taxAmount, $no_of_decimal_places, '.', '');
-			}
+			$taxAmount = number_format($taxAmount, $no_of_decimal_places, '.', '');
 
 			$taxDetails[$taxId]['amount'] = $taxAmount;
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #169 

##  不具合の内容 / Bug
1. 見積の総合計とエクスポートしたPDFファイルの合計金額が1円違うケースが存在する

##  原因 / Cause
1. 見積の総合計はvtiger_quotes.totalを参照しており、PDFファイルの合計金額は税引き前の合計と消費税をPDFファイル生成時に加算した値を参照しているため、参照している値に差異が存在する。
2. include/utils/EditViewUtils.phpにおいて消費税額を生成している箇所が五捨六入になっており、PDFファイルの合計金額を生成する処理において、丸め位置の数値が5の場合に切り捨てが発生している。
3. 見積の総合計はvtiger_quotes.totalをnumber_format関数にて丸め処理を行っている。
4. number_format関数は丸め位置において四捨五入が行われるため、丸め位置の値が5の際に切り捨て、切り上げの差異が発生していた。

##  変更内容 / Details of Change
1. include/utils/EditViewUtils.phpにおいて消費税額を生成している箇所にて丸め位置の数値が5の場合切り捨てを行っている処理を削除し、一律でnumber_format関数で四捨五入するよう修正。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/84055994/129175960-cbf29738-43b8-4ca2-af6c-09b568d13c59.png)
![image](https://user-images.githubusercontent.com/84055994/129176060-b8564cf7-be3d-4030-bfc4-06e14b8d4f27.png)

## 影響範囲  / Affected Area
製品の設定を行う画面（見積、請求、受注、発注）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
