### PR TITLE
カレンダーのエクスポートでヘッダーの順番がvalueと一致するように修正

### DIFF
--- a/modules/Migration/schema/731_to_732.php
+++ b/modules/Migration/schema/731_to_732.php
@@ -41,4 +41,25 @@ if (defined('VTIGER_UPGRADE')) {
 			and vtiger_field.typeofdata LIKE '%~O'
 			and vtiger_tab.name = 'Dailyreports'
 	");
+	//カレンダーのエクスポートでヘッダーの順番を変更(tabid = 9 && block = 19のsequenceを整頓)
+	$query = "SELECT columnname,fieldid,sequence FROM vtiger_field WHERE tabid = 9 AND block = (SELECT block FROM vtiger_field WHERE tabid = 9 AND columnname = 'time_start') ORDER BY sequence;";
+	$result = $db->query($query);
+	$result_num = $db->num_rows($result);
+	for ($j = 0; $j < $result_num; $j++) {
+		$columnname = $db->query_result($result, $j,"columnname");
+		$fieldid = intval($db->query_result($result, $j,"fieldid"));
+		$sequence = intval($db->query_result($result, $j,"sequence"));
+		$fieldData[$columnname] = array(
+			"fieldid" => $fieldid,
+			"sequence" => $sequence,
+		);
+	}
+	if($fieldData["time_start"]["sequence"] == $fieldData["time_end"]["sequence"]){
+		$i = 0;
+		foreach($fieldData as $key => $value){
+			$updateQuery = "UPDATE vtiger_field SET sequence = ".($i+1)."  WHERE fieldid = ".$value['fieldid']." AND tabid = 9;";
+			$db->query($updateQuery);
+			$i++;
+		}
+	}
 }


### PR DESCRIPTION
再フォークにより#18 を再投稿 

## 不具合

カレンダーをエクスポートする際に開始時間と終了時間が逆になる。

## 原因

ヘッダーはtabid=9から、値はtabid=16から独立に生成されている？
vtiger_fieldのtime_endとtime_startのsequenceが同じなのでアルファベット順でtime_endが優先される？

## 修正

vtiger_fieldのtime_endとtime_startのsequenceが同じならsequenceを振り直すようにマイグレーションに追記