### PR TITLE
fixed #238 見積書をPDF出力すると合計に調整金額が反映されない不具合を修正

### DIFF
--- a/include/InventoryPDFController.php
+++ b/include/InventoryPDFController.php
@@ -561,7 +561,8 @@ class Vtiger_InventoryPDFController {
 	private static function getTotalWithTax($relatedProducts) {
 		$preTotal = $relatedProducts[1]['final_details']['preTaxTotal'];
 		$tax = $relatedProducts[1]['final_details']['tax_totalamount'];
-		$currencyField = new CurrencyField($preTotal + $tax);
+		$adjustment = $relatedProducts[1]['final_details']['adjustment'];
+		$currencyField = new CurrencyField($preTotal + $tax + $adjustment);
 		$total = $currencyField->getDisplayValueWithSymbol();
 
 		return $total;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #238 [不具合]見積書で入力した調整金額がPDF出力すると合計金額に反映されない。

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 上記の通り

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 合計金額算出処理時に調整金額を反映していない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. include/InventoryPDFController.phpの549行目を追加し、調整金額を取得、550行目の合計処理を修正し、調整金額を反映。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
これにより注文請書、請求書、注文書等の同様の問題も修正される

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->