### PR TITLE
#420 タグを設定すると、編集内容が反映されない箇所の修正

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -125,8 +125,8 @@ class CRMEntity {
 			}
 		}
 		// tagのテーブルは$table_nameに入ってこないので別途追加
-		if($this->column_fields['tags'] != null && $this->mode == null){
-			$this->insertIntoTagsTable($module);
+		if($this->column_fields['tags'] != null && $_REQUEST['mode'] == 'import'){
+			$this->insertTags_atImportMode($module);
 		}
 		
 		$columnFields->restartTracking();
@@ -729,7 +729,7 @@ class CRMEntity {
 		}
 	}
 
-	function insertIntoTagsTable($module){
+	function insertTags_atImportMode($module){
         $db = PearDatabase::getInstance();
         $currentUser = Users_Record_Model::getCurrentUserModel();
 

--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -125,9 +125,10 @@ class CRMEntity {
 			}
 		}
 		// tagのテーブルは$table_nameに入ってこないので別途追加
-		// if($this->column_fields['tags'] != null){
-		// 	$this->insertIntoTagsTable($module);
-		// }
+		if($this->column_fields['tags'] != null){
+			$this->insertIntoTagsTable($module);
+			$hoge = $this->mode;
+		}
 		
 		$columnFields->restartTracking();
 		//Calling the Module specific save code
@@ -738,7 +739,16 @@ class CRMEntity {
 		$userId = $currentUser->getId();
 		$now = date("Y-m-d H:i:s");
 
-		$explodedValue = explode(' |##| ', $tagName);
+		//tagNameにカンマと' |##| 'が両方に含まれることは想定していない
+		$explodedValue = array();
+		if($tagName && strpos($tagName, ' |##| ') !== false){
+			$explodedValue = explode(' |##| ', $tagName);
+		}elseif($tagName && strpos($tagName, ',') !== false){
+			$explodedValue = explode(',', $tagName);
+		}elseif($tagName){
+			$explodedValue[0] = $tagName;
+		}
+
 		foreach ($explodedValue as $value) {
 			$id = $db->getUniqueId('vtiger_freetags');
 			$TagNotExist = true;
@@ -761,7 +771,7 @@ class CRMEntity {
 
 			/*タグの新規作成の必要確認
 			1. vtiger_freetagsに同名のタグがない → 作成
-			2. vtiger_freetagsに同名のタグがある → publicである → 作成しない
+			2. vtiger_freetagsに同名のタグがある → publicである  → 作成しない
 			3. 　　　　　　　　　                → privateである → ownerが自身 → 作成しない
 			4. 　　　　　　　　　                  　　　        → ownerが自身でない → 作成
 			*/

--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -125,9 +125,8 @@ class CRMEntity {
 			}
 		}
 		// tagのテーブルは$table_nameに入ってこないので別途追加
-		if($this->column_fields['tags'] != null){
+		if($this->column_fields['tags'] != null && $this->mode == null){
 			$this->insertIntoTagsTable($module);
-			$hoge = $this->mode;
 		}
 		
 		$columnFields->restartTracking();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #420
- fix #421 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. タグを複数個(tag1 tag2)登録した後、レコードの編集、これでタグが新しく生成される("tag1,tag2"というタグ)
2. タグを一つ登録した後、レコードの編集、これで編集内容が保存されなくなる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. CRMEntity.php内のinsertIntoTagsTable()関数がインポート時以外にも実行されていたため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インポート時のみ指定の処理が行われるように修正
2. カンマ区切りのタグ名が来た場合にも分割されるように修正
3. 関数名の変更(insertIntoTagsTable→insertTags_atImportMode)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - CRMEntityでの処理
  - [x] 新規レコードのインポート
 - [ ] インポートによる既存レコードの更新※
 - [x] 新規作成
 - [x] クイック作成
 - [x] 詳細画面から編集
 - [x] ワークフローからレコード作成
 - [x] 一括編集
 - [x] APIから更新
 
※インポートによる既存レコードの更新についてはバグがあるため検証できませんでした。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->