### PR TITLE
#351 APIでモジュールの詳細を取得した際の項目の並び順がバラバラ

### DIFF
--- a/include/Webservices/VtigerCRMObjectMeta.php
+++ b/include/Webservices/VtigerCRMObjectMeta.php
@@ -404,7 +404,7 @@ class VtigerCRMObjectMeta extends EntityMeta {
 			$sql = "select vtiger_field.*, '0' as readonly from vtiger_field
 				left join vtiger_blocks on vtiger_blocks.blockid = vtiger_field.block
 				where vtiger_field.tabid =? and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6)
-				order by vtiger_block.sequence, vtiger_field.sequence";
+				order by vtiger_blocks.sequence, vtiger_field.sequence";
 			$params = array($tabid, $block);	
 		}else{
 			$profileList = getCurrentUserProfileList();

--- a/include/Webservices/VtigerCRMObjectMeta.php
+++ b/include/Webservices/VtigerCRMObjectMeta.php
@@ -401,8 +401,11 @@ class VtigerCRMObjectMeta extends EntityMeta {
 		$tabid = $this->getTabId();
 		require('user_privileges/user_privileges_'.$this->user->id.'.php');
 		if($is_admin == true || $profileGlobalPermission[1] == 0 || $profileGlobalPermission[2] ==0){
-			$sql = "select *, '0' as readonly from vtiger_field where tabid =? and block in (".generateQuestionMarks($block).") and displaytype in (1,2,3,4,5,6)";
-			$params = array($tabid, $block);
+			$sql = "select vtiger_field.*, '0' as readonly from vtiger_field
+				left join vtiger_blocks on vtiger_blocks.blockid = vtiger_field.block
+				where vtiger_field.tabid =? and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6)
+				order by vtiger_block.sequence, vtiger_field.sequence";
+			$params = array($tabid, $block);	
 		}else{
 			$profileList = getCurrentUserProfileList();
 
@@ -413,9 +416,12 @@ class VtigerCRMObjectMeta extends EntityMeta {
 						ON vtiger_profile2field.fieldid = vtiger_field.fieldid
 						INNER JOIN vtiger_def_org_field
 						ON vtiger_def_org_field.fieldid = vtiger_field.fieldid
-						WHERE vtiger_field.tabid =? AND vtiger_profile2field.visible = 0
+						LEFT JOIN vtiger_blocks ON vtiger_blocks.blockid = vtiger_field.block
+						WHERE vtiger_field.tabid =? AND vtiger_profile2field.visible = 0 
 						AND vtiger_profile2field.profileid IN (". generateQuestionMarks($profileList) .")
-						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2) group by columnname";
+						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2)
+						group by vtiger_field.columnname
+						ORDER BY vtiger_blocks.sequence, vtiger_field.sequence";
 				$params = array($tabid, $profileList, $block);
 			} else {
 				$sql = "SELECT vtiger_field.*, vtiger_profile2field.readonly
@@ -424,9 +430,12 @@ class VtigerCRMObjectMeta extends EntityMeta {
 						ON vtiger_profile2field.fieldid = vtiger_field.fieldid
 						INNER JOIN vtiger_def_org_field
 						ON vtiger_def_org_field.fieldid = vtiger_field.fieldid
-						WHERE vtiger_field.tabid=?
-						AND vtiger_profile2field.visible = 0
-						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2) group by columnname";
+						LEFT JOIN vtiger_blocks ON vtiger_blocks.blockid = vtiger_field.block
+						WHERE vtiger_field.tabid=? 
+						AND vtiger_profile2field.visible = 0 
+						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2)
+						group by columnname
+						ORDER BY vtiger_blocks.sequence, vtiger_field.sequence";
 				$params = array($tabid, $block);
 			}
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #351 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. APIの「describe」 でモジュールの詳細を取得した際に項目の並び順が画面上の並び順と異なる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. フィールド取得時のクエリに order by が指定されていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. include/Webservices/VtigerCRMObjectMeta.php#retrieveMetaForBlock
vtiger_blocksもJOINして、ブロック順、フィールド順でorder byを指定する。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
API全般（モジュールの詳細取得は至る所で使われているため、API全体が影響範囲となる）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->