### PR TITLE
fixed #244 Inventoryの送料を設定した際、常に0になっていた問題を修正

### DIFF
--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -1168,7 +1168,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		var chargesTotal = 0;
 		chargesBlockContainer.find('.chargeValue').each(function(index, domElement){
 			var chargeElementValue = jQuery(domElement).val();
-			if(!Number.isFinite(chargeElementValue)){
+			if(isNaN(chargeElementValue)){
 				jQuery(domElement).val(0);
 				chargeElementValue=0;
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #244 

##  不具合の内容 / Bug
1. 見積などの「項目の設定」から送料を入力しても設定されない

##  原因 / Cause
1. 送料を設定するポップアップにおいて、「保存」ボタン押下時のイベント内で送料の算出を行っている。
2. jQuery(element).val()で取得した金額が数値かどうかの判定にNumber.isFinite()を使用している。
3. 取得した金額は"100"のように常に文字列で取得されるため、判定が常にfalseとなり、金額が常に0で上書きされていた。

##  変更内容 / Details of Change
1. Number.isFinite()ではなく、isNaN()を使用した判定に変更。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/84055994/129304510-97c2fe90-16f3-434b-bf3f-a570e3ff98e2.png)
![image](https://user-images.githubusercontent.com/84055994/129304526-0d94bf58-024c-4496-bbf4-0d3b884c9201.png)
![image](https://user-images.githubusercontent.com/84055994/129304551-dfcf4525-1a18-4f56-bbc3-e5d059302f51.png)

## 影響範囲  / Affected Area
製品の設定を行う画面（見積、請求、受注、発注）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
