### PR TITLE
#370 ワークフロー新規作成・保存後の遷移を対象モジュールのフィルターがかかったリストになるように修正

### DIFF
--- a/modules/Settings/Workflows/actions/SaveWorkflow.php
+++ b/modules/Settings/Workflows/actions/SaveWorkflow.php
@@ -135,6 +135,9 @@ class Settings_Workflows_SaveWorkflow_Action extends Vtiger_Action_Controller {
 
 		$returnPage = $request->get("returnpage", null);
 		$returnSourceModule = $request->get("returnsourcemodule", null);
+		if (empty($returnSourceModule)) {
+			$returnSourceModule = $request->get("module_name", null);
+		}
 		$returnSearchValue = $request->get("returnsearch_value", null);
 		$redirectUrl = $moduleModel->getDefaultUrl() . "&sourceModule=$returnSourceModule&page=$returnPage&search_value=$returnSearchValue";
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #370 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフロー新規作成・保存後の画面遷移で、フィルタが解除されて「全て　ワークフロー」になってしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 編集の場合はヘッダーのreturnSourceModuleに遷移前のフィルターモジュールが記録されるが,上部の新規追加のボタンはsettingsの共通部分なので値が入らない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. returnSourceModuleがない場合は保存するモジュールにがフィルターされたリストに遷移するように変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフロー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- モジュールのフィルターなし状態で保存した際にフィルターあり状態にするか,フィルターなし状態するかは微妙だが,現状フィルターありになる