### PR TITLE
パスワード登録、変更の文字数制限が正常に機能していない箇所の修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -2093,6 +2093,7 @@ $jsLanguageStrings = array(
 	'LBL_LOADING' => '読み込み中',
 	'JS_NO_RESULTS_FOUND' => '結果がありません',
 	'JS_INVALID_STRENGTH_PASSWORDS'=>'複雑なパスワードを指定してください（アルファベット大文字・小文字、数字、記号を含む8文字以上）',
+	'Changed password successfully'=>'パスワードの変更に成功しました',
 	'LBL_MASS_PDF_EXPORT_CONFIRMATION' => '選択したレコードに関するPDFを生成してもよろしいですか？',
 
 	//個人カレンダー

--- a/layouts/v7/modules/Install/resources/Index.js
+++ b/layouts/v7/modules/Install/resources/Index.js
@@ -75,7 +75,7 @@ jQuery.Class('Install_Index_Js', {}, {
 
 		function checkStrengthPassword() {
 			var password = jQuery('input[name="password"]').val();
-			if(password.lenght < 8) {
+			if(password.length < 8) {
 				setPasswordError('8文字以上のパスワードにしてください。');
 				return false;
 			}

--- a/layouts/v7/modules/Users/ForgotPassword.tpl
+++ b/layouts/v7/modules/Users/ForgotPassword.tpl
@@ -114,7 +114,7 @@
     <body>
         <div id="container">
             <div class="logo" style = "padding-left:50%">
-                <img  src="{$LOGOURL}" alt="{$TITLE}" style="height: 4em;width: 12em;"><br><br><br>
+                <img  src="{$LOGOURL}" alt="{$TITLE}" style="height: auto;width: 12em;"><br><br><br>
             </div>
             <div style = "padding-left:50%;width:100%">
                 {if $LINK_EXPIRED neq 'true'}

--- a/layouts/v7/modules/Users/ForgotPassword.tpl
+++ b/layouts/v7/modules/Users/ForgotPassword.tpl
@@ -96,7 +96,7 @@
                 }
             }
             function checkStrengthPassword(password) {
-                if(password.lenght < 8) {
+                if(password.length < 8) {
                     return false;
                 }
                 if(!/[a-z]/.test(password)

--- a/layouts/v7/resources/helper.js
+++ b/layouts/v7/resources/helper.js
@@ -1043,7 +1043,7 @@ jQuery.Class("Vtiger_Helper_Js",{
     },
 
     checkStrengthPassword: function (password) {
-        if(password.lenght < 8) {
+        if(password.length < 8) {
             return false;
         }
         if(!/[a-z]/.test(password)


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #284 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. パスワード登録、変更の文字数制限が正常に機能していない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. checkStrengthPassword()関数内の文字数判定が機能していなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. password.lenght → password.lengthへ
2. パスワード変更成功時の通知の翻訳
3. パスワード変更画面のロゴ修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/133710282-bc5ee74b-59af-4d44-8aa2-de286869545d.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
パスワード設定/変更時

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
以下の内容についてテストしました
 - ユーザー新規作成時
 - 既存ユーザーのパスワード変更
 - インストール時
 - ログイン画面からパスワード変更時