### PR TITLE
RSSが取れないときにログイン画面を正常に表示させる修正

### DIFF
--- a/layouts/v7/modules/Users/Login.tpl
+++ b/layouts/v7/modules/Users/Login.tpl
@@ -305,7 +305,7 @@
 						<div>
 							<h4>F-RevoCRMに関するお知らせ</h4>
 						</div>
-						<a href="https://f-revocrm.jp" target="_blank" style="margin-right: 25px;"><img src="https://f-revocrm.jp/frevowp/wp-content/uploads/2018/07/top_keyvisual-11-2.png" style="width: 85%; height: 100%; margin-top: 25px;"/></a>
+						<a href="https://f-revocrm.jp" target="_blank" style="margin-right: 25px;"><img src="https://f-revocrm.jp/frevowp/wp-content/uploads/2021/09/image_frevo_top.png" style="width: 85%; height: 100%; margin-top: 25px;"/></a>
 					</div>
 				{/if}
 				</div>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- RSSがうまく取れないときにログイン画面を正常に表示させる修正

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. RSSが取れなかったときにログイン画面が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. SimpleXMLElementに例外が発生したときに処理を抜けられない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. SimpleXMLElementに例外があった場合、処理を抜ける
2. RSSが取れなかったときに表示される画像の差し替え

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/134845401-62a68d23-5729-432d-a5e0-09d31d2e35c9.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ログイン画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->