### PR TITLE
項目追加時に項目タイプを何回か切り替えると、デフォルト値の表示がおかしくなる箇所の修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -979,9 +979,9 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 
 				data.name = nameAttr;
 				data.value = defaultValueUi.val();
-				if(nameAttr == 'fieldDefaultValue' && TypeBeforChange == 'Boolean'){
-					data.value = ""; //チェックボックス項目からの変更の場合、デフォルト値に何も表示されないようにする
-					TypeBeforChange = "";
+				//チェックボックス項目から、または選択肢(複数)からの変更の場合、デフォルト値に何も表示されないようにする
+				if(nameAttr == 'fieldDefaultValue' && (TypeBeforChange == 'Boolean' || TypeBeforChange == 'Multipicklist')){
+					data.value = "";
 				}
 				if (currentTarget.val() == "MultiSelectCombo") {
 					if (data.value != null && data.value.length > 0) {

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -873,6 +873,10 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		var maxLengthValidator = 'maximumlength';
 		var decimalValidator = 'range';
 
+		// 「チェックボックス」→ 他の項目 の変更等でデフォルト値に0やNULLが表示される
+		// 上記を回避するために変更前の項目タイプを保存する
+		var TypeBeforChange;
+
 		//register the change event for field types
 		form.find('[name="fieldType"]').on('change', function (e) {
 			var currentTarget = jQuery(e.currentTarget);
@@ -942,6 +946,8 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 
 				form.find('[name="defaultvalue"]').attr('readonly', 'readonly').removeAttr('checked');
 				form.find('.defaultValueUi').addClass('zeroOpacity');
+			}else{ // 「関連」項目以外はデフォルト値が設定できるためclassを削除している
+				form.find('.defaultValueUi').removeClass('zeroOpacity');
 			}
 
 			if (form.find('input[type="checkbox"][name="defaultvalue"]').data('defaultDisabled') == "1") {
@@ -973,6 +979,10 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 
 				data.name = nameAttr;
 				data.value = defaultValueUi.val();
+				if(nameAttr == 'fieldDefaultValue' && TypeBeforChange == 'Boolean'){
+					data.value = ""; //チェックボックス項目からの変更の場合、デフォルト値に何も表示されないようにする
+					TypeBeforChange = "";
+				}
 				if (currentTarget.val() == "MultiSelectCombo") {
 					if (data.value != null && data.value.length > 0) {
 						data.value = data.value.join('|##|');
@@ -989,6 +999,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					case 'MultiSelectCombo':type = 'Multipicklist';break;
 				}
 				data.type = type;
+				TypeBeforChange = type;
 
 				if (typeof data.picklistvalues == "undefined")
 					data.picklistvalues = {};

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -875,7 +875,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 
 		// 「チェックボックス」→ 他の項目 の変更等でデフォルト値に0やNULLが表示される
 		// 上記を回避するために変更前の項目タイプを保存する
-		var TypeBeforChange;
+		var typeBeforeChange;
 
 		//register the change event for field types
 		form.find('[name="fieldType"]').on('change', function (e) {
@@ -980,7 +980,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 				data.name = nameAttr;
 				data.value = defaultValueUi.val();
 				//チェックボックス項目から、または選択肢(複数)からの変更の場合、デフォルト値に何も表示されないようにする
-				if(nameAttr == 'fieldDefaultValue' && (TypeBeforChange == 'Boolean' || TypeBeforChange == 'Multipicklist')){
+				if(nameAttr == 'fieldDefaultValue' && (typeBeforeChange == 'Boolean' || typeBeforeChange == 'Multipicklist')){
 					data.value = "";
 				}
 				if (currentTarget.val() == "MultiSelectCombo") {
@@ -999,7 +999,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					case 'MultiSelectCombo':type = 'Multipicklist';break;
 				}
 				data.type = type;
-				TypeBeforChange = type;
+				typeBeforeChange = type;
 
 				if (typeof data.picklistvalues == "undefined")
 					data.picklistvalues = {};


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #350 

##  不具合の内容 / Bug
1. 「関連」項目から他の項目に変更すると、デフォルト値の入力欄が消える
2. 「チェックボックス」項目から他の項目に変更すると、デフォルト値の入力欄に0が表示される
3. 「選択肢(複数)」項目から他の項目に変更すると、デフォルト値の入力欄にnullが表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 関連項目から変更した際に追加したクラスを外す処理がなかった
2. 「チェックボックス」と「選択肢(複数)」項目に変更した際にはデフォルト値が設定される

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 関連項目以外ではクラスを追加するように変更(他の項目はすべてデフォルト値が設定可能なため)
2. 変更前の項目データを用意し、これが「チェックボックス」or「選択肢(複数)」の場合はデフォルト値を""(空)にするように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - カスタム項目の作成

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->