### PR TITLE
#198 共有カレンダーにて参加者が2名以上いる予定をドラッグアンドドロップすると予定表示が2倍になる不具合を修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1136,7 +1136,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	_updateAllOnCalendar: function (calendarModule) {
 		var thisInstance = this;
 		this.getCalendarViewContainer().fullCalendar('addEventSource',
-				function (start, end, timezone, render) {
+			updateAllOnCalendarEvent = function (start, end, timezone, render) {
 					var activeFeeds = jQuery('[data-calendar-feed="' + calendarModule + '"]:checked');
 
 					var activeFeedsRequestParams = {};
@@ -1177,7 +1177,10 @@ Vtiger.Class("Calendar_Calendar_Js", {
 							app.helper.hideProgress();
 						});
 					}
-				});
+			});
+		this.getCalendarViewContainer().fullCalendar('removeEventSource', updateAllOnCalendarEvent);
+		this.getCalendarViewContainer().fullCalendar('refetchEvents');
+
 	},
 	showCreateTaskModal: function () {
 		this.showCreateModal('Calendar');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #198 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 共有カレンダーにて参加者が2名以上いる予定をドラッグアンドドロップすると予定表示が2倍になる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. layouts\v7\modules\Calendar\resources\Calendar.jsのrenderEvents関数と_updateAllOnCalendar関数で,二重にfullCalendarのイベントが登録されている.処理のタイミングで二重に表示されたりされなかったする.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. _updateAllOnCalendar関数でイベントを一回実行後に削除する.

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->