### PR TITLE
#203 リスト作成時のエラーメッセージ翻訳

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1572,6 +1572,7 @@ $jsLanguageStrings = array(
 	'JS_PLEASE_SELECT_ATLEAST_ONE_OPTION' => '少なくとも 1 つのオプションを選択してください',
 	'JS_SELECT_MODULE' => 'モジュールを選択してください',
 	'JS_PLEASE_SELECT_ATLEAST_ONE_MANDATORY_FIELD' => '少なくとも 1 つの必須項目を選択してください',
+	'Select atleast one mandatory value.' => '少なくとも 1 つの必須項目を選択してください',
 	'JS_SELECT_MODULE' => 'モジュールを選択してください',
 	'JS_PLEASE_ENTER_INTEGER_VALUE' => '整数値を入力してください',
 	'JS_PLEASE_ENTER_DECIMAL_VALUE' => '小数値を入力してください',

--- a/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -236,7 +236,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 						} 
 					} 
 						  if(mandatoryFieldsMissing){ 
-						app.helper.showErrorNotification({message:"Select atleast one mandatory value."}); 
+						app.helper.showErrorNotification({message: app.vtranslate('Select atleast one mandatory value.')}); 
 							  return false; 
 					} 
 					//handled advanced filters saved values.


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #203 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リスト作成時、必須項目を選ばず作成するとエラーメッセージが表示される。このメッセージが未翻訳であった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. CustomView.jsのメッセージ作成箇所にvtranslate()関数が使用されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtranslate()関数を使用した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/125216904-71919600-e2fa-11eb-8984-837b080ec198.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
新しいリストを作成する処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->

