### PR TITLE
fixed #89 #218 ミニリスト作成時の日本語翻訳を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/dashboards/MiniListWizard.tpl
+++ b/layouts/v7/modules/Vtiger/dashboards/MiniListWizard.tpl
@@ -63,9 +63,9 @@
 {elseif $WIZARD_STEP eq 'step2'}
 	<option></option>
 	{foreach from=$ALLFILTERS item=FILTERS key=FILTERGROUP}
-		<optgroup label="{$FILTERGROUP}">
+		<optgroup label="{vtranslate($FILTERGROUP, $SELECTED_MODULE)}">
 			{foreach from=$FILTERS item=FILTER key=FILTERNAME}
-				<option value="{$FILTER->getId()}">{$FILTER->get('viewname')}</option>
+				<option value="{$FILTER->getId()}">{vtranslate($FILTER->get('viewname'),$SELECTED_MODULE)}</option>
 			{/foreach}
 		</optgroup>
 	{/foreach}

--- a/modules/Vtiger/views/MiniListWizard.php
+++ b/modules/Vtiger/views/MiniListWizard.php
@@ -40,6 +40,7 @@ class Vtiger_MiniListWizard_View extends Vtiger_Index_View {
 			case 'step2':
 				$selectedModule = $request->get('selectedModule');
 				$filters = CustomView_Record_Model::getAllByGroup($selectedModule, false);
+				$viewer->assign('SELECTED_MODULE', $selectedModule);
 				$viewer->assign('ALLFILTERS', $filters);
 				break;
 			case 'step3':


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #89 #218 
- add #221 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ミニリスト追加時に、英語のままだった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. vtranslateの埋め込み不足
2. 日本語翻訳の不足

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtranslateの埋め込み不足
2. 日本語翻訳の追加
ミニリスト作成時に日本語が表示されるように修正した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84700230/135413147-83a0cf9d-556b-4bab-a699-e83062df2f89.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ウィジェット内のミニリスト範囲のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->