### PR TITLE
[WIP]背景透明化のcssがデフォルトのアイコンにも適応されてしまっていたので修正

### DIFF
--- a/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
 	<div class="col-sm-6">
 		<div class="clearfix record-header ">
-			<div class="recordImage bgAccounts app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+			<div class="recordImage bgAccounts app-{$SELECTED_MENU_CATEGORY}">
 				{assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
 				{foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
 					{if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
 	<div class="col-sm-6">
 		<div class="clearfix record-header ">
 			<div class="recordImage bgAccounts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-				{if !empty($IMAGE_INFO.imgName)}
-					{if $IMAGE_INFO.imgName neq "summaryImg"}
-						<div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+				{if !empty($IMAGE_INFO[0].imgpath)}
+					{if $IMAGE_INFO[0].imgName neq "summaryImg"}
+						<div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
 					{else}
 						<img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
 					{/if}

--- a/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Accounts/DetailViewHeaderTitle.tpl
@@ -12,16 +12,14 @@
 {strip}
 	<div class="col-sm-6">
 		<div class="clearfix record-header ">
-			<div class="recordImage bgAccounts app-{$SELECTED_MENU_CATEGORY}">
-				{assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-				{foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-					{if !empty($IMAGE_INFO.url)}
-						<img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
+			<div class="recordImage bgAccounts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+				{if !empty($IMAGE_INFO.imgName)}
+					{if $IMAGE_INFO.imgName neq "summaryImg"}
+						<div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
 					{else}
 						<img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
 					{/if}
-				{/foreach}
-				{if empty($IMAGE_DETAILS)}
+				{else}
 					<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 				{/if}
 			</div>

--- a/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
    <div class="col-lg-6 col-md-6 col-sm-6">
 	  <div class="record-header clearfix ">
-		 <div class="recordImage bgcontacts app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+		 <div class="recordImage bgcontacts app-{$SELECTED_MENU_CATEGORY}">
 			{assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
 			{foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
 			   {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
    <div class="col-lg-6 col-md-6 col-sm-6">
 	  <div class="record-header clearfix ">
 		 <div class="recordImage bgcontacts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-			{if !empty($IMAGE_INFO.imgName)}
-				{if $IMAGE_INFO.imgName neq "summaryImg"}
-					<div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+			{if !empty($IMAGE_INFO[0].imgpath)}
+				{if $IMAGE_INFO[0].imgName neq "summaryImg"}
+					<div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
 			    {else}
 					<img src="{vimage_path('summary_Contact.png')}" class="summaryImg"/>
 				{/if}

--- a/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Contacts/DetailViewHeaderTitle.tpl
@@ -12,16 +12,14 @@
 {strip}
    <div class="col-lg-6 col-md-6 col-sm-6">
 	  <div class="record-header clearfix ">
-		 <div class="recordImage bgcontacts app-{$SELECTED_MENU_CATEGORY}">
-			{assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-			{foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-			   {if !empty($IMAGE_INFO.url)}
-				  <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
-			   {else}
-				  <img src="{vimage_path('summary_Contact.png')}" class="summaryImg"/>
-			   {/if}
-			{/foreach}
-			{if empty($IMAGE_DETAILS)}
+		 <div class="recordImage bgcontacts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+			{if !empty($IMAGE_INFO.imgName)}
+				{if $IMAGE_INFO.imgName neq "summaryImg"}
+					<div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+			    {else}
+					<img src="{vimage_path('summary_Contact.png')}" class="summaryImg"/>
+				{/if}
+			{else}
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 			{/if}
 		 </div>

--- a/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="recordImage bghelpdesk app-{$SELECTED_MENU_CATEGORY}">
+            <div class="recordImage bghelpdesk app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
             </div>
             <div class="recordBasicInfo">

--- a/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="recordImage bghelpdesk app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bghelpdesk app-{$SELECTED_MENU_CATEGORY}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
             </div>
             <div class="recordBasicInfo">

--- a/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
     <div class="col-sm-6">
         <div class="record-header clearfix">
             <div class="recordImage bginvoice app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.imgName)}
-                    {if $IMAGE_INFO.imgName neq "summaryImg"}
-                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}

--- a/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
@@ -12,18 +12,16 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bginvoice app-{$SELECTED_MENU_CATEGORY}">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-                    {if !empty($IMAGE_INFO.url)}
-                        <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
+            <div class="recordImage bginvoice app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.imgName)}
+                    {if $IMAGE_INFO.imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}
-                {/foreach}
-				{if empty($IMAGE_DETAILS)}
-					<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-				{/if}
+                {else}
+                    <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
+                {/if}
             </div>
             <div class="recordBasicInfo">
                 <div class="info-row" >

--- a/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Invoice/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bginvoice app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bginvoice app-{$SELECTED_MENU_CATEGORY}">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
                     {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="hidden-sm hidden-xs recordImage bgleads app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="hidden-sm hidden-xs recordImage bgleads app-{$SELECTED_MENU_CATEGORY}">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
                     {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
             <div class="hidden-sm hidden-xs recordImage bgleads app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.imgName)}
-                    {if $IMAGE_INFO.imgName neq "summaryImg"}
-                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_Leads.png')}" class="summaryImg"/>
                     {/if}

--- a/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Leads/DetailViewHeaderTitle.tpl
@@ -12,18 +12,16 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="hidden-sm hidden-xs recordImage bgleads app-{$SELECTED_MENU_CATEGORY}">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-                    {if !empty($IMAGE_INFO.url)}
-                        <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100px" align="left"><br>
+            <div class="hidden-sm hidden-xs recordImage bgleads app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.imgName)}
+                    {if $IMAGE_INFO.imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_Leads.png')}" class="summaryImg"/>
                     {/if}
-                {/foreach}
-                {if empty($IMAGE_DETAILS)}
+                {else}
                     <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-				{/if}
+                {/if}
             </div>
             <div class="recordBasicInfo">
                 <div class="info-row">

--- a/layouts/v7/modules/Potentials/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Potentials/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgpotentials app-{$SELECTED_MENU_CATEGORY}">
+            <div class="recordImage bgpotentials app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
             </div>
 

--- a/layouts/v7/modules/Potentials/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Potentials/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgpotentials app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bgpotentials app-{$SELECTED_MENU_CATEGORY}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
             </div>
 

--- a/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
@@ -13,7 +13,7 @@
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-            <div class="recordImage bgproducts app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}" {if $IMAGE_DETAILS|@count gt 1}style = "display:block"{/if} >
+            <div class="recordImage bgproducts app-{$SELECTED_MENU_CATEGORY}" {if $IMAGE_DETAILS|@count gt 1}style = "display:block"{/if} >
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
 	               {if !empty($IMAGE_INFO.url)}
 	                {if $IMAGE_DETAILS|@count eq 1}

--- a/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
@@ -13,8 +13,8 @@
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
             <div class="recordImage bgproducts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.0.imgpath)}
-                    {if $IMAGE_INFO.0.imgName neq "summaryImg"}
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
                         {assign var=WIDTH value="40px"}{assign var=HEIGHT value="40px"}
                         {if $IMAGE_INFO|@count eq 1}{$WIDTH="80px"}{$HEIGHT="80px"}
                         {elseif $IMAGE_INFO|@count eq 2}{$HEIGHT="80px"}

--- a/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Products/DetailViewHeaderTitle.tpl
@@ -12,27 +12,22 @@
 {strip}
     <div class="col-sm-6 col-lg-6 col-md-6">
         <div class="record-header clearfix">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-            <div class="recordImage bgproducts app-{$SELECTED_MENU_CATEGORY}" {if $IMAGE_DETAILS|@count gt 1}style = "display:block"{/if} >
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-	               {if !empty($IMAGE_INFO.url)}
-	                {if $IMAGE_DETAILS|@count eq 1}
-	                    <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
-	                {else if $IMAGE_DETAILS|@count eq 2}
-	                    <span><img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="50%" height="100%" align="left"></span>
-	                {else if $IMAGE_DETAILS|@count eq 3}
-	                    <span><img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" {if $ITER eq 0 or $ITER eq 1}width="50%" height = "50%"{/if}{if $ITER eq 2}width="100%" height="50%"{/if} align="left"></span>
-	                {else if $IMAGE_DETAILS|@count eq 4 or $IMAGE_DETAILS|@count gt 4}
-	                    {if $ITER gt 3}{break}{/if}
-	                    <span><img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}"width="50%" height="50%" align="left"></span>
-	                {/if}
-	               {else}
-	                  <img src="{vimage_path('summary_Products.png')}" class="summaryImg"/>
-	               {/if}
-	        {/foreach}
-			{if empty($IMAGE_DETAILS)}
-				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-			{/if}
+            <div class="recordImage bgproducts app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.0.imgpath)}
+                    {if $IMAGE_INFO.0.imgName neq "summaryImg"}
+                        {assign var=WIDTH value="40px"}{assign var=HEIGHT value="40px"}
+                        {if $IMAGE_INFO|@count eq 1}{$WIDTH="80px"}{$HEIGHT="80px"}
+                        {elseif $IMAGE_INFO|@count eq 2}{$HEIGHT="80px"}
+                        {/if}
+                        {for $ITER=0 to $IMAGE_INFO|@count-1 max=4}
+                            <div class="change_BG_center" style="width: {$WIDTH}; height: {$HEIGHT}; background-image: url({$IMAGE_INFO.$ITER.imgpath})"></div>
+                        {/for}
+                    {else}
+                        <img src="{vimage_path('summary_Contact.png')}" class="summaryImg"/>
+                    {/if}
+                {else}
+                    <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
+                {/if}
             </div>
 
             <div class="recordBasicInfo">

--- a/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
@@ -12,18 +12,16 @@
 {strip}
     <div class="col-lg-6 col-md-6 col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgpurchaseorder app-{$SELECTED_MENU_CATEGORY}">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-                    {if !empty($IMAGE_INFO.url)}
-                        <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
+            <div class="recordImage bgpurchaseorder app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.imgName)}
+                    {if $IMAGE_INFO.imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}
-                {/foreach}
-                {if empty($IMAGE_DETAILS)}
+                {else}
                     <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-				{/if}
+                {/if}
             </div>
             <div class="recordBasicInfo">
                 <div class="info-row">

--- a/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
     <div class="col-lg-6 col-md-6 col-sm-6">
         <div class="record-header clearfix">
             <div class="recordImage bgpurchaseorder app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.imgName)}
-                    {if $IMAGE_INFO.imgName neq "summaryImg"}
-                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}

--- a/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/PurchaseOrder/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-lg-6 col-md-6 col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgpurchaseorder app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bgpurchaseorder app-{$SELECTED_MENU_CATEGORY}">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
                     {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgquotes app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bgquotes app-{$SELECTED_MENU_CATEGORY}">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
                     {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
     <div class="col-sm-6">
         <div class="record-header clearfix">
             <div class="recordImage bgquotes app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.imgName)}
-                    {if $IMAGE_INFO.imgName neq "summaryImg"}
-                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}

--- a/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Quotes/DetailViewHeaderTitle.tpl
@@ -12,18 +12,16 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgquotes app-{$SELECTED_MENU_CATEGORY}">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-                    {if !empty($IMAGE_INFO.url)}
-                        <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
+            <div class="recordImage bgquotes app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.imgName)}
+                    {if $IMAGE_INFO.imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}
-                {/foreach}
-				{if empty($IMAGE_DETAILS)}
-					<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-				{/if}
+                {else}
+                    <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
+                {/if}
             </div>
             <div class="recordBasicInfo">
                 <div class="info-row">

--- a/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
@@ -12,18 +12,16 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgsalesorder app-{$SELECTED_MENU_CATEGORY}">
-                {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
-                {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
-                    {if !empty($IMAGE_INFO.url)}
-                        <img src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="100%" height="100%" align="left"><br>
+            <div class="recordImage bgsalesorder app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
+                {if !empty($IMAGE_INFO.imgName)}
+                    {if $IMAGE_INFO.imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}
-                {/foreach}
-				{if empty($IMAGE_DETAILS)}
-					<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
-				{/if}
+                {else}
+                    <div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
+                {/if}
             </div>
             <div class="recordBasicInfo">
                 <div class="info-row">

--- a/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
     <div class="col-sm-6">
         <div class="record-header clearfix">
-            <div class="recordImage bgsalesorder app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+            <div class="recordImage bgsalesorder app-{$SELECTED_MENU_CATEGORY}">
                 {assign var=IMAGE_DETAILS value=$RECORD->getImageDetails()}
                 {foreach key=ITER item=IMAGE_INFO from=$IMAGE_DETAILS}
                     {if !empty($IMAGE_INFO.url)}

--- a/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/SalesOrder/DetailViewHeaderTitle.tpl
@@ -13,9 +13,9 @@
     <div class="col-sm-6">
         <div class="record-header clearfix">
             <div class="recordImage bgsalesorder app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
-                {if !empty($IMAGE_INFO.imgName)}
-                    {if $IMAGE_INFO.imgName neq "summaryImg"}
-                        <div class="name"><span><strong><img src="{$IMAGE_INFO.imgpath}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" width="1"/></strong></span></div>
+                {if !empty($IMAGE_INFO[0].imgpath)}
+                    {if $IMAGE_INFO[0].imgName neq "summaryImg"}
+                        <div class="name"><span><strong><img src="{$IMAGE_INFO[0].imgpath}" alt="{$IMAGE_INFO[0].orgname}" title="{$IMAGE_INFO[0].orgname}" width="1"/></strong></span></div>
                     {else}
                         <img src="{vimage_path('summary_organizations.png')}" class="summaryImg"/>
                     {/if}

--- a/layouts/v7/modules/Vendors/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vendors/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
 	<div class="col-lg-6 col-md-6 col-sm-6">
 		<div class="record-header clearfix">
-			<div class="recordImage bgvendors app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+			<div class="recordImage bgvendors app-{$SELECTED_MENU_CATEGORY}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 			</div>
 			<div class="recordBasicInfo">

--- a/layouts/v7/modules/Vendors/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vendors/DetailViewHeaderTitle.tpl
@@ -12,7 +12,7 @@
 {strip}
 	<div class="col-lg-6 col-md-6 col-sm-6">
 		<div class="record-header clearfix">
-			<div class="recordImage bgvendors app-{$SELECTED_MENU_CATEGORY}">
+			<div class="recordImage bgvendors app-{$SELECTED_MENU_CATEGORY} {if $BGWHITE}change_BG_white{/if}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 			</div>
 			<div class="recordBasicInfo">

--- a/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
@@ -13,7 +13,7 @@
 			{if !$MODULE}
 				{assign var=MODULE value=$MODULE_NAME}
 			{/if}
-			<div class="recordImage bg_{$MODULE} app-{$SELECTED_MENU_CATEGORY} {if $IMAGE_DETAILS == false}Read_BG_clear{/if}">
+			<div class="recordImage bg_{$MODULE} app-{$SELECTED_MENU_CATEGORY}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 			</div>
 

--- a/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
@@ -13,7 +13,7 @@
 			{if !$MODULE}
 				{assign var=MODULE value=$MODULE_NAME}
 			{/if}
-			<div class="recordImage bg_{$MODULE} app-{$SELECTED_MENU_CATEGORY}">
+			<div class="recordImage bg_{$MODULE} app-{$SELECTED_MENU_CATEGORY}  {if $BGWHITE}change_BG_white{/if}">
 				<div class="name"><span><strong>{$MODULE_MODEL->getModuleIcon()}</strong></span></div>
 			</div>
 

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -2058,7 +2058,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 
 		$imageFilePath = 'layouts/'.Vtiger_Viewer::getLayoutName()."/modules/$moduleName/$moduleName.png";
 		if (file_exists($imageFilePath)) {
-			$moduleIcon = "<img src='$imageFilePath' title='$title' width='1' style='background-color: white;'/>";
+			$moduleIcon = "<img src='$imageFilePath' title='$title' width='1'/>";
 		}
 
 		return $moduleIcon;

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -2058,7 +2058,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 
 		$imageFilePath = 'layouts/'.Vtiger_Viewer::getLayoutName()."/modules/$moduleName/$moduleName.png";
 		if (file_exists($imageFilePath)) {
-			$moduleIcon = "<img src='$imageFilePath' title='$title' width='1'/>";
+			$moduleIcon = "<img src='$imageFilePath' title='$title' width='1' style='background-color: white;'/>";
 		}
 
 		return $moduleIcon;

--- a/modules/Vtiger/views/Detail.php
+++ b/modules/Vtiger/views/Detail.php
@@ -166,8 +166,11 @@ class Vtiger_Detail_View extends Vtiger_Index_View {
 		$imagedetails = $recordModel->getImageDetails();
 		if($imagedetails){
 			if(!empty($imagedetails[0]['url'])){
-				$imageInfo["imgpath"] = $imagedetails[0]['url'];
-				$imageInfo["imgName"] = $imagedetails[0]['orgname'];
+				// 製品の場合、画像を複数アップロードできるためfor文を使っている
+				for($i = 0; $i < count($imagedetails); $i++){
+					$imageInfo[$i]["imgpath"] = $imagedetails[$i]['url'];
+					$imageInfo[$i]["imgName"] = $imagedetails[$i]['orgname'];
+				}
 				$isBGwhite = true;
 			}else{
 				$imageInfo["imgpath"] = "summaryImg.png";
@@ -178,6 +181,7 @@ class Vtiger_Detail_View extends Vtiger_Index_View {
 			$imageInfo["imgpath"] = $this->record->getModule()->getModuleIcon();
 			$imageInfo["imgName"] = "";
 			$isBGwhite = false;
+			// (例:顧客担当者)/layouts/v7/modules/Contacts/Contacts.pngがある場合、背景を白に
 			if(strpos($imageInfo["imgpath"],$moduleName.'.png') !== false) $isBGwhite = true;
 		}
 		$viewer->assign('IMAGE_INFO',$imageInfo);

--- a/modules/Vtiger/views/Detail.php
+++ b/modules/Vtiger/views/Detail.php
@@ -162,6 +162,27 @@ class Vtiger_Detail_View extends Vtiger_Index_View {
 			$viewer->assign('SELECTED_MENU_CATEGORY',$appName);
 		}
 
+		//サムネイル部分を生成するために必要な情報をView側に渡す
+		$imagedetails = $recordModel->getImageDetails();
+		if($imagedetails){
+			if(!empty($imagedetails[0]['url'])){
+				$imageInfo["imgpath"] = $imagedetails[0]['url'];
+				$imageInfo["imgName"] = $imagedetails[0]['orgname'];
+				$isBGwhite = true;
+			}else{
+				$imageInfo["imgpath"] = "summaryImg.png";
+				$imageInfo["imgName"] = "summaryImg";
+				$isBGwhite = false;
+			}
+		}else{
+			$imageInfo["imgpath"] = $this->record->getModule()->getModuleIcon();
+			$imageInfo["imgName"] = "";
+			$isBGwhite = false;
+			if(strpos($imageInfo["imgpath"],$moduleName.'.png') !== false) $isBGwhite = true;
+		}
+		$viewer->assign('IMAGE_INFO',$imageInfo);
+		$viewer->assign('BGWHITE',$isBGwhite);
+
 		$selectedTabLabel = $request->get('tab_label');
 		$relationId = $request->get('relationId');
 

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -423,9 +423,6 @@ button#advanceIntiateSave + input {
   max-height: 80px;
   margin: 0 auto;
 }
-.detailview-header .col-sm-6 .clearfix .Read_BG_clear{/*背景透明化*/
-  background-color: rgba(0,0,0,0) !important;
-}
 
 /*クイック作成*/
 .col-lg-12 .row .col-lg-4 .quickCreateModule img{

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -423,6 +423,14 @@ button#advanceIntiateSave + input {
   max-height: 80px;
   margin: 0 auto;
 }
+/*レコード画面アイコンの背景白色化と中央寄せ*/
+.detailview-header .col-sm-6 .clearfix .change_BG_white{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-color: white !important;
+}
 
 /*クイック作成*/
 .col-lg-12 .row .col-lg-4 .quickCreateModule img{

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -425,11 +425,26 @@ button#advanceIntiateSave + input {
 }
 /*レコード画面アイコンの背景白色化と中央寄せ*/
 .detailview-header .col-sm-6 .clearfix .change_BG_white{
+  width: 80px;
+  height: 80px;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
 
   background-color: white !important;
+}
+/* 製品の場合のみ画像を複数アップロードできる仕様
+ * object-fit:containはIE11で使えないのでbackground-size:containを使って中央寄せする
+*/
+.detailview-header .col-sm-6 .clearfix .change_BG_white .change_BG_center{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  background-position: center center;
+  background-size: contain;
+  background-repeat: no-repeat;
 }
 
 /*クイック作成*/


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #295 
- merge #53 のコミットで発生した不具合

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
詳細画面のアイコンの背景色が消えている

##  原因 / Cause
<!-- バグの原因を記述 -->
背景色透明化のcss(.Read_BG_clear)を、
ユーザーが画像を追加した場合にのみ適応したかったが、それ以外の場合にも適応されてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Read_BG_clearの削除
2. ユーザーが画像を追加した場合、背景色をwhiteで上書きする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
- デフォルトアイコン
![image](https://user-images.githubusercontent.com/75693720/136326560-200e9322-282c-4e4e-9a5e-cdad8b8f11f3.png)
- 背景透過されている画像を追加した場合
![image](https://user-images.githubusercontent.com/75693720/136326954-7e135473-1be6-4d1a-a8ff-b72efa8ca8d4.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
モジュール詳細画面のアイコン背景色

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->