### PR TITLE
fixed: #237 見積書、発注書などに単位を表示できるように修正

### DIFF
--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -128,7 +128,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	{
 		$query = '(SELECT vtiger_products.productid, vtiger_products.productname, vtiger_products.product_no AS productcode, vtiger_products.purchase_cost,
 					vtiger_products.unit_price, vtiger_products.qtyinstock, vtiger_crmentity.deleted, "Products" AS entitytype,
-					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description '.$additionalProductFieldsString.' FROM vtiger_products
+					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description, vtiger_products.usageunit '.$additionalProductFieldsString.' FROM vtiger_products
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid=vtiger_products.productid
 					INNER JOIN vtiger_seproductsrel ON vtiger_seproductsrel.productid=vtiger_products.productid
 					INNER JOIN vtiger_productcf ON vtiger_products.productid = vtiger_productcf.productid
@@ -146,7 +146,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	elseif ($module == 'Vendors') {
 		$query = 'SELECT vtiger_products.productid, vtiger_products.productname, vtiger_products.product_no AS productcode, vtiger_products.purchase_cost,
 					vtiger_products.unit_price, vtiger_products.qtyinstock, vtiger_crmentity.deleted, "Products" AS entitytype,
-					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description '.$additionalServiceFieldsString.' FROM vtiger_products
+					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description, vtiger_products.usageunit '.$additionalServiceFieldsString.' FROM vtiger_products
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid=vtiger_products.productid
 					INNER JOIN vtiger_vendor ON vtiger_vendor.vendorid = vtiger_products.vendor_id
 					INNER JOIN vtiger_productcf ON vtiger_products.productid = vtiger_productcf.productid
@@ -167,7 +167,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	{
 		$query = 'SELECT vtiger_products.productid, vtiger_products.productname, vtiger_products.product_no AS productcode, vtiger_products.purchase_cost,
 					vtiger_products.unit_price, vtiger_products.qtyinstock, vtiger_crmentity.deleted, "Products" AS entitytype,
-					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description '.$additionalProductFieldsString.' FROM vtiger_products
+					vtiger_products.is_subproducts_viewable, vtiger_crmentity.description, vtiger_products.usageunit '.$additionalProductFieldsString.' FROM vtiger_products
 					INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid=vtiger_products.productid
 					INNER JOIN vtiger_productcf ON vtiger_products.productid = vtiger_productcf.productid
 					WHERE vtiger_crmentity.deleted=0 AND vtiger_products.productid=?';
@@ -203,6 +203,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$margin = $adb->query_result($result,$i-1,'margin');
 		$sequence_no = $adb->query_result($result,$i-1,'sequence_no');
 		$isSubProductsViewable = $adb->query_result($result, $i-1, 'is_subproducts_viewable');
+		$usageunit=$adb->query_result($result,$i-1,'usageunit');
 
 		if ($sequence_no) {
 			$product_Detail[$i]['sequence_no' . $i] = $sequence_no;
@@ -338,7 +339,8 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$discountTotal = number_format($discountTotal, $no_of_decimal_places,'.','');
 		$product_Detail[$i]['discountTotal'.$i] = $discountTotal;
 		$product_Detail[$i]['totalAfterDiscount'.$i] = $totalAfterDiscount;
-
+		$product_Detail[$i]['usageunit'.$i]=$usageunit;
+		
 		$taxTotal = 0;
 		$taxTotal = number_format($taxTotal, $no_of_decimal_places,'.','');
 		$product_Detail[$i]['taxTotal'.$i] = $taxTotal;

--- a/include/utils/InventoryUtils.php
+++ b/include/utils/InventoryUtils.php
@@ -663,6 +663,7 @@ function saveInventoryProductDetails(&$focus, $module, $update_prod_stock='false
 		$comment = vtlib_purify($_REQUEST['comment'.$i]);
 		$purchaseCost = vtlib_purify($_REQUEST['purchaseCost'.$i]);
 		$margin = vtlib_purify($_REQUEST['margin'.$i]);
+		$usageunit = vtlib_purify($_REQUEST['usageunit'.$i]);
 
 		if($module == 'SalesOrder') {
 			if($updateDemand == '-')
@@ -675,9 +676,9 @@ function saveInventoryProductDetails(&$focus, $module, $update_prod_stock='false
 			}
 		}
 
-		$query = 'INSERT INTO vtiger_inventoryproductrel(id, productid, sequence_no, quantity, listprice, comment, description, purchase_cost, margin)
-					VALUES(?,?,?,?,?,?,?,?,?)';
-		$qparams = array($focus->id,$prod_id,$prod_seq,$qty,$listprice,$comment,$description, $purchaseCost, $margin);
+		$query = 'INSERT INTO vtiger_inventoryproductrel(id, productid, sequence_no, quantity, listprice, comment, description, purchase_cost, margin, usageunit)
+		VALUES(?,?,?,?,?,?,?,?,?,?)';
+		$qparams = array($focus->id,$prod_id,$prod_seq,$qty,$listprice,$comment,$description, $purchaseCost, $margin, $usageunit);
 		$adb->pquery($query,$qparams);
 
 		$lineitem_id = $adb->getLastInsertID();

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1523,7 +1523,9 @@ $languageStrings = array(
 	//ツール>ゴミ箱
 	'Sales Stage' => '販売段階',
 	'Amount' => '数',
-	'Templates' => 'テンプレート'
+	'Templates' => 'テンプレート',
+	//請求
+	'Member Of' => '親企業',
 );
 
 $jsLanguageStrings = array(

--- a/layouts/v7/modules/Inventory/LineItemsDetail.tpl
+++ b/layouts/v7/modules/Inventory/LineItemsDetail.tpl
@@ -175,6 +175,7 @@
                         {if $QUANTITY_VIEWABLE}
                             <td>
                                 {$LINE_ITEM_DETAIL["qty$INDEX"]}
+                                <br><br><span>{vtranslate('Usage Unit', "Products")}：</span>{$LINE_ITEM_DETAIL["usageunit$INDEX"]}
                             </td>
                         {/if}
 

--- a/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
@@ -41,6 +41,8 @@
     {assign var="netPrice" value="netPrice"|cat:$row_no}
     {assign var="FINAL" value=$RELATED_PRODUCTS.1.final_details}
 
+		{assign var="usageunit" value="usageunit"|cat:$row_no}
+
 	{assign var="productDeleted" value="productDeleted"|cat:$row_no}
 	{assign var="productId" value=$data[$hdnProductId]}
 	{assign var="listPriceValues" value=Products_Record_Model::getListPriceValues($productId)}
@@ -143,6 +145,10 @@
 			<input type="hidden" name="{$margin}" value="{if $data.$margin}{$data.$margin}{else}0{/if}"></span>
 			<span class="margin pull-right" style="display:none">{if $data.$margin}{$data.$margin}{else}0{/if}</span>
 		{/if}
+		<br><br>
+		<span>{vtranslate('Usage Unit', "Products")}：</span>
+		<input id="{$usageunit}" name="{$usageunit}" value="{if !empty($data.$usageunit)}{$data.$usageunit}{/if}" type="text" class="usageunit smallInputBox inputElement" readonly style="border:hidden"/>
+
 		{if $MODULE neq 'PurchaseOrder'}
 			<br>
 			<span class="stockAlert redColor {if $data.$qty <= $data.$qtyInStock}hide{/if}" >

--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -344,7 +344,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		return swappedArray;
 	},
     
-    getLineItemNextRowNumber : function() {
+  getLineItemNextRowNumber : function() {
         return ++this.numOfLineItems;
     },
     
@@ -354,11 +354,14 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		return this;
 	},
     
+  formatUsageUnit : function(lineItemRow, usageunit) {
+		lineItemRow.find('.usageunit').val(usageunit);
+		return this;
+	},
     
-    
-    getLineItemRowNumber : function(itemRow) {
-        return parseInt(itemRow.attr('data-row-num'));
-    },
+  getLineItemRowNumber : function(itemRow) {
+    return parseInt(itemRow.attr('data-row-num'));
+  },
     
     /**
 	 * Function which gives quantity value
@@ -744,6 +747,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		jQuery('.lineItemCommentBox', lineItemRow).val('');
 		jQuery('.subProductIds', lineItemRow).val('');
 		jQuery('.subProductsContainer', lineItemRow).html('');
+		jQuery('input.usageunit',lineItemRow).val('');
 		this.quantityChangeActions(lineItemRow);
 	},
     
@@ -775,7 +779,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		var idFields = new Array('productName','subproduct_ids','hdnProductId','purchaseCost','margin',
 									'comment','qty','listPrice','discount_div','discount_type','discount_percentage',
 									'discount_amount','lineItemType','searchIcon','netPrice','subprod_names',
-									'productTotal','discountTotal','totalAfterDiscount','taxTotal');
+									'productTotal','discountTotal','totalAfterDiscount','taxTotal', 'usageunit');
 
 		var classFields = new Array('taxPercentage');
 		//To handle variable tax ids
@@ -1532,6 +1536,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 			var purchaseCost = recordData.purchaseCost;
 			this.setPurchaseCostValue(parentRow, purchaseCost);
 			var imgSrc = recordData.imageSource;
+			var usageunit = recordData.usageunit;
 			this.setImageTag(parentRow, imgSrc);
 			if(referenceModule == 'Products') {
 				parentRow.data('quantity-in-stock',recordData.quantityInStock);
@@ -1543,12 +1548,13 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 			lineItemNameElment.attr('disabled', 'disabled');
 			jQuery('input.listPrice',parentRow).val(unitPrice);
 			var currencyId = this.currencyElement.val();
-            var listPriceValuesJson  = JSON.stringify(listPriceValues);
-            if(typeof listPriceValues[currencyId]!= 'undefined') {
-            	this.formatListPrice(parentRow, listPriceValues[currencyId]);
-                this.lineItemRowCalculations(parentRow);
-        	}
-            jQuery('input.listPrice',parentRow).attr('list-info',listPriceValuesJson);
+			var listPriceValuesJson  = JSON.stringify(listPriceValues);
+			if(typeof listPriceValues[currencyId]!= 'undefined') {
+				this.formatListPrice(parentRow, listPriceValues[currencyId]);
+				this.lineItemRowCalculations(parentRow);
+			}
+			this.formatUsageUnit(parentRow, usageunit);
+			jQuery('input.listPrice',parentRow).attr('list-info',listPriceValuesJson);
 			jQuery('input.listPrice',parentRow).data('baseCurrencyId', recordData.baseCurrencyId);
 			jQuery('textarea.lineItemCommentBox',parentRow).val(description);
 			var taxUI = this.getTaxDiv(taxes,parentRow);

--- a/layouts/v7/modules/Vtiger/PopupContents.tpl
+++ b/layouts/v7/modules/Vtiger/PopupContents.tpl
@@ -111,7 +111,7 @@
                                 <span {if !empty($LISTVIEW_ENTRY_VALUE)} class="picklist-color picklist-{$LISTVIEW_HEADER->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen(trim($MULTI_PICKLIST_VALUE))}" {/if}> {trim($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX])} </span>
                             {/foreach}
                         {else}
-                            {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
+                            {vtranslate($LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME), $MODULE)}
                         {/if}
                     </td>
                     {/foreach}

--- a/modules/Inventory/actions/GetTaxes.php
+++ b/modules/Inventory/actions/GetTaxes.php
@@ -76,6 +76,7 @@ class Inventory_GetTaxes_Action extends Vtiger_Action_Controller {
 		}
 
 		foreach($idList as $id) {
+			$recordModel = Vtiger_Record_Model::getInstanceById($id);
 			$resultData = array(
 								'id'					=> $id,
 								'name'					=> $namesList[$id],
@@ -86,7 +87,8 @@ class Inventory_GetTaxes_Action extends Vtiger_Action_Controller {
 								'description'			=> $descriptionsList[$id],
 								'baseCurrencyId'		=> $baseCurrencyIdsList[$id],
 								'quantityInStock'		=> $quantitiesList[$id],
-								'imageSource'			=> $imageSourcesList[$id]
+								'imageSource'			=> $imageSourcesList[$id],
+								'usageunit'				=> vtranslate($recordModel->get('usageunit'), $recordModel->getModuleName()),
 					);
 
 			$info[] = array($id => $resultData);

--- a/modules/Inventory/actions/GetTaxes.php
+++ b/modules/Inventory/actions/GetTaxes.php
@@ -88,8 +88,12 @@ class Inventory_GetTaxes_Action extends Vtiger_Action_Controller {
 								'baseCurrencyId'		=> $baseCurrencyIdsList[$id],
 								'quantityInStock'		=> $quantitiesList[$id],
 								'imageSource'			=> $imageSourcesList[$id],
-								'usageunit'				=> vtranslate($recordModel->get('usageunit'), $recordModel->getModuleName()),
 					);
+			if($recordModel->getModuleName() == 'Products'){
+				$resultData['usageunit'] = vtranslate($recordModel->get('usageunit'), $recordModel->getModuleName());
+			}else if($recordModel->getModuleName() == 'Services'){
+				$resultData['usageunit'] = vtranslate($recordModel->get('service_usageunit'), $recordModel->getModuleName());
+			}
 
 			$info[] = array($id => $resultData);
 		}

--- a/modules/Migration/models/Module.php
+++ b/modules/Migration/models/Module.php
@@ -43,13 +43,14 @@ class Migration_Module_Model extends Vtiger_Module_Model {
 			array('700' => '7.0.0'),
 			array('701' => '7.0.1'),
 			array('710' => '7.1.0'),
-                        array('711' => '7.1.1'),
-                        array('720' => '7.2.0'),
-						array('730' => '7.3.0'),
-						array('731' => '7.3.1'),
-						array('732' => '7.3.2'),
-						array('733' => '7.3.3'),
-						array('734' => '7.3.4'),
+			array('711' => '7.1.1'),
+			array('720' => '7.2.0'),
+			array('730' => '7.3.0'),
+			array('731' => '7.3.1'),
+			array('732' => '7.3.2'),
+			array('733' => '7.3.3'),
+			array('734' => '7.3.4'),
+			array('735' => '7.3.5'),
 		);
 		return $versions;
 	}

--- a/modules/Migration/schema/734_to_735.php
+++ b/modules/Migration/schema/734_to_735.php
@@ -1,0 +1,41 @@
+<?php
+/*+********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+	global $current_user, $adb;
+	$db = PearDatabase::getInstance();
+
+    // 使用単位項目を追加
+    $modulearray = array("Quotes","PurchaseOrder","SalesOrder","Invoice");
+    $itemFieldsName = array('usageunit');
+    $itemFieldsLabel = array('使用単位');
+    $itemFieldsTypeOfData = array('V~O~LE~200');
+    $itemFieldsDisplayType = array('1');
+    $itemFieldsColumnType = array('varchar(200)');
+    foreach ($modulearray as $key => $modulename) {
+        $moduleInstance = Vtiger_Module::getInstance($modulename);
+        $blockInstance = Vtiger_Block::getInstance('LBL_ITEM_DETAILS', $moduleInstance);
+        for ($j=0;$j<count($itemFieldsName);$j++) {
+            //追加
+            $field = new Vtiger_Field();
+            $field->name = $itemFieldsName[$j];
+            $field->label = $itemFieldsLabel[$j];
+            $field->column = $itemFieldsName[$j];
+            $field->table = 'vtiger_inventoryproductrel';
+            $field->uitype = $itemFieldsDisplayType[$j];
+            $field->typeofdata = $itemFieldsTypeOfData[$j];
+            $field->readonly = '0';
+            $field->displaytype = '5';
+            $field->masseditable = '0';
+            $field->columntype = '';
+            $blockInstance->addField($field);
+        }
+    }
+}

--- a/modules/Vtiger/actions/GetData.php
+++ b/modules/Vtiger/actions/GetData.php
@@ -23,6 +23,7 @@ class Vtiger_GetData_Action extends Vtiger_IndexAjax_View {
 
 		$recordModel = Vtiger_Record_Model::getInstanceById($record, $sourceModule);
 		$data = $recordModel->getData();
+
 		$response->setResult(array('success'=>true, 'data'=>array_map('decode_html',$data)));
 		
 		$response->emit();

--- a/vtigerversion.php
+++ b/vtigerversion.php
@@ -10,7 +10,7 @@
 
 $patch_version = '20210907'; // -ve timestamp before release, +ve timestamp after release.
 $modified_database = '';
-$vtiger_current_version = '7.3.4';
+$vtiger_current_version = '7.3.5';
 $_SESSION['vtiger_version'] = $vtiger_current_version;
 
 ?>


### PR DESCRIPTION
PDFテンプレートで $invoice-usageunit$ を利用する必要がある

## WIP
作業中です、サービスを紐付けた時に正常に単位が出ない不具合が残っています。
その他、サービスに関係する処理がテストできていません。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #237 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFテンプレートで製品の単位を利用できるようにする

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 製品の単位を見えるように修正

## 影響範囲  / Affected Area
Inventory関係のモジュール全体に影響

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
サービスを請求などに紐付けたときの処理がまだ完成していないため、WIPとする。