### PR TITLE
#290 ユーザー一覧の｢名前とメールアドレス｣の列がズレて表示される不具合を修正

### DIFF
--- a/layouts/v7/modules/Users/ListViewContents.tpl
+++ b/layouts/v7/modules/Users/ListViewContents.tpl
@@ -106,13 +106,13 @@
 													{assign var=IMAGE_DETAILS value=$LISTVIEW_ENTRY->getImageDetails()}
 													{foreach item=IMAGE_INFO from=$IMAGE_DETAILS}
 														{if !empty($IMAGE_INFO.url)}
-															<div class='col-lg-2'>
+															<div class='userIconDiv'>
 																<img height="25px" width="25px" src="{$IMAGE_INFO.url}">
 															</div>
 														{/if}
 													{/foreach}
 													{if $IMAGE_DETAILS[0]['id'] eq null}
-														<div class='col-lg-2'>
+														<div class='userIconDiv'>
 															<i class="fa fa-user userDefaultIcon"></i>
 														</div>
 													{/if}

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -473,3 +473,10 @@ button#advanceIntiateSave + input {
     padding: 0;
   }
 }
+
+/* ユーザー一覧画面のユーザーアイコン */
+.userIconDiv{
+  float: left;
+  width: 30px;
+  padding: 0 26px 0 10px;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #290 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー一覧の｢名前とメールアドレス｣の列がズレて表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ユーザー一覧のユーザーアイコンは｢名前とメールアドレス｣の列の幅によって相対的にdivの幅が決められている

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. スタイルが相対変化しないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/133754993-75fd696b-2b04-481f-b0de-99100379dde6.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー一覧

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->