### PR TITLE
#127 概要・詳細画面でのマージンを一部調整

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -480,3 +480,20 @@ button#advanceIntiateSave + input {
   width: 30px;
   padding: 0 26px 0 10px;
 }
+
+/* 概要・詳細画面 */
+@media (min-width: 992px) {
+  .detailViewContainer.viewContent > .content-area {
+      padding-left: 57px;
+  }
+}
+@media (max-width: 991px) {
+  .detailViewContainer.viewContent > .content-area {
+      padding-left: 15px;
+  }
+}
+@media (min-width: 769px) {
+  .detailview-header-block {
+  margin-top: 10px;
+  }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #127

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画面幅が1500から1000程度の場合,コンテナと左サイドバーに隙間がなくなる
2. 概要・詳細画面のヘッダー上部のマージンが無く,微妙にかぶっている

##  原因 / Cause
<!-- バグの原因を記述 -->
1. padding-leftが3%の相対指定のため,画面幅が狭いと相対的にサイドバーの幅が大きくなる
2. そもそもマージンが無い

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. サイドバーがあるときは57px,ないときは15pxのpadding-leftを指定
2. 10pxのマージン追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
before
![image](https://user-images.githubusercontent.com/53038605/136330448-354204e3-0e17-405f-9868-997c967da4f3.png)
after
![image](https://user-images.githubusercontent.com/53038605/136330488-f736410e-fe22-4e06-b96b-81c300a1fc45.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
概要・詳細画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った