### PR TITLE
#261 ワークフローで値を更新すると更新履歴がシステム管理者になる問題を修正

### DIFF
--- a/modules/com_vtiger_workflow/VTWorkflowUtils.php
+++ b/modules/com_vtiger_workflow/VTWorkflowUtils.php
@@ -65,8 +65,12 @@ class VTWorkflowUtils {
 	 */
 	function revertUser() {
 		global $current_user;
-		if (count(self::$userStack) != 0) {
-			$current_user = array_pop(self::$userStack);
+		$userStackCounts = count(self::$userStack);
+		if ($userStackCounts != 0) {
+			for  ($i=1; $i<$userStackCounts; $i++) {
+				array_pop(self::$userStack);
+			}
+			$current_user = self::$userStack[0];
 		} else {
 			$current_user = null;
 		}

--- a/modules/com_vtiger_workflow/VTWorkflowUtils.php
+++ b/modules/com_vtiger_workflow/VTWorkflowUtils.php
@@ -65,11 +65,8 @@ class VTWorkflowUtils {
 	 */
 	function revertUser() {
 		global $current_user;
-		$userStackCounts = count(self::$userStack);
-		if ($userStackCounts != 0) {
-			for  ($i=1; $i<$userStackCounts; $i++) {
-				array_pop(self::$userStack);
-			}
+		if (count(self::$userStack) != 0) {
+			array_splice(self::$userStack, 1);
 			$current_user = self::$userStack[0];
 		} else {
 			$current_user = null;


### PR DESCRIPTION
再フォークにより#262 を再投稿

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #261 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  ワークフローで値の更新を行う対象のレコード(実際に更新されない場合も含む)を更新すると更新履歴の更新者がシステム管理者になる.

##  原因 / Cause
<!-- バグの原因を記述 -->
1. VTWorkflowUtilsインスタンスの配列$userStackにレコードの更新時に一時的にシステム管理者が追加されているが,これを戻す関数のrevertUserがうまく働いていない.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 0番目の値を残して配列の値を削除するように変更.

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフローのアクション

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
ワークフローで関連モジュールの値の更新をすると,更新はされるが更新履歴が残らない(本変更を行う前でも発生する).