### PR TITLE
#398 ワークフローのアクション(レコードの作成)における一部表示の乱れを修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/Tasks/VTCreateEntityTask.tpl
+++ b/layouts/v7/modules/Settings/Workflows/Tasks/VTCreateEntityTask.tpl
@@ -13,7 +13,7 @@
 	<div class="row">
         <div class="col-lg-9">
             <div class="row">
-                <div class="col-lg-2" style="position:relative;top:4px;padding-right: 0px;">
+                <div class="col-lg-2" style="position:relative;top:-8px;padding-right: 0px;">
                     {vtranslate('LBL_MODULES_TO_CREATE_RECORD',$QUALIFIED_MODULE)} <span class="redColor">*</span>
                 </div>
                 <div class="col-lg-10">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #398 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画面の幅を小さくした際に、一部表示が乱れる箇所があった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. タグのスタイル属性における文字の表示位置がずれていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 表示位置を12px上にずらした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/148017987-b9eec675-392a-4fc8-9229-7d1c45d5312c.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
この箇所のみ
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->