### PR TITLE
#312 ワークフローで｢レコードの作成｣,｢項目の値の更新｣を行う際に,フィールドタイプがメールアドレスだと,値を常にrawテキストとしてしまう不具合を修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/CreateEntity.tpl
+++ b/layouts/v7/modules/Settings/Workflows/CreateEntity.tpl
@@ -29,7 +29,7 @@
 					<select name="fieldname" class="select2" style="min-width: 250px" {if $SELECTED_FIELD_MODEL->isMandatory() || ($DISABLE_ROW eq 'true') } disabled="" {/if} >
 						<option value="none"></option>
 						{foreach from=$RELATED_MODULE_MODEL->getFields() item=FIELD_MODEL}
-							{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+							{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfoForWfEditTask()}
 							<option value="{$FIELD_MODEL->get('name')}" {if $FIELD_MAP['fieldname'] eq $FIELD_MODEL->get('name')} {if $FIELD_MODEL->isMandatory()}{assign var=MANDATORY_FIELD value=true} {else} {assign var=MANDATORY_FIELD value=false} {/if}{assign var=FIELD_TYPE value=$FIELD_MODEL->getFieldDataType()} selected=""{/if} data-fieldtype="{$FIELD_MODEL->getFieldType()}" data-field-name="{$FIELD_MODEL->get('name')}" data-fieldinfo='{ZEND_JSON::encode($FIELD_INFO)}' >
 								{vtranslate($FIELD_MODEL->get('label'), $FIELD_MODEL->getModuleName())}{if $SELECTED_FIELD_MODEL->isMandatory() and $FIELD_MODEL->getName() neq 'assigned_user_id'}<span class="redColor">*</span>{/if}
 							</option>	
@@ -70,7 +70,7 @@
 						<select name="fieldname" class="select2" disabled="" style="min-width: 250px">
 							<option value="none"></option>
 							{foreach from=$RELATED_MODULE_MODEL->getFields() item=FIELD_MODEL}
-								{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+								{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfoForWfEditTask()}
 								<option value="{$FIELD_MODEL->get('name')}" data-fieldtype="{$FIELD_MODEL->getFieldType()}" {if $FIELD_MODEL->get('name') eq $MANDATORY_FIELD_MODEL->get('name')} {assign var=FIELD_TYPE value=$FIELD_MODEL->getFieldDataType()} selected=""{/if} data-field-name="{$FIELD_MODEL->get('name')}" data-fieldinfo='{ZEND_JSON::encode($FIELD_INFO)}' >
 									{vtranslate($FIELD_MODEL->get('label'), $FIELD_MODEL->getModuleName())}<span class="redColor">*</span>
 								</option>	
@@ -100,7 +100,7 @@
 			<select name="fieldname" style="min-width: 250px">
 				<option value="none">{vtranslate('LBL_NONE',$QUALIFIED_MODULE)}</option>
 				{foreach from=$RELATED_MODULE_MODEL->getFields() item=FIELD_MODEL}
-					{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+					{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfoForWfEditTask()}
 					{if !$FIELD_MODEL->isMandatory()}
 					<option value="{$FIELD_MODEL->get('name')}" data-fieldtype="{$FIELD_MODEL->getFieldType()}" data-field-name="{$FIELD_MODEL->get('name')}" data-fieldinfo='{ZEND_JSON::encode($FIELD_INFO)}' >
 						{vtranslate($FIELD_MODEL->get('label'), $FIELD_MODEL->getModuleName())}

--- a/layouts/v7/modules/Settings/Workflows/Tasks/VTUpdateFieldsTask.tpl
+++ b/layouts/v7/modules/Settings/Workflows/Tasks/VTUpdateFieldsTask.tpl
@@ -33,7 +33,7 @@
                                 {if (!($FIELD_MODEL->get('workflow_fieldEditable') eq true)) or ($MODULE_MODEL->get('name')=="Documents" and in_array($FIELD_MODEL->get('name'),$RESTRICTFIELDS))}
                                     {continue}
                                 {/if}
-							{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+							{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfoForWfEditTask()}
                             {assign var=FIELD_NAME value=$FIELD_MODEL->getName()}
                                 {assign var=FIELD_MODULE_MODEL value=$FIELD_MODEL->getModule()}
                                 <option value="{$FIELD_MODEL->get('workflow_columnname')}" {if $FIELD_MAP['fieldname'] eq $FIELD_MODEL->get('workflow_columnname')}selected=""{/if}data-fieldtype="{$FIELD_MODEL->getFieldType()}" data-field-name="{$FIELD_MODEL->get('name')}" 
@@ -69,7 +69,7 @@
                             {if (!($FIELD_MODEL->get('workflow_fieldEditable') eq true))  or ($MODULE_MODEL->get('name')=="Documents" and in_array($FIELD_MODEL->get('name'),$RESTRICTFIELDS))}
                                 {continue}
                             {/if}
-						{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+						{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfoForWfEditTask()}
                         {assign var=FIELD_NAME value=$FIELD_MODEL->getName()}
                             {assign var=FIELD_MODULE_MODEL value=$FIELD_MODEL->getModule()}
                             <option value="{$FIELD_MODEL->get('workflow_columnname')}" data-fieldtype="{$FIELD_MODEL->getFieldType()}" data-field-name="{$FIELD_MODEL->get('name')}" 

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -1407,7 +1407,7 @@ class Vtiger_Field_Model extends Vtiger_Field {
 	public function getFieldInfoForWfEditTask() {
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 		$fieldDataType = $this->getFieldDataType();
-		$exceptDataType = ['email', 'picklist', 'multipicklist'];
+		$exceptDataType = ['email'];
 		if(in_array($fieldDataType, $exceptDataType)) {
 			$fieldDataType = "string";
 		}

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -1403,4 +1403,96 @@ class Vtiger_Field_Model extends Vtiger_Field {
 	public function isUniqueField() {
 		return $this->isunique;
 	}
+
+	public function getFieldInfoForWfEditTask() {
+		$currentUser = Users_Record_Model::getCurrentUserModel();
+		$fieldDataType = $this->getFieldDataType();
+		$exceptDataType = ['email', 'picklist', 'multipicklist'];
+		if(in_array($fieldDataType, $exceptDataType)) {
+			$fieldDataType = "string";
+		}
+
+		$this->fieldInfo['mandatory'] = $this->isMandatory();
+		$this->fieldInfo['presence'] = $this->isActiveField();
+		$this->fieldInfo['quickcreate'] = $this->isQuickCreateEnabled();
+		$this->fieldInfo['masseditable'] = $this->isMassEditable();
+		$this->fieldInfo['defaultvalue'] = $this->hasDefaultValue();
+		$this->fieldInfo['column'] = $this->get('column');
+		$this->fieldInfo['type'] = $fieldDataType;
+		$this->fieldInfo['name'] = $this->get('name');
+		$this->fieldInfo['label'] = vtranslate($this->get('label'), $this->getModuleName());
+
+		if($fieldDataType == 'picklist' || $fieldDataType == 'multipicklist' || $fieldDataType == 'multiowner') {
+			$pickListValues = $this->getPicklistValues();
+            $editablePicklistValues = $this->getEditablePicklistValues();
+			if(!empty($pickListValues)) {
+				$this->fieldInfo['picklistvalues'] = $pickListValues;
+			} else {
+				$this->fieldInfo['picklistvalues'] = array();
+			}
+            
+            if(!empty($editablePicklistValues)) {
+                $this->fieldInfo['editablepicklistvalues'] = $editablePicklistValues;
+            } else {
+				$this->fieldInfo['editablepicklistvalues'] = array();
+			}
+
+			$this->fieldInfo['picklistColors'] = array();
+			$picklistColors = $this->getPicklistColors();
+			if ($picklistColors) {
+				$this->fieldInfo['picklistColors'] = $picklistColors;
+			}
+		}
+        
+        if($fieldDataType == "documentsFolder"){
+            $documentFolders = $this->getDocumentFolders();
+            if(!empty($documentFolders)) {
+                $this->fieldInfo['documentFolders'] = $documentFolders;
+            }
+        }
+
+		if($fieldDataType === 'currencyList'){
+		   $currencyList = $this->getCurrencyList();
+		   $this->fieldInfo['currencyList'] = $currencyList;
+		}
+
+		if($this->getFieldDataType() == 'date' || $this->getFieldDataType() == 'datetime'){
+			$currentUser = Users_Record_Model::getCurrentUserModel();
+			$this->fieldInfo['date-format'] = $currentUser->get('date_format');
+		}
+
+		if($this->getFieldDataType() == 'time') {
+			$currentUser = Users_Record_Model::getCurrentUserModel();
+			$this->fieldInfo['time-format'] = $currentUser->get('hour_format');
+		}
+
+		if($this->getFieldDataType() == 'currency') {
+			$currentUser = Users_Record_Model::getCurrentUserModel();
+			$this->fieldInfo['currency_symbol'] = $currentUser->get('currency_symbol');
+			$this->fieldInfo['decimal_separator'] = $currentUser->get('currency_decimal_separator');
+			$this->fieldInfo['group_separator'] = $currentUser->get('currency_grouping_separator');
+		}
+
+		if($this->getFieldDataType() == 'owner' || $this->get('uitype') == '52') {
+			$userList = $currentUser->getAccessibleUsers();
+			$groupList = $currentUser->getAccessibleGroups();
+			$pickListValues = array();
+			$pickListValues[vtranslate('LBL_USERS', $this->getModuleName())] = $userList;
+			$pickListValues[vtranslate('LBL_GROUPS', $this->getModuleName())] = $groupList;
+			$this->fieldInfo['picklistvalues'] = $pickListValues;
+		}
+
+		if($this->getFieldDataType() == 'ownergroup') {
+			$groupList = $currentUser->getAccessibleGroups();
+			$pickListValues = array();
+			$this->fieldInfo['picklistvalues'] = $groupList;
+		}
+
+		if($this->getFieldDataType() == 'reference') {
+			$this->fieldInfo['referencemodules'] = $this->getReferenceList();
+		}
+
+		$this->fieldInfo['validator'] = $this->getValidator();
+		return $this->fieldInfo;
+	}
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #312 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローを追加する
2. アクションで｢レコードの作成｣か｢項目の値の更新｣を追加する
3. 項目の追加でメールアドレスを追加する
4. 値に表現式を保存する
5. 表現式がrawテキストとして保存されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. おそらく型がemailなのでバリデーションがかかっているため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  型をstringに変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/144361831-5d6553e9-0c92-4b7d-8ced-1473aec756d4.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフロー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* `getFieldInfoForWfEditTask()` の変更は `getFieldInfo()` に例外を追加したのみ
* コミット d844b7e はチェリーピック