### PR TITLE
fixed #346 金額フィールドでマイナス値を登録できるように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/validation.js
+++ b/layouts/v7/modules/Vtiger/resources/validation.js
@@ -278,9 +278,6 @@ jQuery.validator.addMethod("currency", function(value, element, params) {
 	if(isNaN(strippedValue)){
 		return false;
 	}
-	if(strippedValue < 0){
-		return false;
-	}
 	return true;
 	}, jQuery.validator.format(app.vtranslate('JS_PLEASE_ENTER_VALID_VALUE'))
 );


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #346 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 金額フィールドでマイナスの値を登録できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. バリデーションで弾いている
2. データベース的にはINT型なので問題ない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. validation.jsにて該当のコードを削除
2. 表示確認
3. CSVエクスポート
4. レポート出力
5. Excel・CSV出力

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
金額フィールド全体に影響があります。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->