### PR TITLE
fix #296 リストからカラムをすべて消そうとしたときに表示される文言の翻訳

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1577,6 +1577,7 @@ $jsLanguageStrings = array(
 	'JS_PLEASE_ENTER_INTEGER_VALUE' => '整数値を入力してください',
 	'JS_PLEASE_ENTER_DECIMAL_VALUE' => '小数値を入力してください',
 	'JS_PLEASE_ENTER_POSITIVE_DECIMAL_VALUE' => '正の小数値を入力してください',
+	'JS_ATLEAST_SELECT_ONE_FIELD' => '少なくとも 1 つの項目を選択してください',
 
 	'JS_START_TIME_SHOULD_BE_GREATER_THAN_CURRENT_TIME' => '開始時刻は現在時刻よりも未来にする必要があります',
 	'JS_SHOULD_BE_LESS_THAN_CURRENT_DATE' => '現在の日付より前である必要があります',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #296 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストからカラムをすべて消そうとしたときに表示される文言が英語のままだった。

##  原因 / Cause
<!-- バグの原因を記述 -->
'JS_ATLEAST_SELECT_ONE_FIELD' => 'At least one field should be selected',
に対応する日本語訳が存在しない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 翻訳の追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84700230/135420109-11f7f1ff-a4fc-470c-a100-548bed17a7ef.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
特になし

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->