### PR TITLE
#418 項目編集一覧画面で横2幅取るような項目の場合は、表示と一致するように修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -89,7 +89,8 @@
 							<ul name="{if $IS_FIELDS_SORTABLE}sortable1{else}unSortable1{/if}" class="connectedSortable col-sm-6">
 								{foreach item=FIELD_MODEL from=$FIELDS_LIST name=fieldlist}
 									{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
-                  <li>
+									{assign var=FIELD_UITYPE value=$FIELD_MODEL->get('uitype')}
+                  <li {if $FIELD_UITYPE == 19 || $FIELD_UITYPE == 20} class="wideField" {/if}>
                     <div class="row border1px">
                       <div class="col-sm-4">
                         <div class="opacity editFields marginLeftZero" data-block-id="{$BLOCK_ID}" data-field-id="{$FIELD_MODEL->get('id')}" 

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -582,3 +582,8 @@ ul#productsImageContainer > li a{
   background-repeat: no-repeat;
   background-position: center center;
 }
+
+/* 項目設定でuitype=19 or 20 の行を広げる*/
+.layoutContent .blockFieldsList ul li.wideField {
+  width: 92%;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #418 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目の並び順が見た目通りに変更できるようになったが、横2個分の項目の場合に並び順が以降ずれる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. uitype=19と20のフィールドは2列ぶんの幅を取るが設定画面ではそうなっていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. uitype=19と20のフィールドにwideFieldのclassを追加し、幅を広げた

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/146298825-cb6008b2-625d-4547-8f03-811ed032dc60.png)

## 影響範囲  / Affected Area
項目設定画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
uitype=19と20のカスタムフィールドは設定画面から作成できない