### PR TITLE
fixed #153 2列分の表示項目がセンター寄せされる不具合の修正

### DIFF
--- a/layouts/v7/modules/Users/DetailViewBlockView.tpl
+++ b/layouts/v7/modules/Users/DetailViewBlockView.tpl
@@ -24,8 +24,15 @@
 					<table class="table detailview-table no-border">
 						<tbody>
 							{assign var=COUNTER value=0}
-							<tr>
+							<tr class="firstTr">
+								{assign var=IS_FIRST value=true}
 								{foreach item=FIELD_MODEL key=FIELD_NAME from=$FIELD_MODEL_LIST}
+									{if $IS_FIRST}
+										{assign var=IS_FIRST value=false}
+											<td></td><td></td><td></td><td></td>
+										</tr>
+										<tr>
+									{/if}
 									{assign var=fieldDataType value=$FIELD_MODEL->getFieldDataType()}
 									{if !$FIELD_MODEL->isViewableInDetailView()}
 										{continue}

--- a/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
@@ -31,8 +31,15 @@
 				<table class="table detailview-table no-border">
 					<tbody {if $IS_HIDDEN} class="hide" {/if}>
 						{assign var=COUNTER value=0}
-						<tr>
+						<tr class="firstTr">
+							{assign var=IS_FIRST value=true}
 							{foreach item=FIELD_MODEL key=FIELD_NAME from=$FIELD_MODEL_LIST}
+								{if $IS_FIRST}
+									{assign var=IS_FIRST value=false}
+										<td></td><td></td><td></td><td></td>
+									</tr>
+									<tr>
+								{/if}
 								{assign var=fieldDataType value=$FIELD_MODEL->getFieldDataType()}
 								{if !$FIELD_MODEL->isViewableInDetailView()}
 									{continue}

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -497,3 +497,7 @@ button#advanceIntiateSave + input {
   margin-top: 10px;
   }
 }
+/* 4カラムを維持する為の行を挿入 */
+.firstTr td{
+  padding: 0 !important;
+}


### PR DESCRIPTION
かならず内部的にはtd4カラム構成になるように、高さ0のtdを追加する

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #153 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. uitype19だけのBlockの場合、横長のテキストエリアが左に寄ってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. uitype19だけの場合、trの中身はtd2つのみの要素になる
2. ただし、上部にuitype1などの要素がある場合は、そのtrがtd4つの要素になるため、左による

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. block内のtableの最初の行に、高さ0のtd4つ分の要素を追加するようにした

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
Block表示全体

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->