### PR TITLE
#387 カレンダー上から詳細入力を行ったあとの戻り先が遷移元のカレンダーとなるように修正

### DIFF
--- a/includes/http/Request.php
+++ b/includes/http/Request.php
@@ -272,5 +272,7 @@ class Vtiger_Request {
 		$viewer->assign('RETURN_MODE', $this->get('returnmode'));
         $viewer->assign('RETURN_RELATION_ID', $this->get('returnrelationId'));
         $viewer->assign('RETURN_PARENT_MODULE', $this->get('returnparent'));
+        $viewer->assign('FROM_QUICK_CREATE', $this->get('fromQuickCreate'));
+        $viewer->assign('QUICK_CREATE_RETURN_URL', $this->get('quickCreateReturnURL'));
 	}
 }

--- a/layouts/v7/modules/Calendar/QuickCreate.tpl
+++ b/layouts/v7/modules/Calendar/QuickCreate.tpl
@@ -159,9 +159,9 @@
 							{assign var=BUTTON_LABEL value={vtranslate('LBL_SAVE', $MODULE)}}
 						{/if}
 						{assign var="CALENDAR_MODULE_MODEL" value=$QUICK_CREATE_CONTENTS['Calendar']['moduleModel']}
-						{assign var="EDIT_VIEW_URL" value=$CALENDAR_MODULE_MODEL->getCreateTaskRecordUrl()}
+						{assign var="EDIT_VIEW_URL" value=$CALENDAR_MODULE_MODEL->getQuickCreateTaskRecordUrl()}
 						{if $MODULE eq 'Events'}
-							{assign var="EDIT_VIEW_URL" value=$CALENDAR_MODULE_MODEL->getCreateEventRecordUrl()}
+							{assign var="EDIT_VIEW_URL" value=$CALENDAR_MODULE_MODEL->getQuickCreateEventRecordUrl()}
 						{/if}
 						<button class="btn btn-default" id="goToFullForm" data-edit-view-url="{$EDIT_VIEW_URL}" type="button"><strong>{vtranslate('LBL_GO_TO_FULL_FORM', $MODULE)}</strong></button>
 						<button {if $BUTTON_ID neq null} id="{$BUTTON_ID}" {/if} class="btn btn-success" type="submit" name="saveButton"><strong>{$BUTTON_LABEL}</strong></button>

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1674,8 +1674,17 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var HEADER_HEIGHT = 200;
 		var CalendarHeight = $(window).height() - HEADER_HEIGHT;
 		CalendarHeight = (CalendarHeight < MIN_CALENDAR_HEIGHT) ? MIN_CALENDAR_HEIGHT : CalendarHeight;
+
+		// 表示する日付を取得
 		var URL_Serarch = new URLSearchParams(location.search);
-		var defaultDate = new Date(URL_Serarch.get("lastRecordDate"));
+		var calendarStartDate = URL_Serarch.get("calendarStartDate");
+		if (calendarStartDate) {
+			var defaultDate = new Date(calendarStartDate);
+		} else {
+			var defaultDate = new Date(); // 今日
+		}
+		URL_Serarch.delete("calendarStartDate");
+		history.replaceState('', '', 'index.php?' + URL_Serarch.toString());
 
 		var calenderConfigs = {
 			header: {

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1674,6 +1674,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var HEADER_HEIGHT = 200;
 		var CalendarHeight = $(window).height() - HEADER_HEIGHT;
 		CalendarHeight = (CalendarHeight < MIN_CALENDAR_HEIGHT) ? MIN_CALENDAR_HEIGHT : CalendarHeight;
+		var URL_Serarch = new URLSearchParams(location.search);
+		var defaultDate = new Date(URL_Serarch.get("lastRecordDate"));
 
 		var calenderConfigs = {
 			header: {
@@ -1712,6 +1714,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			defaultView: ($(window).width() > 1020 ? userDefaultActivityView : 'agendaDay'),
 			slotLabelFormat: userDefaultTimeFormat,
 			timeFormat: userDefaultTimeFormat,
+			defaultDate: defaultDate,
 			events: [],
 			monthNames: [
 				app.vtranslate('LBL_JANUARY'),

--- a/layouts/v7/modules/Vtiger/EditView.tpl
+++ b/layouts/v7/modules/Vtiger/EditView.tpl
@@ -68,6 +68,8 @@
 								<input type="hidden" name="returnmode" value={$RETURN_MODE} />
 								<input type="hidden" name="returnrelationId" value="{$RETURN_RELATION_ID}" />
 								<input type="hidden" name="returnparent" value="{$RETURN_PARENT_MODULE}" />
+								<input type="hidden" name="fromQuickCreate" value="{$FROM_QUICK_CREATE}" />
+								<input type="hidden" name="quickCreateReturnURL" value="{$QUICK_CREATE_RETURN_URL}" />
 							{/if}
 							{include file="partials/EditViewContents.tpl"|@vtemplate_path:$MODULE}
 						</div>

--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -441,7 +441,10 @@ Vtiger.Class('Vtiger_Index_Js', {
 		var thisInstance = this;
 
 		app.event.on("post.QuickCreateForm.show",function(event,form){
-			form.find('#goToFullForm').on('click', function(e) {
+			jQuery('<input type="hidden" name="returnview" value="Detail" />').appendTo(form);
+			jQuery('<input type="hidden" name="fromQuickCreate" value="true" />').appendTo(form);
+			jQuery('<input type="hidden" name="quickCreateReturnURL" value="'+location.search+'" />').appendTo(form);
+			form.find('#goToFullForm').on('click', function (e) {
 				window.onbeforeunload = true;
 				var form = jQuery(e.currentTarget).closest('form');
 				var editViewUrl = jQuery(e.currentTarget).data('editViewUrl');

--- a/modules/Calendar/actions/Save.php
+++ b/modules/Calendar/actions/Save.php
@@ -27,7 +27,19 @@ class Calendar_Save_Action extends Vtiger_Save_Action {
 	public function process(Vtiger_Request $request) {
 		try {
 			$recordModel = $this->saveRecord($request);
-			$loadUrl = 'index.php?module=Calendar&view=Calendar&lastRecordDate='. $recordModel->get('date_start');
+
+			$refererUrl  = $_SERVER['HTTP_REFERER'];
+			$parsedurl = parse_url($refererUrl);
+			$searchParams = explode('&', $parsedurl['query']);
+			foreach ($searchParams as $searchParam){
+				$explodedParams = explode('=', $searchParam);
+				$parsedParams[$explodedParams[0]] =$explodedParams[1];
+			}
+			if($parsedParams['referer'] == 'SharedCalendar') {
+				$loadUrl = 'index.php?module=Calendar&view=SharedCalendar&calendarStartDate='. $recordModel->get('date_start');
+			} else {
+				$loadUrl = 'index.php?module=Calendar&view=Calendar&calendarStartDate='. $recordModel->get('date_start');
+			}
 
 			if ($request->get('returntab_label')) {
 				$loadUrl = 'index.php?'.$request->getReturnURL();

--- a/modules/Calendar/actions/Save.php
+++ b/modules/Calendar/actions/Save.php
@@ -41,7 +41,9 @@ class Calendar_Save_Action extends Vtiger_Save_Action {
 				$loadUrl = 'index.php?module=Calendar&view=Calendar&calendarStartDate='. $recordModel->get('date_start');
 			}
 
-			if ($request->get('returntab_label')) {
+			if ($request->get('fromQuickCreate')) {
+				$loadUrl = 'index.php'.$request->get('quickCreateReturnURL');
+			} else if($request->get('returntab_label')) {
 				$loadUrl = 'index.php?'.$request->getReturnURL();
 			} else if($request->get('relationOperation')) {
 				$parentModuleName = $request->get('sourceModule');

--- a/modules/Calendar/actions/Save.php
+++ b/modules/Calendar/actions/Save.php
@@ -27,7 +27,7 @@ class Calendar_Save_Action extends Vtiger_Save_Action {
 	public function process(Vtiger_Request $request) {
 		try {
 			$recordModel = $this->saveRecord($request);
-			$loadUrl = $recordModel->getDetailViewUrl();
+			$loadUrl = 'index.php?module=Calendar&view=Calendar&lastRecordDate='. $recordModel->get('date_start');
 
 			if ($request->get('returntab_label')) {
 				$loadUrl = 'index.php?'.$request->getReturnURL();

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -66,11 +66,50 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 	}
 
 	/**
+	 * Function returns the URL for creating Events at QuickCreat
+	 * @return <String>
+	 */
+	public function getQuickCreateEventRecordUrl() {
+		$refererUrl  = $_SERVER['HTTP_REFERER'];
+		$parsedurl = parse_url($refererUrl);
+		$searchParams = explode('&', $parsedurl['query']);
+		foreach ($searchParams as $searchParam) {
+			$explodedParams = explode('=', $searchParam);
+			$parsedParams[$explodedParams[0]] = $explodedParams[1];
+		}
+		$eventRecordUrl = 'index.php?module=' . $this->get('name') . '&view=' . $this->getEditViewName() . '&mode=Events';
+		if ($parsedParams['view'] == 'SharedCalendar') {
+			return $eventRecordUrl . '&referer=SharedCalendar';
+		}
+		return $eventRecordUrl;
+	}
+
+	/**
 	 * Function returns the URL for creating Task
 	 * @return <String>
 	 */
 	public function getCreateTaskRecordUrl() {
 		return 'index.php?module='.$this->get('name').'&view='.$this->getEditViewName().'&mode=Calendar';
+	}
+
+	/**
+	 * Function returns the URL for creating Tasks at QuickCreat
+	 * @return <String>
+	 */
+	public function getQuickCreateTaskRecordUrl()
+	{
+		$refererUrl  = $_SERVER['HTTP_REFERER'];
+		$parsedurl = parse_url($refererUrl);
+		$searchParams = explode('&', $parsedurl['query']);
+		foreach ($searchParams as $searchParam) {
+			$explodedParams = explode('=', $searchParam);
+			$parsedParams[$explodedParams[0]] = $explodedParams[1];
+		}
+		$eventRecordUrl = 'index.php?module=' . $this->get('name') . '&view=' . $this->getEditViewName() . '&mode=Calendar';
+		if ($parsedParams['view'] == 'SharedCalendar') {
+			return $eventRecordUrl . '&referer=SharedCalendar';
+		}
+		return $eventRecordUrl;
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #387 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  カレンダー上から詳細入力を行ったあとの戻り先は対象レコードの詳細画面となる

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. URLSearchParamsにlastRecordDateとして変更したレコード開始日時を保持し,その日が含まれるデフォルトカレンダーを表示

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
・URLSearchParamsに日付が入った状態で詳細入力→キャンセルするとhistory.back()によりその日付に戻ってしまう
・historyを書き換える処理が必要かもしれない