### PR TITLE
fixed #384 共有リストではAll（すべて）が先頭に来るように修正

### DIFF
--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -1126,7 +1126,15 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		for ($i=0; $i<$noOfCVs; ++$i) {
 			$row = $db->query_result_rowdata($result, $i);
 			$customView = new self();
-			$customViews[] = $customView->setData($row)->setModule($row['entitytype']);
+			$cv = $customView->setData($row)->setModule($row['entitytype']);
+			// 「すべて」のリストは各モジュールでの標準のリストとして運用されるものであるが、
+			// 現状でも「All」であることから上部に表示されやすいとはいえ、00.---といったリストがあると下になってしまう為
+			// 共有リストの中では常に一番上に表示するようにする。
+			if($row['viewname'] == 'All'){
+				array_unshift($customViews, $cv);
+			}else{
+				$customViews[] = $cv;
+			}
 		}
 		return $customViews;
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #384 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 共有リストで「すべて」がフィルター名をソートした場所になる
2. 「すべて」は一番上にきてほしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ソートの結果順だから

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. array_shiftを使って「All」の場合は先頭にする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 個人リストには影響なし
- フィルターの表示順関係すべての並び順

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->