### PR TITLE
#149 半角で数字0を入力し保存した場合、編集画面で0の値が表示されずに空となっている箇所の修正

### DIFF
--- a/modules/Documents/models/EditRecordStructure.php
+++ b/modules/Documents/models/EditRecordStructure.php
@@ -33,7 +33,7 @@ class Documents_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mod
 					if($fieldModel->isEditable()) {
 						$fieldValue = $recordModel->get($fieldName);
 
-						if (!$fieldValue && !$recordId) {
+						if ((!$fieldValue && strlen($fieldValue) == 0) && !$recordId) {
 							$fieldValue = $fieldModel->getDefaultFieldValue();
 						}
 
@@ -42,7 +42,7 @@ class Documents_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mod
 							$fieldValue = true;
 						}
 
-						if ($fieldValue) {
+						if (strlen($fieldValue) > 0) {
 							$fieldModel->set('fieldvalue', $fieldValue);
 						}
 						$values[$blockLabel][$fieldName] = $fieldModel;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #149 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ドキュメントモジュールの編集画面にて、メモやバージョンに記入されていた**0**が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. データの有無の判定に`if ($fieldValue)`が使用されていたため、値が**0**だとif文を通り抜けてしまう。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 文字列の長さで判定するように変更した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/144373763-5b008d22-a571-4109-9d99-fe0ff6738fab.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - ドキュメントの編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->