### PR TITLE
#307 カレンダーの詳細編集画面での一部表示の乱れを修正

### DIFF
--- a/layouts/v7/modules/Calendar/ModuleHeader.tpl
+++ b/layouts/v7/modules/Calendar/ModuleHeader.tpl
@@ -49,7 +49,7 @@
 					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{$RECORD->get('label')}&nbsp;</a></p>
 				{/if}
 			</div>
-			<div class="col-lg-5 col-md-5 pull-right">
+			<div class="col-lg-5 col-md-5 pull-right" style='position: absolute; right: 0%; top: 0px;width:72%; height;40px;'>
 				<div id="appnav" class="navbar-right">
 					<ul class="nav navbar-nav">
 						{foreach item=BASIC_ACTION from=$MODULE_BASIC_ACTIONS}

--- a/layouts/v7/modules/Calendar/ModuleHeader.tpl
+++ b/layouts/v7/modules/Calendar/ModuleHeader.tpl
@@ -10,7 +10,7 @@
 {strip}
 	<div class="col-sm-12 col-xs-12 module-action-bar coloredBorderTop">
 		<div class="module-action-content clearfix {$MODULE}-module-action-content">
-			<div class="col-lg-7 col-md-7 module-breadcrumb module-breadcrumb-{$smarty.request.view} transitionsAllHalfSecond">
+			<div class="col-lg-4 col-md-4 module-breadcrumb module-breadcrumb-{$smarty.request.view} transitionsAllHalfSecond">
 				{assign var=MODULE_MODEL value=Vtiger_Module_Model::getInstance($MODULE)}
 				{if $MODULE_MODEL->getDefaultViewName() neq 'List'}
 					{assign var=DEFAULT_FILTER_URL value=$MODULE_MODEL->getDefaultUrl()}
@@ -49,7 +49,7 @@
 					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{$RECORD->get('label')}&nbsp;</a></p>
 				{/if}
 			</div>
-			<div class="col-lg-5 col-md-5 pull-right" style='position: absolute; right: 0%; top: 0px;width:72%; height;40px;'>
+			<div class="col-lg-8 col-md-8 pull-right">
 				<div id="appnav" class="navbar-right">
 					<ul class="nav navbar-nav">
 						{foreach item=BASIC_ACTION from=$MODULE_BASIC_ACTIONS}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #307 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ウィンドウの横幅が1000ｐx前後のとき,カレンダーの詳細編集画面で｢カスタマイズ｣タブの位置がずれる.

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ウィンドウを小さくしたときにヘッダーの領域の大きさが足りず、表示が乱れていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「カスタマイズ」などがあるヘッダーの領域を大きくした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/147192108-42be3fbd-9e14-4251-9183-43bde802102b.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーのヘッダーの表示に関する範囲
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->