### PR TITLE
fix #342 PDFテンプレートで作成されたPDFの明細行に、テキストエリアで入力された改行が反映されない件を修正

### DIFF
--- a/include/InventoryPDFController.php
+++ b/include/InventoryPDFController.php
@@ -467,6 +467,10 @@ class Vtiger_InventoryPDFController {
 				$fieldname = strtolower($name);
 				$fieldname = preg_replace('/'.$cnt.'$/', '', $fieldname);
 				$fieldname = self::convertFieldName($fieldname);
+
+				// 改行が適用されるように修正
+				$value = nl2br($value);
+
 				$block = preg_replace('/\$'.$prefix.'\-'.$fieldname.'\$/', $value, $block);
 			}
 			$convertedArray[] = $block;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #342 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 明細行のテキストエリア内の改行がPDFに反映されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 改行記号をそのままHTMLとして出力していた為、改行として認識されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 改行記号を<br>に変換するように修正。

## 影響範囲  / Affected Area
受注、発注、見積、請求モジュールにて、テキストエリア項目で且つ改行を入力している場合。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->