### PR TITLE
fix #335 PDFテンプレートモジュールにて、各明細の行番号が表示できるように修正。

### DIFF
--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -201,7 +201,12 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$entitytype=$adb->query_result($result,$i-1,'entitytype');
 		$purchaseCost = $adb->query_result($result,$i-1,'purchase_cost');
 		$margin = $adb->query_result($result,$i-1,'margin');
+		$sequence_no = $adb->query_result($result,$i-1,'sequence_no');
 		$isSubProductsViewable = $adb->query_result($result, $i-1, 'is_subproducts_viewable');
+
+		if ($sequence_no) {
+			$product_Detail[$i]['sequence_no' . $i] = $sequence_no;
+		}
 
 		if ($purchaseCost) {
 			$product_Detail[$i]['purchaseCost'.$i] = number_format($purchaseCost, $no_of_decimal_places, '.', '');

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1483,6 +1483,7 @@ $languageStrings = array(
 	'Item net price' => '品目の金額',
 	'Item total price' => '品目の割引前合計',
 	'List columns saved successfully' => 'カラムは正常に保存されました',
+	'Sequence no' => '明細行番号',
 
 	//ユーザー管理>プロファイル
 	'Import' => 'インポート',

--- a/modules/PDFTemplates/models/Module.php
+++ b/modules/PDFTemplates/models/Module.php
@@ -132,6 +132,7 @@ class PDFTemplates_Module_Model extends Vtiger_Module_Model {
 					}
 				}
 			}
+			$allFields[] = array(vtranslate($field['module'], $field['module']) . ':' . vtranslate('Sequence no', $field['module']), "$" . strtolower($field['module']) . "-sequence_no$");
 			$allFields[] = array(vtranslate($field['module'], $field['module']) . ':' . vtranslate('Item total price', $field['module']), "$" . strtolower($field['module']) . "-producttotal$");
 			$allFields[] = array(vtranslate($field['module'], $field['module']) . ':' . vtranslate('Item net price', $field['module']), "$" . strtolower($field['module']) . "-netprice$");
 			$allFields[] = array(vtranslate($field['module'], $field['module']) . ':' . vtranslate('Tax', $field['module']), "$" . strtolower($field['module']) . "-tax_totalamount$");


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #335

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. PDFテンプレーtト編集画面より､｢明細行番号｣が選択できるように修正。
2. 明細魚番号を選択した際、$[モジュール名]-sequence_no$の文言が設定されるように修正。
3. $[モジュール名]-sequence_no$の箇所に明細行の行番号が表示されるように修正。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/63196364/139416667-5637a61d-5e28-4909-8b06-44a5054232bd.png)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->