### PR TITLE
項目の並び順変更時の挙動を変えたい箇所の修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -300,7 +300,6 @@
 					</span>
 				</li>
 			</ul>
-			<ul class="connectedSortable col-sm-6 ui-sortable" name="sortable2"></ul>
 		</div>
 	</div>
 

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -405,12 +405,14 @@
 								{/foreach}
                 {if $BLOCK_MODEL->isAddCustomFieldEnabled()}
                   <li class="row dummyRow">
-                    <span class="dragUiText col-sm-8">
-                      {vtranslate('LBL_ADD_NEW_FIELD_HERE',$QUALIFIED_MODULE)}
-                    </span>
-                    <span class="col-sm-4" style="margin-top: 7%;margin-left: -15%;">
-                      <button class="btn btn-default btn-sm addButton"><i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD',$QUALIFIED_MODULE)}</button>
-                    </span>
+                    <div class="row border1px" style="border: 1px dotted #DDDDDD;">
+                      <span class="dragUiText col-sm-8">
+                        {vtranslate('LBL_ADD_NEW_FIELD_HERE',$QUALIFIED_MODULE)}
+                      </span>
+                      <span class="col-sm-4" style="margin-top: 7%;margin-left: -15%;">
+                        <button class="btn btn-default btn-sm addButton"><i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD',$QUALIFIED_MODULE)}</button>
+                      </span>
+                    </div>
                   </li>
                 {/if}
 							</ul>

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -246,24 +246,7 @@
 											</div>
 										</li>
 									{/if}
-								{/foreach}
-								{if count($FIELDS_LIST)%2 eq 0 }
-									{if $BLOCK_MODEL->isAddCustomFieldEnabled()}
-										<li class="row dummyRow">
-											<span class="dragUiText col-sm-8">
-												{vtranslate('LBL_ADD_NEW_FIELD_HERE',$QUALIFIED_MODULE)}
-											</span>
-											<span class="col-sm-4" style="margin-top: 7%;margin-left: -15%;">
-												<button class="btn btn-default btn-sm addButton"><i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD',$QUALIFIED_MODULE)}</button>
-											</span>
-										</li>
-									{/if}
-								{/if}
-							</ul>
-							<ul name="{if $IS_FIELDS_SORTABLE}sortable2{else}unSortable2{/if}" class="connectedSortable col-sm-6">
-								{foreach item=FIELD_MODEL from=$FIELDS_LIST name=fieldlist1}
-									{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
-									{if $smarty.foreach.fieldlist1.index % 2 neq 0}
+                  {if $smarty.foreach.fieldlist.index % 2 neq 0}
 										<li>
 											<div class="row border1px">
 												<div class="col-sm-4">
@@ -420,18 +403,16 @@
 										</li>
 									{/if}
 								{/foreach}
-								{if count($FIELDS_LIST)%2 neq 0 }
-									{if $BLOCK_MODEL->isAddCustomFieldEnabled()}
-										<li class="row dummyRow">
-											<span class="dragUiText col-sm-8">
-												{vtranslate('LBL_ADD_NEW_FIELD_HERE',$QUALIFIED_MODULE)}
-											</span>
-											<span class="col-sm-4" style="margin-top: 7%;margin-left: -15%;">
-												<button class="btn btn-default btn-sm addButton"><i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD',$QUALIFIED_MODULE)}</button>
-											</span>
-										</li>
-									{/if}
-								{/if}
+                {if $BLOCK_MODEL->isAddCustomFieldEnabled()}
+                  <li class="row dummyRow">
+                    <span class="dragUiText col-sm-8">
+                      {vtranslate('LBL_ADD_NEW_FIELD_HERE',$QUALIFIED_MODULE)}
+                    </span>
+                    <span class="col-sm-4" style="margin-top: 7%;margin-left: -15%;">
+                      <button class="btn btn-default btn-sm addButton"><i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD',$QUALIFIED_MODULE)}</button>
+                    </span>
+                  </li>
+                {/if}
 							</ul>
 						</div>
 					</div>

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -75,333 +75,174 @@
 							</div>
 						</div>
 						{assign var=IS_FIELDS_SORTABLE value=$SELECTED_MODULE_MODEL->isFieldsSortableAllowed($BLOCK_LABEL_KEY)}
+            {assign var=M_FIELD_TITLE value={vtranslate('LBL_MAKE_THIS_FIELD', $QUALIFIED_MODULE, vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE))}}
+            {assign var=Q_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE))}}
+            {assign var=M_E_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE))}}
+            {assign var=S_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE))}}
+            {assign var=H_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_DETAIL_HEADER',$QUALIFIED_MODULE))}}
+            {assign var=NOT_M_FIELD_TITLE value={vtranslate('LBL_NOT_MAKE_THIS_FIELD', $QUALIFIED_MODULE, vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE))}}
+            {assign var=NOT_Q_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE))}}
+            {assign var=NOT_M_E_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE))}}
+            {assign var=NOT_S_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE))}}
+            {assign var=NOT_H_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_DETAIL_HEADER',$QUALIFIED_MODULE))}}
 						<div class="blockFieldsList {if $IS_FIELDS_SORTABLE} blockFieldsSortable {/if} row">
 							<ul name="{if $IS_FIELDS_SORTABLE}sortable1{else}unSortable1{/if}" class="connectedSortable col-sm-6">
 								{foreach item=FIELD_MODEL from=$FIELDS_LIST name=fieldlist}
 									{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
-									{if $smarty.foreach.fieldlist.index % 2 eq 0}
-										<li>
-											<div class="row border1px">
-												<div class="col-sm-4">
-													<div class="opacity editFields marginLeftZero" data-block-id="{$BLOCK_ID}" data-field-id="{$FIELD_MODEL->get('id')}" 
-														 data-sequence="{$FIELD_MODEL->get('sequence')}" data-field-name="{$FIELD_MODEL->get('name')}" 
-														 >
-														<div class="row">
-															{assign var=IS_MANDATORY value=$FIELD_MODEL->isMandatory()}
-															<span class="col-sm-1">&nbsp;
-																{if $IS_FIELDS_SORTABLE}
-																	<img src="{vimage_path('drag.png')}" class="cursorPointerMove" border="0" title="{vtranslate('LBL_DRAG',$QUALIFIED_MODULE)}"/>
-																{/if}
-															</span>
-															<div class="col-sm-9" style="word-wrap: break-word;">
-																<div class="fieldLabelContainer row">
-																	<span class="fieldLabel">
-																		<b>{vtranslate($FIELD_MODEL->get('label'), $SELECTED_MODULE_NAME)}</b>
-																		&nbsp;{if $IS_MANDATORY}<span class="redColor">*</span>{/if}
-																	</span><br>
-																	<span class="pull-right" style="opacity:0.6;">
-																		{vtranslate($FIELD_MODEL->getFieldDataTypeLabel(),$QUALIFIED_MODULE)}
-																	</span>
-																</div>
-															</div>
-														</div>
-													</div>
-												</div>
-												<div class="col-sm-8 fieldPropertyContainer">
-													<div class="row " style="padding: 10px 0px;">
-														{assign var=M_FIELD_TITLE value={vtranslate('LBL_MAKE_THIS_FIELD', $QUALIFIED_MODULE, vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE))}}
-														{assign var=Q_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE))}}
-														{assign var=M_E_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE))}}
-														{assign var=S_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE))}}
-														{assign var=H_FIELD_TITLE value={vtranslate('LBL_SHOW_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_DETAIL_HEADER',$QUALIFIED_MODULE))}}
-														{assign var=NOT_M_FIELD_TITLE value={vtranslate('LBL_NOT_MAKE_THIS_FIELD', $QUALIFIED_MODULE, vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE))}}
-														{assign var=NOT_Q_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE))}}
-														{assign var=NOT_M_E_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE))}}
-														{assign var=NOT_S_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE))}}
-														{assign var=NOT_H_FIELD_TITLE value={vtranslate('LBL_HIDE_THIS_FIELD_IN', $QUALIFIED_MODULE, vtranslate('LBL_DETAIL_HEADER',$QUALIFIED_MODULE))}}
-														{assign var=IS_MANDATORY value=$FIELD_MODEL->isMandatory()}
-														<div class="fieldProperties col-sm-10" data-field-id="{$FIELD_MODEL->get('id')}">
-															<span class="mandatory switch text-capitalize {if (!$IS_MANDATORY)}disabled{/if} {if $FIELD_MODEL->isMandatoryOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_MANDATORY} title="{$NOT_M_FIELD_TITLE}" {else} title="{$M_FIELD_TITLE}" {/if}>
-																<i class="fa fa-exclamation-circle" data-name="mandatory" 
-																	data-enable-value="M" data-disable-value="O"
-																	{if $FIELD_MODEL->isMandatoryOptionDisabled()}readonly="readonly"{/if}
-																	></i>&nbsp;{vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE)}
-															</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-															{assign var=IS_QUICK_EDIT_ENABLED value=$FIELD_MODEL->isQuickCreateEnabled()}
-															<span class="quickCreate switch {if (!$IS_QUICK_EDIT_ENABLED)}disabled{/if} 
-																	{if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY } cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_QUICK_EDIT_ENABLED} title="{$NOT_Q_FIELD_TITLE}" {else} title="{$Q_FIELD_TITLE}" {/if}>
-																<i class="fa fa-plus" data-name="quickcreate" 
-																	data-enable-value="2" data-disable-value="1"
-																	{if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY }readonly="readonly"{/if}
-																	title="{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}
-															</span><br><br>
-															{assign var=IS_MASS_EDIT_ENABLED value=$FIELD_MODEL->isMassEditable()}
-															<span class="massEdit switch {if (!$IS_MASS_EDIT_ENABLED)} disabled {/if} 
-																	{if $FIELD_MODEL->isMassEditOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_MASS_EDIT_ENABLED} title="{$NOT_M_E_FIELD_TITLE}" {else} title="{$M_E_FIELD_TITLE}" {/if}>
-																<img src="{vimage_path('MassEdit.png')}" data-name="masseditable" 
-																	 data-enable-value="1" data-disable-value="2" title="{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}" 
-																	 {if $FIELD_MODEL->isMassEditOptionDisabled()}readonly="readonly"{/if} height=14 width=14 
-																	 />&nbsp;{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}
-															</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-															{assign var=IS_HEADER_FIELD value=$FIELD_MODEL->isHeaderField()}
-															<span class="header switch {if (!$IS_HEADER_FIELD)} disabled {/if} 
-																	{if $FIELD_MODEL->isHeaderFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_HEADER_FIELD} title="{$NOT_H_FIELD_TITLE}" {else} title="{$H_FIELD_TITLE}" {/if}>
-																<i class="fa fa-flag-o" data-name="headerfield" 
-																	data-enable-value="1" data-disable-value="0"
-																	{if $FIELD_MODEL->isHeaderFieldOptionDisabled()}readonly="readonly"{/if}
-																	title="{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}
-															</span><br><br>
-															{assign var=IS_SUMMARY_VIEW_ENABLED value=$FIELD_MODEL->isSummaryField()}
-															<span class="summary switch {if (!$IS_SUMMARY_VIEW_ENABLED)} disabled {/if} 
-																	{if $FIELD_MODEL->isSummaryFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_SUMMARY_VIEW_ENABLED} title="{$NOT_S_FIELD_TITLE}" {else} title="{$S_FIELD_TITLE}" {/if}>
-																<i class="fa fa-key" data-name="summaryfield" 
-																	data-enable-value="1" data-disable-value="0"
-																	{if $FIELD_MODEL->isSummaryFieldOptionDisabled()}readonly="readonly"{/if}
-																	title="{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}
-															</span><br><br>
-															<div class="defaultValue col-sm-12 {if !$FIELD_MODEL->hasDefaultValue()}disabled{/if} 
-																 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} cursorPointerNotAllowed {/if}">
-																{assign var=DEFAULT_VALUE value=$FIELD_MODEL->getDefaultFieldValueToViewInV7FieldsLayOut()}
-																{if $DEFAULT_VALUE}
-																	{if is_array($DEFAULT_VALUE)}
-																		{foreach key=DEFAULT_FIELD_NAME item=DEFAULT_FIELD_VALUE from=$DEFAULT_VALUE}
-																			<div class="row">
-																				<span><img src="{vimage_path('DefaultValue.png')}"
-																							{if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																							{if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
-																							data-name="defaultValueField" height=14 width=14 /></span>&nbsp;
-																					{if $DEFAULT_FIELD_VALUE}
-																						{assign var=DEFAULT_FIELD_NAME value=$DEFAULT_FIELD_NAME|upper}
-																					<span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)}
-																						{vtranslate("LBL_$DEFAULT_FIELD_NAME",$QUALIFIED_MODULE)} : </span>
-																					<span data-defaultvalue-fieldname="{$DEFAULT_FIELD_NAME}" data-defaultvalue="{$DEFAULT_FIELD_VALUE}">{$DEFAULT_FIELD_VALUE}</span>
-																				{else}
-																					{vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}
-																				{/if}
-																			</div>
-																		{/foreach}
-																	{else}
-																		<div class="row">
-																			<span>
-																				<img src="{vimage_path('DefaultValue.png')}"
-																					 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																					 {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE|strip_tags}" {/if}
-																					 data-name="defaultValueField" height=14 width=14 />
-																			</span>&nbsp;
-																			<span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)} : </span>
-																			<span data-defaultvalue="{$DEFAULT_VALUE|strip_tags}">{$DEFAULT_VALUE|strip_tags}</span>
-																		</div>
-																	{/if}
-																{else}
-																	<div class="row">
-																		<span>
-																			<img src="{vimage_path('DefaultValue.png')}"
-																				 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																				 {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
-																				 data-name="defaultValueField" height=14 width=14 />
-																		</span>&nbsp;
-																		<span>{vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}</span>
-																	</div>
-																{/if}
-															</div>
-														</div>
-														<span class="col-sm-2 actions">
-															{if $FIELD_MODEL->isEditable()}
-																<a href="javascript:void(0)" class="editFieldDetails">
-																	<i class="fa fa-pencil" title="{vtranslate('LBL_EDIT', $QUALIFIED_MODULE)}"></i>
-																</a>
-															{/if}
-															{if $FIELD_MODEL->isCustomField() eq 'true'}
-																<a href="javascript:void(0)" class="deleteCustomField pull-right" data-field-id="{$FIELD_MODEL->get('id')}"
-																	data-one-one-relationship="{$FIELD_MODEL->isOneToOneRelationField()}" data-relationship-field="{$FIELD_MODEL->isRelationShipReponsibleField()}"
-																	{if $FIELD_MODEL->isOneToOneRelationField()}
-																		{assign var=ONE_ONE_RELATION_FIELD_LABEL value=$FIELD_MODEL->getOneToOneRelationField()->get('label')}
-																		{assign var=ONE_ONE_RELATION_MODULE_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getModuleName()}
-																		{assign var=ONE_ONE_RELATION_FIELD_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getName()}
-																		data-relation-field-label="{$ONE_ONE_RELATION_FIELD_LABEL}" 
-																		data-relation-module-label="{vtranslate($ONE_ONE_RELATION_MODULE_NAME,$ONE_ONE_RELATION_MODULE_NAME)}"
-																		data-current-field-label ="{vtranslate($FIELD_MODEL->get('label'),$SELECTED_MODULE_NAME)}"
-																		data-current-module-label="{vtranslate($SELECTED_MODULE_NAME,$SELECTED_MODULE_NAME)}"
-																		data-field-name="{$ONE_ONE_RELATION_FIELD_NAME}"
-																	{/if}
-																	{if $FIELD_MODEL->isRelationShipReponsibleField()}
-																		{assign var=RELATION_MODEL value=$FIELD_MODEL->getRelationShipForThisField()}
+                  <li>
+                    <div class="row border1px">
+                      <div class="col-sm-4">
+                        <div class="opacity editFields marginLeftZero" data-block-id="{$BLOCK_ID}" data-field-id="{$FIELD_MODEL->get('id')}" 
+                            data-sequence="{$FIELD_MODEL->get('sequence')}" data-field-name="{$FIELD_MODEL->get('name')}" 
+                            >
+                          <div class="row">
+                            {assign var=IS_MANDATORY value=$FIELD_MODEL->isMandatory()}
+                            <span class="col-sm-1">&nbsp;
+                              {if $FIELD_MODEL->isEditable() && $IS_FIELDS_SORTABLE}
+                                <img src="{vimage_path('drag.png')}" class="cursorPointerMove" border="0" title="{vtranslate('LBL_DRAG',$QUALIFIED_MODULE)}"/>
+                              {/if}
+                            </span>
+                            <div class="col-sm-9" style="word-wrap: break-word;">
+                              <div class="fieldLabelContainer row">
+                                <span class="fieldLabel">
+                                  <b>{vtranslate($FIELD_MODEL->get('label'), $SELECTED_MODULE_NAME)}</b>
+                                  {if $IS_MANDATORY}&nbsp;<span class="redColor">*</span>{/if}
+                                </span><br>
+                                <span class="pull-right" style="opacity:0.6;">
+                                  {vtranslate($FIELD_MODEL->getFieldDataTypeLabel(),$QUALIFIED_MODULE)}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="col-sm-8 fieldPropertyContainer">
+                        <div class="row " style="padding: 10px 0px;">
+                          <div class="fieldProperties col-sm-10" data-field-id="{$FIELD_MODEL->get('id')}">
+                            <span class="mandatory switch text-capitalize {if (!$IS_MANDATORY)}disabled{/if} {if $FIELD_MODEL->isMandatoryOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $IS_MANDATORY} title="{$NOT_M_FIELD_TITLE}" {else} title="{$M_FIELD_TITLE}" {/if}>
+                              <i class="fa fa-exclamation-circle" data-name="mandatory" 
+                                data-enable-value="M" data-disable-value="O"
+                                {if $FIELD_MODEL->isMandatoryOptionDisabled()}readonly="readonly"{/if}
+                                ></i>&nbsp;{vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE)}
+                            </span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                            {assign var=IS_QUICK_EDIT_ENABLED value=$FIELD_MODEL->isQuickCreateEnabled()}
+                            <span class="quickCreate switch {if (!$IS_QUICK_EDIT_ENABLED)}disabled{/if} 
+                                {if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY } cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $IS_QUICK_EDIT_ENABLED} title="{$NOT_Q_FIELD_TITLE}" {else} title="{$Q_FIELD_TITLE}" {/if}>
+                              <i class="fa fa-plus" data-name="quickcreate" 
+                                data-enable-value="2" data-disable-value="1"
+                                {if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY }readonly="readonly"{/if}
+                                title="{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}
+                            </span><br><br>
+                            {assign var=IS_MASS_EDIT_ENABLED value=$FIELD_MODEL->isMassEditable()}
+                            <span class="massEdit switch {if (!$IS_MASS_EDIT_ENABLED)} disabled {/if} 
+                                {if $FIELD_MODEL->isMassEditOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $IS_MASS_EDIT_ENABLED} title="{$NOT_M_E_FIELD_TITLE}" {else} title="{$M_E_FIELD_TITLE}" {/if}>
+                              <img src="{vimage_path('MassEdit.png')}" data-name="masseditable" 
+                                  data-enable-value="1" data-disable-value="2" title="{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}" 
+                                  {if $FIELD_MODEL->isMassEditOptionDisabled()}readonly="readonly"{/if} height=14 width=14 
+                                  />&nbsp;{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}
+                            </span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                            {assign var=IS_HEADER_FIELD value=$FIELD_MODEL->isHeaderField()}
+                            <span class="header switch {if (!$IS_HEADER_FIELD)} disabled {/if} 
+                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $IS_HEADER_FIELD} title="{$NOT_H_FIELD_TITLE}" {else} title="{$H_FIELD_TITLE}" {/if}>
+                              <i class="fa fa-flag-o" data-name="headerfield" 
+                                data-enable-value="1" data-disable-value="0"
+                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled()}readonly="readonly"{/if}
+                                title="{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}
+                            </span><br><br>
+                            {assign var=IS_SUMMARY_VIEW_ENABLED value=$FIELD_MODEL->isSummaryField()}
+                            <span class="summary switch {if (!$IS_SUMMARY_VIEW_ENABLED)} disabled {/if} 
+                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $IS_SUMMARY_VIEW_ENABLED} title="{$NOT_S_FIELD_TITLE}" {else} title="{$S_FIELD_TITLE}" {/if}>
+                              <i class="fa fa-key" data-name="summaryfield" 
+                                data-enable-value="1" data-disable-value="0"
+                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled()}readonly="readonly"{/if}
+                                title="{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}
+                            </span><br><br>
+                            <div class="defaultValue col-sm-12 {if !$FIELD_MODEL->hasDefaultValue()}disabled{/if} 
+                                {if $FIELD_MODEL->isDefaultValueOptionDisabled()} cursorPointerNotAllowed {/if}">
+                              {assign var=DEFAULT_VALUE value=$FIELD_MODEL->getDefaultFieldValueToViewInV7FieldsLayOut()}
+                              {if $DEFAULT_VALUE}
+                                {if is_array($DEFAULT_VALUE)}
+                                  {foreach key=DEFAULT_FIELD_NAME item=DEFAULT_FIELD_VALUE from=$DEFAULT_VALUE}
+                                    <div class="row defaultValueContent">
+                                      <span><img src="{vimage_path('DefaultValue.png')}"
+                                            {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
+                                            {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
+                                            data-name="defaultValueField" height=14 width=14 /></span>&nbsp;
+                                        {if $DEFAULT_FIELD_VALUE}
+                                          {assign var=DEFAULT_FIELD_NAME value=$DEFAULT_FIELD_NAME|upper}
+                                        <span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)}
+                                          {vtranslate("LBL_$DEFAULT_FIELD_NAME",$QUALIFIED_MODULE)} : </span>
+                                        <span data-defaultvalue-fieldname="{$DEFAULT_FIELD_NAME}" data-defaultvalue="{$DEFAULT_FIELD_VALUE}">{$DEFAULT_FIELD_VALUE}</span>
+                                      {else}
+                                        {vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}
+                                      {/if}
+                                    </div>
+                                  {/foreach}
+                                {else}
+                                  <div class="row defaultValueContent">
+                                    <span>
+                                      <img src="{vimage_path('DefaultValue.png')}"
+                                          {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
+                                          {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE|strip_tags}" {/if}
+                                          data-name="defaultValueField" height=14 width=14 />
+                                    </span>&nbsp;
+                                    <span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)} : </span>
+                                    <span data-defaultvalue="{$DEFAULT_VALUE|strip_tags}">{$DEFAULT_VALUE|strip_tags}</span>
+                                  </div>
+                                {/if}
+                              {else}
+                                <div class="row defaultValueContent">
+                                  <span>
+                                    <img src="{vimage_path('DefaultValue.png')}"
+                                        {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
+                                        {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
+                                        data-name="defaultValueField" height=14 width=14 />
+                                  </span>&nbsp;
+                                  <span>{vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}</span>
+                                </div>
+                              {/if}
+                            </div>
+                          </div>
+                          <span class="col-sm-2 actions">
+                            {if $FIELD_MODEL->isEditable()}
+                              <a href="javascript:void(0)" class="editFieldDetails">
+                                <i class="fa fa-pencil" title="{vtranslate('LBL_EDIT', $QUALIFIED_MODULE)}"></i>
+                              </a>
+                            {/if}
+                            {if $FIELD_MODEL->isCustomField() eq 'true'}
+                              <a href="javascript:void(0)" class="deleteCustomField pull-right" data-field-id="{$FIELD_MODEL->get('id')}"
+                                data-one-one-relationship="{$FIELD_MODEL->isOneToOneRelationField()}" data-relationship-field="{$FIELD_MODEL->isRelationShipReponsibleField()}"
+                                {if $FIELD_MODEL->isOneToOneRelationField()}
+                                  {assign var=ONE_ONE_RELATION_FIELD_LABEL value=$FIELD_MODEL->getOneToOneRelationField()->get('label')}
+                                  {assign var=ONE_ONE_RELATION_MODULE_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getModuleName()}
+                                  {assign var=ONE_ONE_RELATION_FIELD_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getName()}
+                                  data-relation-field-label="{$ONE_ONE_RELATION_FIELD_LABEL}" 
+                                  data-relation-module-label="{vtranslate($ONE_ONE_RELATION_MODULE_NAME,$ONE_ONE_RELATION_MODULE_NAME)}"
+                                  data-current-field-label ="{vtranslate($FIELD_MODEL->get('label'),$SELECTED_MODULE_NAME)}"
+                                  data-current-module-label="{vtranslate($SELECTED_MODULE_NAME,$SELECTED_MODULE_NAME)}"
+                                  data-field-name="{$ONE_ONE_RELATION_FIELD_NAME}"
+                                {/if}
+                                {if $FIELD_MODEL->isRelationShipReponsibleField()}
+                                  {assign var=RELATION_MODEL value=$FIELD_MODEL->getRelationShipForThisField()}
 
-																		data-relation-field-label="{vtranslate($FIELD_MODEL->get('label'),$RELATION_MODEL->getRelationModuleName())}" 
-																		data-relation-module-label="{vtranslate($RELATION_MODEL->getRelationModuleName(),$RELATION_MODEL->getRelationModuleName())}"
-																		data-current-module-label="{vtranslate($RELATION_MODEL->getParentModuleName(),$RELATION_MODEL->getParentModuleName())}"
-																		data-current-tab-label="{vtranslate($RELATION_MODEL->get('label'), $RELATION_MODEL->getRelationModuleName())}"
-																	{/if} >
-																	<i class="fa fa-trash" title="{vtranslate('LBL_DELETE', $QUALIFIED_MODULE)}"></i>
-																</a>
-															{/if}
-														</span>
-													</div>
-												</div>
-											</div>
-										</li>
-									{/if}
-                  {if $smarty.foreach.fieldlist.index % 2 neq 0}
-										<li>
-											<div class="row border1px">
-												<div class="col-sm-4">
-													<div class="opacity editFields marginLeftZero" data-block-id="{$BLOCK_ID}" data-field-id="{$FIELD_MODEL->get('id')}" 
-														 data-sequence="{$FIELD_MODEL->get('sequence')}" data-field-name="{$FIELD_MODEL->get('name')}"
-														 >
-														<div class="row" >
-															{assign var=IS_MANDATORY value=$FIELD_MODEL->isMandatory()}
-															<span class="col-sm-1">&nbsp;
-																{if $FIELD_MODEL->isEditable() && $IS_FIELDS_SORTABLE}
-																	<img src="{vimage_path('drag.png')}" class="cursorPointerMove" border="0" title="{vtranslate('LBL_DRAG',$QUALIFIED_MODULE)}"/>
-																{/if}
-															</span>
-															<div class="col-sm-9" style="word-wrap: break-word;">
-																<div class="fieldLabelContainer row">
-																	<span class="fieldLabel">
-																		<b>{vtranslate($FIELD_MODEL->get('label'), $SELECTED_MODULE_NAME)}</b>
-																		{if $IS_MANDATORY}&nbsp;<span class="redColor">*</span>{/if}
-																	</span><br>
-																	<span class="pull-right" style="opacity:0.6;">
-																		{vtranslate($FIELD_MODEL->getFieldDataTypeLabel(),$QUALIFIED_MODULE)}
-																	</span>
-																</div>
-															</div>
-														</div>
-													</div>
-												</div>
-												<div class="col-sm-8 fieldPropertyContainer">
-													<div class="row " style="padding: 10px 0px;">
-														{assign var=IS_MANDATORY value=$FIELD_MODEL->isMandatory()}
-														<div class="fieldProperties col-sm-10" data-field-id="{$FIELD_MODEL->get('id')}">
-															<span class="mandatory switch text-capitalize {if (!$IS_MANDATORY)}disabled{/if} {if $FIELD_MODEL->isMandatoryOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_MANDATORY} title="{$NOT_M_FIELD_TITLE}" {else} title="{$M_FIELD_TITLE}" {/if}>
-																<i class="fa fa-exclamation-circle" data-name="mandatory" 
-																	data-enable-value="M" data-disable-value="O"
-																	{if $FIELD_MODEL->isMandatoryOptionDisabled()}readonly="readonly"{/if}
-																	></i>&nbsp;{vtranslate('LBL_PROP_MANDATORY',$QUALIFIED_MODULE)}
-															</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-															{assign var=IS_QUICK_EDIT_ENABLED value=$FIELD_MODEL->isQuickCreateEnabled()}
-															<span class="quickCreate switch {if (!$IS_QUICK_EDIT_ENABLED)}disabled{/if} 
-																	{if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY } cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_QUICK_EDIT_ENABLED} title="{$NOT_Q_FIELD_TITLE}" {else} title="{$Q_FIELD_TITLE}" {/if}>
-																<i class="fa fa-plus" data-name="quickcreate" 
-																	data-enable-value="2" data-disable-value="1"
-																	{if $FIELD_MODEL->isQuickCreateOptionDisabled() || $IS_MANDATORY }readonly="readonly"{/if}
-																	title="{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_QUICK_CREATE',$QUALIFIED_MODULE)}
-															</span><br><br>
-															{assign var=IS_MASS_EDIT_ENABLED value=$FIELD_MODEL->isMassEditable()}
-															<span class="massEdit switch {if (!$IS_MASS_EDIT_ENABLED)} disabled {/if} 
-																	{if $FIELD_MODEL->isMassEditOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_MASS_EDIT_ENABLED} title="{$NOT_M_E_FIELD_TITLE}" {else} title="{$M_E_FIELD_TITLE}" {/if}>
-																<img src="{vimage_path('MassEdit.png')}" data-name="masseditable" 
-																	 data-enable-value="1" data-disable-value="2" title="{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}" 
-																	 {if $FIELD_MODEL->isMassEditOptionDisabled()}readonly="readonly"{/if} height=14 width=14 
-																	 />&nbsp;{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}
-															</span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-															{assign var=IS_HEADER_FIELD value=$FIELD_MODEL->isHeaderField()}
-															<span class="header switch {if (!$IS_HEADER_FIELD)} disabled {/if} 
-																	{if $FIELD_MODEL->isHeaderFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_HEADER_FIELD} title="{$NOT_H_FIELD_TITLE}" {else} title="{$H_FIELD_TITLE}" {/if}>
-																<i class="fa fa-flag-o" data-name="headerfield" 
-																	data-enable-value="1" data-disable-value="0"
-																	{if $FIELD_MODEL->isHeaderFieldOptionDisabled()}readonly="readonly"{/if}
-																	title="{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}
-															</span><br><br>
-															{assign var=IS_SUMMARY_VIEW_ENABLED value=$FIELD_MODEL->isSummaryField()}
-															<span class="summary switch {if (!$IS_SUMMARY_VIEW_ENABLED)} disabled {/if} 
-																	{if $FIELD_MODEL->isSummaryFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-																	data-toggle="tooltip" {if $IS_SUMMARY_VIEW_ENABLED} title="{$NOT_S_FIELD_TITLE}" {else} title="{$S_FIELD_TITLE}" {/if}>
-																<i class="fa fa-key" data-name="summaryfield" 
-																	data-enable-value="1" data-disable-value="0"
-																	{if $FIELD_MODEL->isSummaryFieldOptionDisabled()}readonly="readonly"{/if}
-																	title="{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}
-															</span><br><br>
-															<div class="defaultValue col-sm-12 {if !$FIELD_MODEL->hasDefaultValue()}disabled{/if} 
-																 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} cursorPointerNotAllowed {/if}">
-																{assign var=DEFAULT_VALUE value=$FIELD_MODEL->getDefaultFieldValueToViewInV7FieldsLayOut()}
-																{if $DEFAULT_VALUE}
-																	{if is_array($DEFAULT_VALUE)}
-																		{foreach key=DEFAULT_FIELD_NAME item=DEFAULT_FIELD_VALUE from=$DEFAULT_VALUE}
-																			<div class="row defaultValueContent">
-																				<span><img src="{vimage_path('DefaultValue.png')}"
-																							{if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																							{if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
-																							data-name="defaultValueField" height=14 width=14 /></span>&nbsp;
-																					{if $DEFAULT_FIELD_VALUE}
-																						{assign var=DEFAULT_FIELD_NAME value=$DEFAULT_FIELD_NAME|upper}
-																					<span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)}
-																						{vtranslate("LBL_$DEFAULT_FIELD_NAME",$QUALIFIED_MODULE)} : </span>
-																					<span data-defaultvalue-fieldname="{$DEFAULT_FIELD_NAME}" data-defaultvalue="{$DEFAULT_FIELD_VALUE}">{$DEFAULT_FIELD_VALUE}</span>
-																				{else}
-																					{vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}
-																				{/if}
-																			</div>
-																		{/foreach}
-																	{else}
-																		<div class="row defaultValueContent">
-																			<span>
-																				<img src="{vimage_path('DefaultValue.png')}" height=14 width=14 
-																					 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																					 {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE|strip_tags}" {/if}>
-																			</span>&nbsp;
-																			<span>{vtranslate('LBL_DEFAULT_VALUE',$QUALIFIED_MODULE)} : </span>
-																			<span data-defaultvalue="{$DEFAULT_VALUE|strip_tags}">{$DEFAULT_VALUE|strip_tags}</span>
-																		</div>
-																	{/if}
-																{else}
-																	<div class="row defaultValueContent">
-																		<span>
-																			<img src="{vimage_path('DefaultValue.png')}"
-																				 {if $FIELD_MODEL->isDefaultValueOptionDisabled()} readonly="readonly" {/if}
-																				 {if $FIELD_MODEL->hasDefaultValue()} title="{$DEFAULT_VALUE}" {/if}
-																				 data-name="defaultValueField" height=14 width=14 />
-																		</span>&nbsp;
-																		<span>{vtranslate('LBL_DEFAULT_VALUE_NOT_SET',$QUALIFIED_MODULE)}</span>
-																	</div>
-																{/if}
-															</div>
-														</div>
-														<span class="col-sm-2 actions">
-															{if $FIELD_MODEL->isEditable()}
-																<a href="javascript:void(0)" class="editFieldDetails">
-																	<i class="fa fa-pencil" title="{vtranslate('LBL_EDIT', $QUALIFIED_MODULE)}"></i>
-																</a>
-															{/if}
-															{if $FIELD_MODEL->isCustomField() eq 'true'}
-																<a href="javascript:void(0)" class="deleteCustomField pull-right" data-field-id="{$FIELD_MODEL->get('id')}"
-																	data-one-one-relationship="{$FIELD_MODEL->isOneToOneRelationField()}" data-relationship-field="{$FIELD_MODEL->isRelationShipReponsibleField()}"
-																	{if $FIELD_MODEL->isOneToOneRelationField()}
-																		{assign var=ONE_ONE_RELATION_FIELD_LABEL value=$FIELD_MODEL->getOneToOneRelationField()->get('label')}
-																		{assign var=ONE_ONE_RELATION_MODULE_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getModuleName()}
-																		{assign var=ONE_ONE_RELATION_FIELD_NAME value=$FIELD_MODEL->getOneToOneRelationField()->getName()}
-																		data-relation-field-label="{$ONE_ONE_RELATION_FIELD_LABEL}" 
-																		data-relation-module-label="{vtranslate($ONE_ONE_RELATION_MODULE_NAME,$ONE_ONE_RELATION_MODULE_NAME)}"
-																		data-current-field-label ="{vtranslate($FIELD_MODEL->get('label'),$SELECTED_MODULE_NAME)}"
-																		data-current-module-label="{vtranslate($SELECTED_MODULE_NAME,$SELECTED_MODULE_NAME)}"
-																		data-field-name="{$ONE_ONE_RELATION_FIELD_NAME}"
-																	{/if}
-																	{if $FIELD_MODEL->isRelationShipReponsibleField()}
-																		{assign var=RELATION_MODEL value=$FIELD_MODEL->getRelationShipForThisField()}
-
-																		data-relation-field-label="{vtranslate($FIELD_MODEL->get('label'),$RELATION_MODEL->getRelationModuleName())}" 
-																		data-relation-module-label="{vtranslate($RELATION_MODEL->getRelationModuleName(),$RELATION_MODEL->getRelationModuleName())}"
-																		data-current-module-label="{vtranslate($RELATION_MODEL->getParentModuleName(),$RELATION_MODEL->getParentModuleName())}"
-																		data-current-tab-label="{vtranslate($RELATION_MODEL->get('label'), $RELATION_MODEL->getRelationModuleName())}"
-																	{/if} >
-																	<i class="fa fa-trash" title="{vtranslate('LBL_DELETE', $QUALIFIED_MODULE)}"></i>
-																</a>
-															{/if}
-														</span>
-													</div>
-												</div>
-											</div>
-										</li>
-									{/if}
+                                  data-relation-field-label="{vtranslate($FIELD_MODEL->get('label'),$RELATION_MODEL->getRelationModuleName())}" 
+                                  data-relation-module-label="{vtranslate($RELATION_MODEL->getRelationModuleName(),$RELATION_MODEL->getRelationModuleName())}"
+                                  data-current-module-label="{vtranslate($RELATION_MODEL->getParentModuleName(),$RELATION_MODEL->getParentModuleName())}"
+                                  data-current-tab-label="{vtranslate($RELATION_MODEL->get('label'), $RELATION_MODEL->getRelationModuleName())}"
+                                {/if} >
+                                <i class="fa fa-trash" title="{vtranslate('LBL_DELETE', $QUALIFIED_MODULE)}"></i>
+                              </a>
+                            {/if}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
 								{/foreach}
                 {if $BLOCK_MODEL->isAddCustomFieldEnabled()}
                   <li class="row dummyRow">

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -302,7 +302,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		var thisInstance = this;
 		var contents = jQuery('#layoutEditorContainer').find('.contents');
 		var table = contents.find('.editFieldsTable');
-		table.find('ul[name=sortable1], ul[name=sortable2]').sortable({
+		table.find('ul[name=sortable1]').sortable({
 			'containment': '#moduleBlocks',
 			'cancel': 'li.dummyRow',
 			'revert': true,
@@ -362,29 +362,11 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 	reArrangeBlockFields: function (block) {
 		// 1.get the containers, 2.compare the length, 3.if uneven then move the last element
 		var leftSideContainer = block.find('ul[name=sortable1]');
-		var rightSideContainer = block.find('ul[name=sortable2]');
 		if (leftSideContainer.length < 1 && rightSideContainer.length < 1) {
 			var leftSideContainer = block.find('ul[name=unSortable1]');
-			var rightSideContainer = block.find('ul[name=unSortable2]');
 		}
-		var dummyRowElement = jQuery();
-		if (leftSideContainer.find('li.dummyRow').length > 0) {
-			dummyRowElement = leftSideContainer.find('li.dummyRow').detach();
-		} else {
-			dummyRowElement = rightSideContainer.find('li.dummyRow').detach();
-		}
-		if (leftSideContainer.children().length < rightSideContainer.children().length) {
-			var lastElementInRightContainer = rightSideContainer.children(':last');
-			leftSideContainer.append(lastElementInRightContainer);
-		} else if (leftSideContainer.children().length > rightSideContainer.children().length+1) {	//greater than 1
-			var lastElementInLeftContainer = leftSideContainer.children(':last');
-			rightSideContainer.append(lastElementInLeftContainer);
-		}
-		if (rightSideContainer.children().length < leftSideContainer.children().length) {
-			rightSideContainer.append(dummyRowElement);
-		} else {
-			leftSideContainer.append(dummyRowElement);
-		}
+		var lastElementInLeftContainer = leftSideContainer.children(':last');
+		leftSideContainer.append(lastElementInLeftContainer);
 	},
 	/**
 	 * Function to create the list of updated blocks with all the fields and their sequences
@@ -403,16 +385,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 				var fieldEle = jQuery(domElement);
 				var fieldId = fieldEle.data('fieldId');
 				thisInstance.updatedBlockFieldsList.push({'fieldid': fieldId, 'sequence': expectedFieldSequence, 'block': updatedBlockId});
-				expectedFieldSequence = expectedFieldSequence+2;
-			});
-			var secondBlockSortFields = updatedBlock.find('ul[name=sortable2]');
-			var secondEditFields = secondBlockSortFields.find('.editFields');
-			var sequenceValue = 2;
-			secondEditFields.each(function (i, domElement) {
-				var fieldEle = jQuery(domElement);
-				var fieldId = fieldEle.data('fieldId');
-				thisInstance.updatedBlockFieldsList.push({'fieldid': fieldId, 'sequence': sequenceValue, 'block': updatedBlockId});
-				sequenceValue = sequenceValue+2;
+				expectedFieldSequence = expectedFieldSequence+1;
 			});
 		}
 	},
@@ -1062,33 +1035,17 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		}
 		var block = relatedBlock.find('.blockFieldsList');
 		var sortable1 = block.find('ul[name=sortable1]');
-		var sortable2 = block.find('ul[name=sortable2]');
 
-		if (sortable1.length < 1 && sortable2.length < 1) {
+		if (sortable1.length < 1) {
 			var sortable1 = block.find('ul[name=unSortable1]');
-			var sortable2 = block.find('ul[name=unSortable2]');
 			fieldCopy.find('.dragImage').hide();
 		}
-
+		// 作成したフィールドの追加
+		sortable1.append(fieldCopy.removeClass('hide newCustomFieldCopy'));
+		// 項目作成フィールドの追加
 		var firstSortableChildren = sortable1.children();
-		var secondSortableChildren = sortable2.children();
-		if (firstSortableChildren.filter('li.dummyRow').length > 0) {
-			firstSortableChildren.filter('li.dummyRow').detach().appendTo(sortable2);
-		} else {
-			secondSortableChildren.filter('li.dummyRow').detach().appendTo(sortable1);
-		}
-		firstSortableChildren = sortable1.children();
-		secondSortableChildren = sortable2.children();
+		firstSortableChildren.filter('li.dummyRow').detach().appendTo(sortable1);
 
-		var length1 = firstSortableChildren.filter(':not(l1.dummyRow)').length;
-
-		var length2 = secondSortableChildren.filter(':not(l1.dummyRow)').length;
-		// Deciding where to add the new field
-		if (length1 > length2) {
-			sortable2.append(fieldCopy.removeClass('hide newCustomFieldCopy'));
-		} else {
-			sortable1.append(fieldCopy.removeClass('hide newCustomFieldCopy'));
-		}
 		var form = fieldCopy.find('.fieldProperties');
 		thisInstance.setFieldDetails(result, fieldCopy);
 		thisInstance.makeFieldsListSortable();

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -5215,7 +5215,6 @@ TN-34230 .row .nav > li > a:hover {
   vertical-align: middle;
 }
 .layoutContent li.dummyRow {
-  border: 1px dotted #DDDDDD;
   min-height: 116px;
   height: auto;
 }
@@ -5279,7 +5278,7 @@ TN-34230 .row .nav > li > a:hover {
   display: flex;
   width: 100%;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: top;
   justify-content: left;
 
   list-style-type: none;
@@ -5288,7 +5287,7 @@ TN-34230 .row .nav > li > a:hover {
   margin-top: 1%;
 }
 .layoutContent .blockFieldsList ul li {
-  width: 44%; /*決め打ち*/
+  width: 44%;
   margin-left: 4%;
 }
 .layoutContent .blockFieldsList {

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -5276,13 +5276,20 @@ TN-34230 .row .nav > li > a:hover {
   border: 1px solid #CCCCCC;
 }
 .layoutContent .blockFieldsList ul {
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: left;
+
   list-style-type: none;
-  float: left;
   min-height: 1px;
   padding: 2px;
-  margin-left: 4%;
   margin-top: 1%;
-  width: 44%;
+}
+.layoutContent .blockFieldsList ul li {
+  width: 44%; /*決め打ち*/
+  margin-left: 4%;
 }
 .layoutContent .blockFieldsList {
   padding: 5px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #315 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目の並び順を変更する際、左の列と右の列が独立していたため移動後の並び順が不自然であった

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 奇数番目は左の列(sortable1)、奇数番目は右の列(sortable2)に分かれていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. sortable1とsortable2を結合し、sortable2は削除した
2. 「新しい項目の追加」の項目がsortable1の一番最後になるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
 - 変更前(顧客担当者IDを先頭(左上)に移動する。姓→名→勤務先電話番号→顧客担当者IDの順)
![image](https://user-images.githubusercontent.com/75693720/142375650-b04877b5-0894-4414-9267-3c76b559040c.png)
 - 変更後(顧客担当者ID→姓→名→勤務先電話番号の順に並び直されている)
![image](https://user-images.githubusercontent.com/75693720/142375754-4fc2eb80-06b6-4188-9df1-43026e04c5bf.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目設定の項目順番および新規追加項目の挙動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->