### PR TITLE
fixed #363 ユーザー一覧の罫線を正常に表示させる

### DIFF
--- a/layouts/v7/modules/Users/ListViewContents.tpl
+++ b/layouts/v7/modules/Users/ListViewContents.tpl
@@ -60,8 +60,6 @@
 							{/if}
 						{/foreach}
 					</tr>
-				</thead>
-				<tbody class="overflow-y">
 					{if $MODULE_MODEL->isQuickSearchEnabled() && !$SEARCH_MODE_RESULTS}
 						<tr class="searchRow listViewSearchContainer">
                                                     <th class="user-inline-search-btn">
@@ -89,6 +87,8 @@
 							{/foreach}
 						</tr>
 					{/if}
+				</thead>
+				<tbody class="overflow-y">
 					{foreach item=LISTVIEW_ENTRY from=$LISTVIEW_ENTRIES name=listview}
 						<tr class="listViewEntries" data-id='{$LISTVIEW_ENTRY->getId()}' data-recordUrl='{$LISTVIEW_ENTRY->getDetailViewUrl()}&parentblock=LBL_USER_MANAGEMENT' id="{$MODULE}_listView_row_{$smarty.foreach.listview.index+1}">
 							<td class="listViewRecordActions">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #363 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー一覧の罫線が一部消えることがある

##  原因 / Cause
<!-- バグの原因を記述 -->
1. タグの位置が他のリストと異なっていた

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/84700230/144956909-8f910022-d9ec-43ec-a34c-871651f96ab3.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->