### PR TITLE
fixed #404 サービスモジュールのレポートクエリ生成時、UiType10Queryを呼び出すように修正

### DIFF
--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -2886,6 +2886,13 @@ class ReportRun extends CRMEntity {
 			$query .= " ".$this->getRelatedModulesQuery($module,$this->secondarymodule).
 					getNonAdminAccessControlQuery($this->primarymodule,$current_user).
 					" WHERE vtiger_crmentity.deleted = 0";
+		} else if ($module == "Services") {
+			$focus = CRMEntity::getInstance($module);
+			$query = $focus->generateReportsQuery($module, $this->queryPlanner) .
+					$focus->getReportsUiType10Query($module, $this->queryPlanner) .
+					$this->getRelatedModulesQuery($module, $this->secondarymodule) .
+					getNonAdminAccessControlQuery($this->primarymodule, $current_user) .
+					" WHERE vtiger_crmentity.deleted=0";
 		} else {
 			if ($module != '') {
 				$focus = CRMEntity::getInstance($module);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #404 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. サービスモジュールに関連フィールドを追加するとレポートが表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. サービスモジュールのレポートクエリ生成時、CRMEntity::getReportsUiType10Query()が呼び出されておらず、必要なテーブルがJOINされていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ReportRunQueryPlanner::getReportsQuery()にServicesモジュール用の分岐を追加し、CRMEntity::getReportsUiType10Query()を呼び出すように追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84055994/144583850-354ba13b-c045-4879-9986-fc8f02e22a6b.png)
![image](https://user-images.githubusercontent.com/84055994/144583888-b994a8de-576e-4972-9954-5a2eb4d718a3.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
サービスモジュールを含めたレポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->