### PR TITLE
#171 マイグレーションをコマンドラインから実行するスクリプトを追加

### DIFF
--- a/modules/Migration/views/MigrationScript.php
+++ b/modules/Migration/views/MigrationScript.php
@@ -1,0 +1,28 @@
+<?php
+require_once("includes/runtime/BaseModel.php");
+require_once("includes/runtime/Globals.php");
+require_once("config.php");
+require_once("include/logging.php");
+require_once("include/database/PearDatabase.php");
+require_once("include/utils/utils.php");
+require_once("vtlib/Vtiger/Deprecated.php");
+require_once("include/utils/CommonUtils.php");
+require_once("includes/Loader.php");
+require_once("vtlib/Vtiger/Module.php");
+require_once("modules/Vtiger/models/Module.php");
+require_once("modules/Migration/models/Module.php");
+require_once("includes/runtime/Controller.php");
+require_once("modules/Migration/views/Index.php");
+
+try {
+    ob_start(); //出力バッファリング開始
+    $Migration_Index_View = new Migration_Index_View();
+    $Migration_Index_View->applyDBChanges();
+} catch (Exception $e) {
+    echo($e->getMessage());
+}
+$migration_log = ob_get_contents(); // echoされる値を変数に代入
+ob_end_clean(); // バッファ削除
+$migration_log = str_replace("</table>","</table>\n",$migration_log); // 改行追加
+$migration_log = strip_tags($migration_log); // タグ削除
+echo($migration_log);


### PR DESCRIPTION
再フォークにより#187 を再投稿

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #171

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 現状マイグレーションはブラウザでのみ実行可能だが,コマンドラインで行いたい

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->

マイグレーションをwebからでなくコマンドで行う.
適切に配置し以下で実行
```sh
cd /var/www/html/frevocrm
php MigrationScript.php
```

frevoのバージョンはvtigerversion.phpで管理されており,マイグレーションを実行すると$vtiger_current_versionの値がvtiger_versionのテーブルに書き込まれる.
また,実行するパッチはmodules\Migration\models\Module.phpの$versionsの配列で管理されている.
よって,マイグレーションのテストを行う際は,

1. vtigerversion.phpの$vtiger_current_versionを減らし,modules\Migration\models\Module.phpの$versionsのパッチ番号をコメントアウトする.
1. マイグレーションを実行し,DBのvtiger_versionを減らす.
1. vtigerversion.phpの$vtiger_current_versionを戻し,modules\Migration\models\Module.phpの$versionsのパッチ番号のコメントアウトを解除する.
1. マイグレーションを実行し,DBのvtiger_versionを戻すとパッチが実行される.

**注:バージョンを戻しても,実行したクエリは戻らない！**

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
DB

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->