### PR TITLE
#253 すでにあるグループ名を登録すると未翻訳のメッセージが表示される箇所の修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -2099,4 +2099,7 @@ $jsLanguageStrings = array(
 	'Planned' => '計画済み',
 	'Held' => '完了',
 	'Not Held' => '取り止め',
+	
+	//ユーザー管理>グループ作成
+	'JS_DUPLICATES_EXIST' => '既に存在しています',
 );


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #253 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. すでにあるグループ名を登録すると未翻訳のメッセージが表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. JS_DUPLICATES_EXISTに対応する日本語が用意されていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 翻訳を追加した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/129528716-f32d5702-9766-42f0-836c-c20ad8381240.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
JS_DUPLICATES_EXISTが適応されている箇所の和訳

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
