### PR TITLE
fix #344 PDFファイル一括エクスポート時、zipファイルの中身が空となる場合がある件の修正。

### DIFF
--- a/modules/Vtiger/actions/MassPDFExport.php
+++ b/modules/Vtiger/actions/MassPDFExport.php
@@ -193,7 +193,7 @@ class Vtiger_MassPDFExport_Action extends Vtiger_Mass_Action
             $uitype4fieldname = ",".$uitype4fieldname;
         }
 
-        $query = "SELECT ".$this->focus->table_index.$uitype4fieldname;
+        $query = "SELECT ".$this->focus->table_name.".".$this->focus->table_index.$uitype4fieldname;
         $query .= $queryGenerator->getFromClause();
         $query .= $queryGenerator->getWhereClause();
         $this->query = $query;


### PR DESCRIPTION
一括エクスポート時のクエリにて、項目名だけではなくテーブル名も合わせて指定するように修正。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #344

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFファイル一括エクスポート時、zipファイルの中身が空となる場合がある

##  原因 / Cause
<!-- バグの原因を記述 -->
1. PDFファイル一括エクスポート時のクエリにてテーブル名を指定していない箇所があり、テーブル名は異なるが同じカラム名の項目が複数存在する場合に、クエリエラーが発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. PDFファイル一括エクスポート時のクエリにてテーブル名を指定して処理を実行するように修正。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
見積、受注、請求、発注モジュールにてPDF一括エクスポートを行う場合。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->