### PR TITLE
fix #336 WebAPIのQuery処理で受注モジュールの明細行が全行取得できるように修正。

### DIFF
--- a/include/Webservices/VtigerModuleOperation.php
+++ b/include/Webservices/VtigerModuleOperation.php
@@ -198,7 +198,13 @@ class VtigerModuleOperation extends WebserviceEntityOperation {
 			if(!$meta->hasPermission(EntityMeta::$RETRIEVE,$row[$tableIdColumn])){
 				continue;
 			}
-			$output[$row[$tableIdColumn]] = DataTransform::sanitizeDataWithColumn($row,$meta);
+			if(strpos(explode("FROM",$mysql_query)[0], 'vtiger_inventoryproductrel') === false){
+				// 明細行が含まれていない場合
+				$output[$row[$tableIdColumn]] = DataTransform::sanitizeDataWithColumn($row,$meta);
+			}else{
+				// 明細行が含まれている場合
+				$output[] = DataTransform::sanitizeDataWithColumn($row,$meta);
+			}
 		}
 		
 		$newOutput = array();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #336

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Query処理でデータを取得する際、明細行の最終行のデータのみ残っていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Query処理でデータを取得する際、レコードID毎にデータをまとめていた為に明細行が複数あった場合に最終行のデータのみ残る形となっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 明細行のデータを取得する場合、レコードID毎に上書きするのではなく新しい配列データとして追加するように修正。
2. 取得するデータに明細行のデータが含まれていない場合は、今まで通り取得するように修正。
　⇒明細行を除いた項目を取得しようとした場合、同じデータが明細行分取れてしまわないように対応。

## 影響範囲  / Affected Area
見積、受注、発注、請求モジュールをQuery処理で取得する場合。
※Retrieve処理は対象外。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->