### PR TITLE
#310 多数のデータをインポートする際の不具合を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -134,20 +134,27 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 	}
 
 	public function initializeImport() {
+		global $adb;
 		$lockInfo = Import_Lock_Action::isLockedForModule($this->module);
-		if ($lockInfo != null) {
-			if ($lockInfo['userid'] != $this->user->id) {
+		$importUserId = $this->user->id;
+		if (isset($lockInfo)) {
+			if ($lockInfo['userid'] != $importUserId) { //他ユーザーのキューがインポート中なのでインポートしない
 				Import_Utils_Helper::showImportLockedError($lockInfo);
 				return false;
-			} else if($lockInfo['importid'] == $this->id) {
+			}
+			$configReader = new Import_Config_Model();
+			$pagingLimit = intval($configReader->get('importPagingLimit'));
+			$importTable = 'vtiger_import_'.$importUserId;
+			$finishedImportQuery = 'SELECT count(status) FROM '.$importTable.' WHERE status = 1 GROUP BY status';
+			$finishedImportResult = $adb->pquery($finishedImportQuery, array());
+			$finishedImportCount = $adb->query_result($finishedImportResult, 0, 'count(status)');
+			if($lockInfo['importid'] == $this->id && $finishedImportCount % $pagingLimit != 0 ) { //このキューはすでに実行されており,インポート中なのでインポートしない
 				return false;
-			} else {
-				return true;
 			}
 		} else {
 			Import_Lock_Action::lock($this->id, $this->module, $this->user);
-			return true;
 		}
+		return true;
 	}
 
 	public function finishImport() {
@@ -905,7 +912,14 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			$vtigerMailer->Body    = $emailData;
 			$vtigerMailer->Send(true);
 
-			$importDataController->finishImport();
+			//未完了のインポートがない場合のみ終了する
+			$importTable = 'vtiger_import_' . $current_user->id;
+			$unfinishedImportQuery = 'SELECT count(status) FROM ' . $importTable . ' WHERE status = 0 GROUP BY status';
+			$unfinishedImportResult = $adb->pquery($unfinishedImportQuery, array());
+			$unfinishedImportCount = $adb->query_result($unfinishedImportResult, 0, 'count(status)');
+			if(!$unfinishedImportCount){
+				$importDataController->finishImport();
+			}
 		}
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #310 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 10001件以上のデータをインポートすると途中でエラーがでる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. modules\Import\models\Config.phpの**immediateImportLimit**(デフォルト値:1000)を超えるとインポートは一度に行われずcron処理される.さらに,同ファイルの**importPagingLimit**(デフォルト値:10000)を超えるとページング処理されて複数回のcronで処理されるはずがうまく働いていない.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 未完了のインポートがvtiger_import_(ユーザーID)に残っている場合,vtiger_import_queueを消さずに残すように修正
2. vtiger_import_queueが残っている場合,importPagingLimitで止まっているのか前の実行が継続中かどうか判定するように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールのインポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
レコード数が多いCSVをインポートする際に,PHPの制限でデフォルトでは2MB以上のファイルをアップロードできないため,php.iniのupload_max_filesizeの上限を引き上げてApacheを再起動する必要あり(8MBより引き上げたい場合はpost_max_sizeなども変更が必要)