### PR TITLE
#249 関連のユーザーをエクスポート・インポートした際に生じる問題を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -563,8 +563,8 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 						if (count($fieldValueDetails) == 2) {
 							$entityLabel = trim($fieldValueDetails[1]);
 							if ($fieldValueDetails[0] == 'Users') {
-								$query = "SELECT id  FROM vtiger_users WHERE trim(concat(last_name,' ',first_name)) = '".$entityLabel."';";
-								$result = $adb->pquery($query, array());
+								$query = "SELECT id  FROM vtiger_users WHERE trim(concat(last_name,' ',first_name)) = ? ;";
+								$result = $adb->pquery($query, array($entityLabel));
 								if ($adb->num_rows($result) > 0) {
 									$entityId = $adb->query_result($result, 0, "id");
 								}

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -567,6 +567,8 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 								$result = $adb->pquery($query, array($entityLabel));
 								if ($adb->num_rows($result) > 0) {
 									$entityId = $adb->query_result($result, 0, "id");
+								} elseif ($adb->num_rows($result) == 0 && $fieldInstance->isMandatory()) {
+									$entityId = $this->user->id;
 								}
 							} else {
 								$entityId = getEntityId($referenceModuleName, decode_html($entityLabel));

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -390,8 +390,8 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 
 	function getParentModuleName($value, $fieldName) {
 		$db = PearDatabase::getInstance();
-		$query = "SELECT relmodule  FROM vtiger_fieldmodulerel WHERE fieldid = (SELECT fieldid FROM vtiger_field WHERE columnname = '".$fieldName."');";
-		$result = $db->pquery($query, array());
+		$query = "SELECT relmodule  FROM vtiger_fieldmodulerel WHERE fieldid = (SELECT fieldid FROM vtiger_field WHERE columnname = ? );";
+		$result = $db->pquery($query, array($fieldName));
 		if ($db->num_rows($result) > 0) {
 			$columname = $db->query_result($result, 0, "relmodule");
 		}

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -344,7 +344,7 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			}elseif($type == 'reference'){
 				$value = trim($value);
 				if(!empty($value)) {
-					$parent_module = getSalesEntityType($value);
+					$parent_module = $this->getParentModuleName($value, $fieldName);
 					$displayValueArray = getEntityName($parent_module, $value);
 					if(!empty($displayValueArray)){
 						foreach($displayValueArray as $k=>$v){
@@ -386,6 +386,21 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			}
 		}
 		return $arr;
+	}
+
+	function getParentModuleName($value, $fieldName) {
+		$db = PearDatabase::getInstance();
+		$query = "SELECT relmodule  FROM vtiger_fieldmodulerel WHERE fieldid = (SELECT fieldid FROM vtiger_field WHERE columnname = '".$fieldName."');";
+		$result = $db->pquery($query, array());
+		if ($db->num_rows($result) > 0) {
+			$columname = $db->query_result($result, 0, "relmodule");
+		}
+		if($columname == "Users"){
+			$parent_module = "Users";
+		} else {
+			$parent_module = getSalesEntityType($value);
+		}
+		return $parent_module;
 	}
 
 	public function moduleFieldInstances($moduleName) {


### PR DESCRIPTION
再フォークにより#265 を再投稿

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #249 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カスタムフィールドの関連ユーザーをエクスポートすると全く異なるモジュールのデータが出力される.
2. カスタムフィールドの関連ユーザーを正常にインポートできない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 一般のモジュールのidはcrmidとして通しで振られているが,userモジュールのidは含まれていない.
しかし,インポート時にフィールド名からモジュールを逆引きする際には常にcrmidを参照している.
2. 関連ユーザーをインポートする際に,値が空であった場合は常に現在のユーザーの値が入る.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. カスタムフィールドのユーザーをエクスポート・インポートする際にはフィールド名→モジュールの逆引きを独自のものに変更
2. インポート時に関連ユーザーは必須項目以外は値の空を維持するように変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* インポート
* エクスポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- クエリの実行が増加するので,インポート・エクスポートの数が多い際にパフォーマンスに影響する可能性あり.
- 同姓同名の場合はuseridが若い方が当たる(仕様)