### PR TITLE
#410　送信メールサーバーを設定した際に送られるメールの本文が英語になっている

### DIFF
--- a/modules/Settings/Vtiger/models/OutgoingServer.php
+++ b/modules/Settings/Vtiger/models/OutgoingServer.php
@@ -19,9 +19,9 @@ class Settings_Vtiger_OutgoingServer_Model extends Settings_Vtiger_Systems_Model
     
     public function getBody() {
         $currentUser = Users_Record_Model::getCurrentUserModel();
-        return 'Dear '.$currentUser->get('user_name').', <br><br><b> This is a test mail sent to confirm if a mail is 
-                actually being sent through the smtp server that you have configured. </b><br>Feel free to delete this mail.
-                <br><br>Thanks  and  Regards,<br> F-RevoCRM <br><br>';
+        return 'Dear '.$currentUser->get('user_name').', <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され
+                ているかどうかを確認するために送信されるテストメールです. </b><br>Feel 削除していただいてかまいません.
+                <br><br>よろしくお願いいたします。,<br> F-RevoCRM <br><br>';
     }
     
 	public function loadDefaultValues() {

--- a/modules/Settings/Vtiger/models/OutgoingServer.php
+++ b/modules/Settings/Vtiger/models/OutgoingServer.php
@@ -19,9 +19,9 @@ class Settings_Vtiger_OutgoingServer_Model extends Settings_Vtiger_Systems_Model
     
     public function getBody() {
         $currentUser = Users_Record_Model::getCurrentUserModel();
-        return 'Dear '.$currentUser->get('user_name').', <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され
-                ているかどうかを確認するために送信されるテストメールです. </b><br>Feel 削除していただいてかまいません.
-                <br><br>よろしくお願いいたします。,<br> F-RevoCRM <br><br>';
+        return $currentUser->get('user_name').'へ <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され
+                ているかどうかを確認するために送信されるテストメールです。 </b><br>削除していただいてかまいません。
+                <br><br>よろしくお願いいたします。<br> F-RevoCRM <br><br>';
     }
     
 	public function loadDefaultValues() {

--- a/modules/Settings/Vtiger/models/OutgoingServer.php
+++ b/modules/Settings/Vtiger/models/OutgoingServer.php
@@ -19,7 +19,7 @@ class Settings_Vtiger_OutgoingServer_Model extends Settings_Vtiger_Systems_Model
     
     public function getBody() {
         $currentUser = Users_Record_Model::getCurrentUserModel();
-        return $currentUser->get('user_name').'へ <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され
+        return $currentUser->get('user_name').'さん <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され
                 ているかどうかを確認するために送信されるテストメールです。 </b><br>削除していただいてかまいません。
                 <br><br>よろしくお願いいたします。<br> F-RevoCRM <br><br>';
     }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #410 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 送信メールサーバーを設定した際に送られる確認用メールを英語から日本語に変更。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. outgoingServer.phpファイル内の送信するメール文を修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/145343795-3ad5e44a-10b1-410f-9731-a8e352323970.png)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->