### PR TITLE
fixed #401 活動のインポート時、項目設定から追加した項目が含まれていてもインポートできるように修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -462,6 +462,9 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		//Update missing seq numbers
 		$focus = CRMEntity::getInstance($moduleName);
 		$focus->updateMissingSeqNumber($moduleName);
+		if($moduleName == "Calendar"){
+			$focus->updateMissingSeqNumber("Events");
+		}
 
 		//Creating entity data of created records for post save events 
 		if (!empty($createdRecords)) {
@@ -497,7 +500,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				$fieldData['visibility'] = $current_user->calendarsharedtype;
 			}
 			foreach ($eventModuleFields as $fieldName => $fieldModel) {
-				if (stripos($fieldName, 'cf_') !== false) {
+				if (empty($moduleFields[$fieldName])) {
 					$moduleFields[$fieldName] = $fieldModel;
 				}
 			}
@@ -777,10 +780,20 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			}
 			$fieldData['currency_id'] = $this->lineitem_currency_id;
 		}
+
+		$skippedCalendarFields = array('contact_id', 'duration_hours', 'duration_minutes', 'recurringtype', 'reminder_time', 'smcreatorid');
+
 		if ($fieldData != null && $checkMandatoryFieldValues) {
 			foreach ($moduleFields as $fieldName => $fieldInstance) {
+				if($moduleName == "Calendar" && in_array($fieldName, $skippedCalendarFields)) continue;
 				if ((($fieldData[$fieldName] == '') || ($fieldData[$fieldName] == null)) && $fieldInstance->isMandatory()) {
+					if($moduleName == "Calendar" && $fieldData["activitytype"] != "Task" && $fieldName == "eventstatus" && !empty($fieldData["taskstatus"])){
+						$fieldData["eventstatus"] == $fieldData["taskstatus"];
+					}else if($moduleName == "Calendar" && $fieldData["activitytype"] == "Task" && $fieldName == "taskstatus" && !empty($fieldData["eventstatus"])){
+						$fieldData["taskstatus"] == $fieldData["eventstatus"];
+					}else{
 					return null;
+					}
 				}
 			}
 		}

--- a/modules/Import/readers/FileReader.php
+++ b/modules/Import/readers/FileReader.php
@@ -111,6 +111,16 @@ class Import_FileReader_Reader {
 
 		$columnsListQuery = 'id INT PRIMARY KEY AUTO_INCREMENT, status INT DEFAULT 0, recordid INT';
 		$fieldTypes = $this->getModuleFieldDBColumnType();
+
+		if($this->moduleModel->getName() == 'Calendar'){
+			$eventModule = Vtiger_Module_Model::getInstance("Events");
+			$eventModuleFields = $eventModule->getFields();
+			$moduleFields = array_merge($moduleFields, $eventModuleFields);
+
+			$eventFieldTypes = $this->getModuleFieldDBColumnType($eventModule);
+			$fieldTypes = array_merge($fieldTypes, $eventFieldTypes);
+		}
+
 		foreach($fieldMapping as $fieldName => $index) {
 			$fieldObject = $moduleFields[$fieldName];
 			$columnsListQuery .= $this->getDBColumnType($fieldObject, $fieldTypes);
@@ -164,9 +174,13 @@ class Import_FileReader_Reader {
 	/** Function returns array of columnnames and their column datatype
 	 * @return <Array>
 	 */
-	public function getModuleFieldDBColumnType() {
+	public function getModuleFieldDBColumnType($specificModuleModel = null) {
+		$moduleModel = $this->moduleModel;
+		if($specificModuleModel){
+			$moduleModel = $specificModuleModel;
+		}
 		$db = PearDatabase::getInstance();
-		$result = $db->pquery('SELECT tablename FROM vtiger_field WHERE tabid=? GROUP BY tablename', array($this->moduleModel->getId()));
+		$result = $db->pquery('SELECT tablename FROM vtiger_field WHERE tabid=? GROUP BY tablename', array($moduleModel->getId()));
 		$tables = array();
 		if ($result && $db->num_rows($result) > 0) {
 			while ($row = $db->fetch_array($result)) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #401 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動のインポート時、管理画面から追加した項目があるとインポートに失敗する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポート時、仮テーブルを生成する際に、対象モジュールのカラム一覧を取得している。
2. そのカラム一覧から、インポート設定の画面で設定したフィールドをピックアップし、仮テーブルのカラムとしている。
3. その際、活動の場合だけ管理画面から追加したcf_xxxの形のフィールドが取得できていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. カレンダーの場合は別ルートでカラム一覧を取得するように修正。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/84055994/144415772-7f78c0f1-b561-4319-a0c6-e281eb61103e.png)
![image](https://user-images.githubusercontent.com/84055994/144415801-f56fa815-3f5c-4012-8ad4-d3fafdd98544.png)


## 影響範囲  / Affected Area
インポート機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->