### PR TITLE
#266 一覧画面で他のモジュールの項目によるソートが利かない不具合を修正

### DIFF
--- a/modules/Vtiger/models/ListView.php
+++ b/modules/Vtiger/models/ListView.php
@@ -206,7 +206,7 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
 
-		$orderBy = $this->getForSql('orderby');
+		$orderBy = $this->get('orderby');
 		$sortOrder = $this->getForSql('sortorder');
 
 		if(!empty($orderBy)){


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #266

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一覧画面で他のモジュールの項目によるソートが利かない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ソートするカラム名(関連の場合記号を含む)をサニタイズするgetForSql関数によって値が消えていた.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 単純なget関数で記述するように変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールの一覧表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
カラム名のサニタイズを省略したが,これ以降のクエリを生成する前に整形されているのでセキュリティ上の問題は生じないと考えられる.
