### PR TITLE
#391 ポータルの初期パスワードが簡単な英数で生成される問題の修正

### DIFF
--- a/vtlib/Vtiger/Functions.php
+++ b/vtlib/Vtiger/Functions.php
@@ -881,11 +881,11 @@ class Vtiger_Functions {
 	}
 
 	static function generateRandomPassword() {
-		$salt = "abcdefghijklmnopqrstuvwxyz0123456789";
+		$salt = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWZYG0123456789";
 		srand((double) microtime() * 1000000);
 		$i = 0;
 		while ($i <= 7) {
-			$num = rand() % 33;
+			$num = rand() % 62;
 			$tmp = substr($salt, $num, 1);
 			$pass = $pass . $tmp;
 			$i++;

--- a/vtlib/Vtiger/Functions.php
+++ b/vtlib/Vtiger/Functions.php
@@ -884,7 +884,7 @@ class Vtiger_Functions {
 		$salt = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWZYG0123456789";
 		srand((double) microtime() * 1000000);
 		$i = 0;
-		while ($i <= 7) {
+		while ($i <= 15) {
 			$num = rand() % 62;
 			$tmp = substr($salt, $num, 1);
 			$pass = $pass . $tmp;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #391 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ポータルの初期パスワードが簡単な英数で生成されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 小文字と数字のみで生成されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. パスワードの生成に用いる文字の選択肢に大文字を追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/146905507-e57ddd1e-cc1c-42bd-a258-240df8b959f0.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
generateRandomPasswordを用いてパスワードを生成する範囲に影響が想定される。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->