### PR TITLE
#371 マイグレーションでINDEXが効いていないuitype10(関連項目)にINDEXを追加する修正

### DIFF
--- a/modules/Migration/schema/735_to_736.php
+++ b/modules/Migration/schema/735_to_736.php
@@ -13,4 +13,19 @@ if (defined('VTIGER_UPGRADE')) {
     $db = PearDatabase::getInstance();
     // 契約モジュールにprimary keyを追加
     $db->pquery("alter table vtiger_servicecontracts add primary key (servicecontractsid)", array());
+
+    //uitype10にindexが付与される修正を加えた
+    //しかし、過去に作成したものはそのままであるためバージョンアップ時に付与する
+    $result = $adb->pquery("SELECT tablename,columnname FROM vtiger_field WHERE uitype=10");
+    $rows = $adb->num_rows($result);
+    for ($i = 0; $i < $rows; $i++) {
+        $tablename = $adb->query_result($result, $i, 'tablename');
+        $columnname = $adb->query_result($result, $i, 'columnname');
+        
+        $result_index = $adb->pquery('SHOW INDEX FROM '.$tablename.' WHERE Column_name="'.$columnname.'"');
+        $rows_index = $adb->num_rows($result_index);
+        if($rows_index == 0){
+            $adb->pquery("CREATE INDEX ".$columnname." ON ".$tablename."(".$columnname.")");
+        }
+    }
 }

--- a/modules/Migration/schema/735_to_736.php
+++ b/modules/Migration/schema/735_to_736.php
@@ -15,17 +15,25 @@ if (defined('VTIGER_UPGRADE')) {
     $db->pquery("alter table vtiger_servicecontracts add primary key (servicecontractsid)", array());
 
     //uitype10にindexが付与される修正を加えた
-    //しかし、過去に作成したものはそのままであるためバージョンアップ時に付与する
-    $result = $adb->pquery("SELECT tablename,columnname FROM vtiger_field WHERE uitype=10");
+    //しかし過去に作成したものはそのままであるため、バージョンアップ時に付与する
+    $result = $adb->pquery('SELECT f.tablename, f.columnname
+        FROM vtiger_fieldmodulerel AS fmrel
+        LEFT JOIN vtiger_field AS f
+        ON fmrel.fieldid = f.fieldid
+        WHERE f.tablename != "NULL"
+        ORDER BY f.tablename, f.columnname;');
     $rows = $adb->num_rows($result);
     for ($i = 0; $i < $rows; $i++) {
         $tablename = $adb->query_result($result, $i, 'tablename');
         $columnname = $adb->query_result($result, $i, 'columnname');
-        
-        $result_index = $adb->pquery('SHOW INDEX FROM '.$tablename.' WHERE Column_name="'.$columnname.'"');
-        $rows_index = $adb->num_rows($result_index);
-        if($rows_index == 0){
-            $adb->pquery("CREATE INDEX ".$columnname." ON ".$tablename."(".$columnname.")");
+        if($tablename != $tablename_old || $columnname != $columnname_old){ //同じクエリが連続して飛ぶケースを除外する
+            $result_index = $adb->pquery('SHOW INDEX FROM '.$tablename.' WHERE Column_name="'.$columnname.'"');
+            $rows_index = $adb->num_rows($result_index);
+            if($rows_index == 0){
+                $adb->pquery("CREATE INDEX ".$columnname." ON ".$tablename."(".$columnname.")");
+            }
         }
+        $tablename_old = $tablename;
+        $columnname_old = $columnname;
     }
 }

--- a/vtlib/Vtiger/FieldBasic.php
+++ b/vtlib/Vtiger/FieldBasic.php
@@ -201,6 +201,10 @@ class Vtiger_FieldBasic {
 
 		Vtiger_Profile::initForField($this);
 
+		if($this->uitype == 10){
+			$adb->pquery("CREATE INDEX ".$this->column." ON ".$this->table."(".$this->column.")");
+		}
+
 		self::log("Creating Field $this->name ... DONE");
 		self::log("Module language mapping for $this->label ... CHECK");
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #371 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 過去に生成された関連項目(uitype10)にindexが付与されない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 735_to_736のマイグレーションファイルにindexを付与する修正を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
 - 顧客企業に関連項目を追加した後、マイグレーション実行したケース
![image](https://user-images.githubusercontent.com/75693720/145332959-8e4b3cf7-2656-479a-984c-65e667a1965c.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - vtiger_fieldmodulerelに紐づけられたテーブルのindex

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->