### PR TITLE
fixed #414 価格表モジュールのレポートクエリ生成時、UiType10Queryを呼び出すように修正

### DIFF
--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -2886,7 +2886,7 @@ class ReportRun extends CRMEntity {
 			$query .= " ".$this->getRelatedModulesQuery($module,$this->secondarymodule).
 					getNonAdminAccessControlQuery($this->primarymodule,$current_user).
 					" WHERE vtiger_crmentity.deleted = 0";
-		} else if ($module == "Services") {
+		} else if ($module == "Services" || $module == "PriceBooks") {
 			$focus = CRMEntity::getInstance($module);
 			$query = $focus->generateReportsQuery($module, $this->queryPlanner) .
 					$focus->getReportsUiType10Query($module, $this->queryPlanner) .


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #414 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 価格表モジュールに関連のフィールドを項目追加し、レポートにそのフィールドを表示すると、件数だけが表示され、表が表示されなくなる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 価格表モジュールのレポートクエリ生成時、CRMEntity::getReportsUiType10Query()が呼び出されておらず、必要なテーブルがJOINされていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ReportRunQueryPlanner::getReportsQuery()にPriceBooksモジュール用の分岐を追加し、CRMEntity::getReportsUiType10Query()を呼び出すように追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84055994/145359069-11e043d2-1c2c-403c-868f-975071371de4.png)
![image](https://user-images.githubusercontent.com/84055994/145359094-8023c4e6-80f5-4615-ab35-a770a1490cbc.png)

## 影響範囲  / Affected Area
価格表モジュールを含めたレポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
#404 同様のため、分岐を追加