### PR TITLE
fixed #381 価格表モジュールでレポートを出力する際に、新規作成フィールドを扱うとエラーになる不具合の修正

### DIFF
--- a/modules/PriceBooks/PriceBooks.php
+++ b/modules/PriceBooks/PriceBooks.php
@@ -301,6 +301,9 @@ class PriceBooks extends CRMEntity {
 
 		$query = $this->getRelationQuery($module,$secmodule,"vtiger_pricebook","pricebookid", $queryPlanner);
 		// TODO Support query planner
+		if ($queryPlanner->requireTable('vtiger_pricebookcf')) {
+			$query .= " left join vtiger_pricebookcf on vtiger_pricebook.pricebookid = vtiger_pricebookcf.pricebookid";
+		}
 		if ($queryPlanner->requireTable("vtiger_crmentityPriceBooks",$matrix)){
 		$query .=" left join vtiger_crmentity as vtiger_crmentityPriceBooks on vtiger_crmentityPriceBooks.crmid=vtiger_pricebook.pricebookid and vtiger_crmentityPriceBooks.deleted=0";
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #381 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 価格表モジュールが、レポートの「関連」として指定している時に起きる
2. 価格表モジュールでレポートを出力する際に、新規作成フィールドを扱うとエラーになる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. generateReportsSecQueryにて、`vtiger_pricebookcf` をJOINしていなかったため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_pricebookcfを追加するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
価格表のレポート周り

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
本修正を行ったとしても、集計を行う際には価格表モジュールのフィールドを1つ以上、カラムとして指定する必要がある。
根本的な問題については、#357（v7.3.6） にて対応予定となります。