### PR TITLE
#62 ユーザー管理のユーザーの画面にて、パスワードの変更等の表示が埋もれている箇所の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2809,6 +2809,18 @@ Vtiger.Class("Vtiger_List_Js", {
 				} else {
 					$column.addClass("fix-data-column");
 				}
+
+				/* 
+				ユーザー管理の「ユーザー」と「プロファイル」にて
+				fix-data-columnが適応されるとドロップダウンメニューが隠れてしまうので削除する
+				*/
+				var module = app.getModuleName();
+				var parentModule = app.getParentModuleName();
+				if(parentModule == 'Settings'){
+					if(module == 'Users' || 'Profiles'){
+						$column.removeClass("fix-data-column")
+					}
+				}
 	
 				if(i > 0) {
 					$column.css({

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -22,10 +22,6 @@
     transform: scale(0.999);
     background-clip: padding-box;
   }
-  .listViewRecordActions.fix-data-column {
-    position: static;
-    transform: none;
-  }
 }
 /*
  * モーダルウインドウの背景を黒ベースに変更

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -22,6 +22,10 @@
     transform: scale(0.999);
     background-clip: padding-box;
   }
+  .listViewRecordActions.fix-data-column {
+    position: static;
+    transform: none;
+  }
 }
 /*
  * モーダルウインドウの背景を黒ベースに変更


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #62 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ユーザー管理＞ユーザーの画面にて、パスワードの変更等の表示が埋もれていた

##  原因 / Cause
<!-- バグの原因を記述 -->
ドロップダウンメニューの親要素にfix-data-columnが適応されていた。
fix-data-columnは特定の要素を左に固定するクラスであるが、`position: sticky;`が使用されていたため、
ドロップダウンメニューよりも上に重なって表示されてしまった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
バグが報告されているユーザー管理＞ユーザーと
新しく発見したユーザー管理＞プロファイルから
fix-data-columnを削除する処理を加えた。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/129526441-fcd3e429-f727-4934-a7c6-f219aeb58233.png)

![image](https://user-images.githubusercontent.com/75693720/129526383-dd0527fb-24b7-4bb7-af86-e36a287da390.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
バグが報告されているユーザー管理＞ユーザーと
新しく発見したユーザー管理＞プロファイルのドロップダウンメニュー動作

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
