### PR TITLE
Fix calendar mouse movement isallday

### DIFF
--- a/modules/Calendar/RepeatEvents.php
+++ b/modules/Calendar/RepeatEvents.php
@@ -463,7 +463,7 @@ class Calendar_RepeatEvents {
 				$total[] = $total_copy_childId;
 				$total_copy_childId = array();
 			}
-			$copy_parentId = $total[0]; //0でいいのか
+			$copy_parentId = $total[0];
 			for($i = 0;$i < count($total); $i++){
 				$copy_childId = $total[$i];
 				for($j = 0;$j < count($copy_parentId); $j++){

--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -236,6 +236,7 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 					foreach ($childRecords as $childId) {
 						$recordModel = Vtiger_Record_Model::getInstanceById($childId, 'Events');
 						$recordModel->set('mode', 'edit');
+						$recordModel->set('is_allday', $record->get('is_allday'));
 
                         $startDateTime = $this->getFormattedDateTime($recordModel->get('date_start'), $recordModel->get('time_start'));
 						$startDate = strtotime($startDateTime) + $startDateInterval;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #105 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 繰り返し予定編集画面のチェックボックスが変更されない
2. 繰り返し予定を参加者あり(もしくは後から追加)で作成した場合、作成者以外の参加者がこの予定の時間を変更することができない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. is_alldayがrecordModelにセットされていなかった
2. vtiger_activity_recurring_infoに参加者の予定のidがセットされていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. recordModelにis_alldayを追加
2.  予定作成時・参加者追加時、vtiger_activity_recurring_infoを編集する処理を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* 予定の終日チェックボックス
* 繰り返し予定の編集

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* これまでに作成した繰り返し予定に対応できない(修正適用後、新規で作成した予定 or 参加者を追加した予定のみに反映される)
