### PR TITLE
共有カレンダー情報のユーザー表示をnullから0に変更

### DIFF
--- a/modules/Migration/schema/732_to_733.php
+++ b/modules/Migration/schema/732_to_733.php
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <?php
 /*+********************************************************************************
  * The contents of this file are subject to the vtiger CRM Public License Version 1.0
@@ -16,4 +17,13 @@ if (defined('VTIGER_UPGRADE')) {
     $db->query("UPDATE vtiger_projecttaskstatus SET projecttaskstatus = 'Canceled' WHERE projecttaskstatus = 'Canceled '");
     //activity_reminder_popupの高速化
     $db->query("CREATE INDEX reminder_popup ON vtiger_activity_reminder_popup(status, date_start, time_start);");
+
+	//共有カレンダー情報のユーザー表示をnullから0に変更
+	$db->query("INSERT INTO vtiger_shareduserinfo(userid,shareduserid,visible)
+				SELECT u1.id AS id, u2.id AS shareduserid, 1 AS visible
+				FROM vtiger_users u1
+				LEFT OUTER JOIN vtiger_users u2 ON u2.id != u1.id
+				LEFT OUTER JOIN vtiger_shareduserinfo s ON s.shareduserid = u2.id AND s.userid = u1.id
+				WHERE u2.status = 'Active' AND u2.id IS NOT NULL AND (s.userid IS NULL OR s.userid <> '' ) AND s.visible IS NULL
+				ORDER BY u1.id ASC, u2.id ASC;");
 }


### PR DESCRIPTION
再フォークにより #46 を再投稿

## 概要
https://github.com/thinkingreed-inc/F-RevoCRM/pull/15 参照
共有カレンダーに表示されるユーザーをvtiger_shareduserinfoテーブルのvisibleが=1であるときのみに変更したことで、これまでvisible=nullで表示されていたユーザーが表示されなくなった

## 修正
現状でvtiger_shareduserinfoテーブルのvisible=nullのユーザー(旧バージョンでは表示されていた)を全てvisible=1に変更するマイグレーション
(現状visible=0 or visible=1のユーザーには影響なし)