### PR TITLE
fix #337 文字列項目が多数含まれているモジュールをインポートした場合、インポートに失敗する件を修正。

### DIFF
--- a/modules/Import/readers/FileReader.php
+++ b/modules/Import/readers/FileReader.php
@@ -144,7 +144,16 @@ class Import_FileReader_Reader {
 		if(in_array($dataType, $skipDataType)){
 			$columnsListQuery .= ','.$fieldName.' varchar(250)';
 		} else {
-			$columnsListQuery .= ','.$fieldName.' '.$fieldTypes[$fieldObject->get('column')];
+			if (strpos($fieldTypes[$fieldObject->get('column')], 'varchar') !== false) {
+				preg_match('/(?<=\().*?(?=\))/', $fieldTypes[$fieldObject->get('column')], $match);
+				if (intval($match[0]) > 200) {
+					$columnsListQuery .= ',' . $fieldName . ' text';
+				} else {
+					$columnsListQuery .= ',' . $fieldName . ' ' . $fieldTypes[$fieldObject->get('column')];
+				}
+			} else {
+				$columnsListQuery .= ',' . $fieldName . ' ' . $fieldTypes[$fieldObject->get('column')];
+			}
 		}
 
 		return $columnsListQuery;


### PR DESCRIPTION
varchar(200)以上のカラムをインポートする場合、text型として作成するように修正。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #337 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 文字列項目が多数含まれているモジュールをインポートした場合、インポートに失敗していた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポートの際、1つのテーブルにインポートデータをまとめて登録している。
　もともと複数テーブルに分かれていた項目が1テーブルにまとめられることで、1テーブルに設定可能なサイズの上限を超えておりエラーが発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. varchar(200)以上の項目については、インポート用テーブルにtext型として登録するように修正。

## 影響範囲  / Affected Area
文字列項目が多数存在するモジュールをインポートする場合。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->