### PR TITLE
一括編集にて複数選択肢の編集が反映されない箇所の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1239,6 +1239,9 @@ Vtiger.Class("Vtiger_List_Js", {
 			//automatically select fields for mass edit when updated
 			$('#massEdit :input').change(function() {
 				var _replacedName =  $(this).attr('name').replace('[]', "");
+				if($("[name=" + _replacedName + "]").parent().attr("class") == "input-group"){
+					_replacedName = _replacedName.replace(/(.*)_display/,"$1");
+				}
 				$(this).closest('tr').find("input[id^=include_in_mass_edit_" + _replacedName + "]").prop( "checked", true );
 			});
 			

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1238,7 +1238,8 @@ Vtiger.Class("Vtiger_List_Js", {
 			
 			//automatically select fields for mass edit when updated
 			$('#massEdit :input').change(function() {
-				$(this).closest('tr').find("input[id^=include_in_mass_edit_" + $(this).attr('name') + "]").prop( "checked", true );
+				var _replacedName =  $(this).attr('name').replace('[]', "");
+				$(this).closest('tr').find("input[id^=include_in_mass_edit_" + _replacedName + "]").prop( "checked", true );
 			});
 			
 			app.helper.registerLeavePageWithoutSubmit($("#massEdit"));
@@ -1419,6 +1420,13 @@ Vtiger.Class("Vtiger_List_Js", {
 			//add url params for fields that will be updated
 			changedFields.each(function(i, obj){
 				var key = $(this).data("update-field");
+				// multipicklistの場合は[]をつけた方のvalueを取得する
+				var $elm = $('[name='+key+']');
+				var fieldType = $elm.data('fieldtype');
+				if(fieldType == 'multipicklist'){
+					key = encodeURI(key+'[]');
+				}
+
 				var value = newData[key];
 				form_update_data += key + '=';
 				

--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -1187,6 +1187,7 @@ Vtiger.Class('Vtiger_Index_Js', {
 			if(selectedName) {
 				fieldElement.parent().find('.clearReferenceSelection').removeClass('hide');
 				fieldElement.parent().find('.referencefield-wrapper').addClass('selected');
+				fieldElement.closest('tr').find("input[id^=include_in_mass_edit_" + sourceField + "]").prop( "checked", true );
 			}else {
 				fieldElement.parent().find('.clearReferenceSelection').addClass('hide');
 				fieldElement.parent().find('.referencefield-wrapper').removeClass('selected');

--- a/modules/Vtiger/helpers/Util.php
+++ b/modules/Vtiger/helpers/Util.php
@@ -1246,7 +1246,7 @@ class Vtiger_Util_Helper {
         }elseif(!empty($fieldValue) && $fieldDataType == 'multipicklist'){
             if(!empty($editablePicklistValues)){
                 foreach($fieldValue as $key => $value){
-                    if(!isset($editablePicklistValues[$fieldValue])){
+                    if(!isset($editablePicklistValues[$value])){
                         unset($fieldValue[$key]);
                     }
                 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #281 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一括編集にて複数選択肢の変更が保存されない
2. 一括編集にて関連項目のチェックボックスが変更後に✓されない
3. クイック作成にて複数選択肢が保存されない
4. カレンダー/TODOのクイック作成にて複数選択肢が保存されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. multipicklsitの場合、"cf_980"ではなく"cf_980[]"の値を参照する必要があった(cf_980はフィールド名)
2. キーワードを入力する場合、フィールド名から"_display"を削除する必要があった。選択肢から選択する場合、選択肢の保存画面にてチェックボックスに✓を入れる処理する必要があった
 - キーワードを入力する場合
![image](https://user-images.githubusercontent.com/75693720/135408941-b697d5a1-e40a-4206-9577-f193e4160afc.png)
 - 選択肢から選択する場合
![image](https://user-images.githubusercontent.com/75693720/135409385-602c31e9-7da6-4dd0-a03a-5457f273cea0.png)
3. validateFieldValue()内の編集可能な変数(editablePicklistValues)の条件が誤っていた
4. 3と同様

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. "cf_980"ではなく"cf_980[]"の値を参照するようにした
2. _displayの削除と、チェックボックスに✓を入れる処理を追加した
3. $fieldValueを$valueに変更した(4も同様)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->