### PR TITLE
#246 リストで同名の関連フィールドが並んだ場合、項目名が全く同一となり見分けがつかない問題を修正

### DIFF
--- a/languages/ja_jp/Products.php
+++ b/languages/ja_jp/Products.php
@@ -50,6 +50,7 @@ $languageStrings = array(
 	'Unit Price'=>'単価',
 	'Commission Rate'=>'手数料率 (%)',
 	'Qty/Unit'=>'数量/ユニット',
+	'Product' => '製品',
 	
 	//Added for existing picklist entries
 

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -104,7 +104,10 @@
 									<i class="fa fa-sort customsort"></i>
 								{/if}
 							{/if}
-							&nbsp;{vtranslate($LISTVIEW_HEADER->get('label'), $LISTVIEW_HEADER->getModuleName())}&nbsp;
+							{if $LISTVIEW_HEADER->parentFieldName}
+								{vtranslate($LISTVIEW_HEADER->parentFieldName, $LISTVIEW_HEADER->getModuleName())}&nbsp;-
+							{/if}
+							{vtranslate($LISTVIEW_HEADER->get('label'), $LISTVIEW_HEADER->getModuleName())}
 						</a>
 						{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}
 							<a href="#" class="removeSorting"><i class="fa fa-remove"></i></a>

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -375,6 +375,16 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$this->allUserTags = Vtiger_Tag_Model::getAllUserTags($currentUser->getId());
 		}
 
+		foreach ($this->listViewHeaders as $headerFieldModel) {
+			$headerfieldName = $headerFieldModel->name;
+			$parsedFieldName = preg_split("/\s\;\s\(|^\(|\)$/", $headerfieldName, -1, PREG_SPLIT_NO_EMPTY)[0];
+			if (preg_match("/^\(.*\s\;\s\(.*\)\s.*\)$/", $headerfieldName)) {
+				$parsedFieldModuleModel = Vtiger_Module_Model::getInstance($moduleName);
+				$parsedFieldModel = Vtiger_Field_Model::getInstance($parsedFieldName, $parsedFieldModuleModel);
+				$this->listViewHeaders[$headerfieldName]->set("parentFieldName", $parsedFieldModel->get('label'));
+			}
+		}
+
 		$listViewController = $listViewModel->get('listview_controller');
 		$selectedHeaderFields = $listViewController->getListViewHeaderFields();
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #246 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストで同名の関連フィールドが並んだ場合、項目名が全く同一となり見分けがつかない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 関連の場合、親モジュールのフィールド名と関連モジュールのフィールド名が文字列結合されて配列に格納されているので扱いにくい

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. リストの追加時と同様にカスタムフィールド名を表示するように変更

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/147211936-15b6b2a5-2ade-4331-a5a2-2f76bba2f494.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
各モジュールのヘッダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
｢製品｣の和訳が当たらない場合があったので言語ファイルを追加