### PR TITLE
#94 私の予定表で「繰り返しの予定の変更/削除」の「×」ボタンを押すと保存できなくなる問題を修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1422,7 +1422,6 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var thisInstance = this;
 		var params = {
 			submitHandler: function (form) {
-				jQuery("button[name='saveButton']").attr("disabled", "disabled");
 				if (this.numberOfInvalids() > 0) {
 					jQuery("button[name='saveButton']").removeAttr("disabled");
 					return false;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #94 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーで繰り返し予定を修正するとモーダルウィンドウでどの範囲で修正するか選択できるが,このモーダルウィンドウを消すと元画面の保存ボタンが押せなくなっている.

##  原因 / Cause
<!-- バグの原因を記述 -->
1. モーダルウィンドウを出す際に,もとの保存ボタンにdisable属性が付与されている.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. disable属性を付与する行を削除

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った