### PR TITLE
fixed #239 ユーザー一覧を表示する関連項目のリストに、管理者でない場合は自分のみしか表示されない不具合を修正

### DIFF
--- a/modules/Users/models/ListView.php
+++ b/modules/Users/models/ListView.php
@@ -65,12 +65,13 @@ class Users_ListView_Model extends Vtiger_ListView_Model {
 	 * Functions returns the query
 	 * @return string
 	 */
-    public function getQuery() {
+	public function getQuery()
+	{
 		$listQuery = parent::getQuery();
 		$searchKey = $this->get('search_key');
-        $db = PearDatabase::getInstance();
+		$db = PearDatabase::getInstance();
 
-		if(!empty($searchKey)) {
+		if (!empty($searchKey)) {
 			$listQueryComponents = explode(" WHERE vtiger_users.status='Active' AND", $listQuery);
 			$listQuery = implode(' WHERE ', $listQueryComponents);
 		}
@@ -78,13 +79,25 @@ class Users_ListView_Model extends Vtiger_ListView_Model {
 
 		// Impose non-admin restrictions.
 		$user = vglobal('current_user');
-		if(!is_admin($user)){
-			$listQuery .= " AND vtiger_users.id = ?";
-            $param[] = $user->id;
+		if (!is_admin($user)) {
+			// getAccessibleUsersを使い、inで処理を行う
+			$listQuery .= " AND vtiger_users.id IN (";
+			$currentUser = Users_Record_Model::getCurrentUserModel();
+			$userList = $currentUser->getAccessibleUsers();
+			$isFirst = true;
+			foreach ($userList as $id => $name) {
+				if (!$isFirst) {
+					$listQuery .= ", ";
+				}
+				$listQuery .= "?";
+				$param[] = $id;
+				$isFirst = false;
+			}
+			$listQuery .= ")";
 			//TODO: Consider user based on Role-heirarchy 
 		}
 		return $db->convert2Sql($listQuery, $param);
-    }
+	}
 
 	/**
 	 * Function to get the list view entries


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #239

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連項目でモジュール「ユーザー」を作成する
2. 一般ユーザーでアクセスすると、自身しか選択できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 取得処理が自分のみとなっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Users_Record_Model::getAccessibleUsers()を使い、ロールベースのアクセス可能なユーザー一覧を取得し、SQLのINで取得するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ListViewのgetQuery()を修正しているので、Usersモジュールに関しては、Popup表示のみの想定です。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->