### PR TITLE
req#280 担当ユーザ選択で、自分を一番上に設定する

### DIFF
--- a/include/utils/utils.php
+++ b/include/utils/utils.php
@@ -162,7 +162,7 @@ function get_user_array($add_blank=true, $status="Active", $assigned_user="",$pr
 			 array_push($params, $assigned_user);
 		}
 
-		$query .= " order by user_name ASC";
+		$query .= " order by id = $current_user->id DESC, user_name ASC";
 
 		$result = $db->pquery($query, $params, true, "Error filling in user array: ");
 

--- a/layouts/v7/modules/Calendar/uitypes/OwnerFieldTaskSearchView.tpl
+++ b/layouts/v7/modules/Calendar/uitypes/OwnerFieldTaskSearchView.tpl
@@ -30,13 +30,8 @@
 		<optgroup label="{vtranslate('LBL_USERS')}">
 			{foreach key=OWNER_ID item=OWNER_NAME from=$ALL_ACTIVEUSER_LIST}
 				<option {if $OWNER_NAME|in_array:$TASK_FILTERS['assigned_user_id']}selected{/if} value="{$OWNER_NAME}" data-picklistvalue= '{$OWNER_NAME}'
-					{if array_key_exists($OWNER_ID, $ACCESSIBLE_USER_LIST)} data-recordaccess=true {else} data-recordaccess=false {/if}
-					data-userId="{$OWNER_ID}">
-					{if $OWNER_ID eq $USER_MODEL->getId()}
-						{vtranslate("LBL_MINE",$MODULE)}
-					{else}
-						{$OWNER_NAME}
-					{/if}
+					{if array_key_exists($OWNER_ID, $ACCESSIBLE_USER_LIST)} data-recordaccess=true {else} data-recordaccess=false {/if} data-userId="{$OWNER_ID}">
+					{$OWNER_NAME}
 				</option>
 			{/foreach}
 		</optgroup>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #280 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 担当ユーザ選択の際リストが登録順になっており、選択頻度の高い「自分」を探すのが面倒である
2. 自分の名前が「自分」になっており分かりづらい

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「自分」を一番上に設定する
2. 「自分」をユーザ名に変更する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/84700230/146851771-7b8218dd-65b1-4e3d-88ed-eeeb5f123c44.png)
登録順の場合「システム管理者」が一番上に設定されるが、この変更により、鈴木太郎（自分）が一番上に設定される。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
TODOリストの担当欄だけでなく、その他モジュールの担当欄でも適用される

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->