### PR TITLE
#259 パスワードを日本語翻訳漏れ箇所の修正

### DIFF
--- a/include/Webservices/Custom/ChangePassword.php
+++ b/include/Webservices/Custom/ChangePassword.php
@@ -64,7 +64,7 @@ function vtws_changePassword($id, $oldPassword, $newPassword, $confirmPassword, 
 							WebServiceErrorCode::$CHANGEPASSWORDFAILURE));
 		}
 		VTWS_PreserveGlobal::flush();
-		return array('message' => 'Changed password successfully');
+		return array('message' => vtranslate('Changed password successfully'));
 	}
 }
 ?>

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -2093,6 +2093,7 @@ $jsLanguageStrings = array(
 	'LBL_LOADING' => '読み込み中',
 	'JS_NO_RESULTS_FOUND' => '結果がありません',
 	'JS_INVALID_STRENGTH_PASSWORDS'=>'複雑なパスワードを指定してください（アルファベット大文字・小文字、数字、記号を含む8文字以上）',
+	'Changed password successfully' => 'パスワードは正常に変更されました',
 	'LBL_MASS_PDF_EXPORT_CONFIRMATION' => '選択したレコードに関するPDFを生成してもよろしいですか？',
 
 	//個人カレンダー


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #259 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ユーザー詳細画面にてパスワードを変更した際のメッセージが未翻訳

##  原因 / Cause
<!-- バグの原因を記述 -->
該当箇所にvtranslate()がかかっていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
vtranslate()関数の追加と日本語訳の追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/131301147-d595b61e-87eb-49b3-b40a-1c357f5452f1.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
パスワード変更後の和訳

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
