### PR TITLE
#377 請求,受注,発注,見積に関連した活動を関連のリストから作成できない不具合を修正

### DIFF
--- a/modules/Migration/schema/734_to_735.php
+++ b/modules/Migration/schema/734_to_735.php
@@ -46,4 +46,8 @@ if (defined('VTIGER_UPGRADE')) {
         $db->pquery("update vtiger_field set typeofdata = 'DT~O' where fieldname = 'createdtime' and tabid = ?", array($dailyreportsId));
         $db->pquery("update vtiger_field set typeofdata = 'DT~O' where fieldname = 'modifiedtime' and tabid = ?", array($dailyreportsId));
     }
+
+    // 一部モジュールの関連活動の設定の不具合を修正
+    $relationfieldid = $db->pquery("SELECT fieldid FROM vtiger_field WHERE fieldname = 'parent_id' AND tabid = (SELECT tabid FROM vtiger_tab WHERE name = 'Calendar');", array());
+    $db->pquery("UPDATE vtiger_relatedlists SET relationfieldid = ?, relationtype = '1:N' WHERE name = 'get_activities' AND relationtype = 'N:N' AND relationfieldid is NULL", array($db->query_result($relationfieldid, 0, 'fieldid')));
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #377

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 請求,受注,発注,見積に関連した活動を関連のリストから作成できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 該当モジュールの｢予定の登録｣ボタンのURLにparent_idがないため自動で親モジュールが選択されない
2. 親フィールド(関連元)と活動が1対多で紐づく場合のみparent_idを付与する
2. 親フィールド(関連元)と活動はrelationtypeが1対多で紐づくはずが,該当モジュールでは多対多で登録されている

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_relatedlistsの該当フィールドの値を更新

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
before
![image](https://user-images.githubusercontent.com/53038605/142823942-2ae65a42-06b5-44b0-919d-45882c351e2b.png)
after
![image](https://user-images.githubusercontent.com/53038605/142823966-54713e2b-d28c-40d8-bc26-c6d8020cbca9.png)
## 影響範囲  / Affected Area
請求,受注,発注,見積,日報モジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->