### PR TITLE
#138 レポート作成画面において画面幅が狭いときの一部表示の乱れを修正

### DIFF
--- a/layouts/v7/modules/Vtiger/BreadCrumbs.tpl
+++ b/layouts/v7/modules/Vtiger/BreadCrumbs.tpl
@@ -16,8 +16,10 @@
 			<li class="step {if $smarty.foreach.breadcrumbLabels.first} first {$FIRSTBREADCRUMB} {else} {$ADDTIONALCLASS} {/if} {if $smarty.foreach.breadcrumbLabels.last} last {/if} {if $ACTIVESTEP eq $INDEX}active{/if}"
 				id="{$CRUMBID}" data-value="{$INDEX}" style="z-index:{$ZINDEX}">
 				<a href="#">
-					<span class="stepNum">{$INDEX}</span>
-					<span class="stepText" title="{vtranslate($STEPTEXT,$MODULE)}">{vtranslate($STEPTEXT,$MODULE)}</span>
+						<div class="header_workflow">
+							<span class="stepNum">{$INDEX}</span>
+							<span class="stepText" title="{vtranslate($STEPTEXT,$MODULE)}">{vtranslate($STEPTEXT,$MODULE)}</span>
+						</div>
 				</a>
 			</li>
 			{assign var=ZINDEX value=$ZINDEX-1}

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -2866,7 +2866,7 @@ input[type="text"]:read-only {
 }
 .header_workflow {
   white-space: nowrap;
-}aaaaaa
+}
 
 .crumbs {
   height: 40px;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -2864,6 +2864,10 @@ input[type="text"]:read-only {
   height: auto;
   background: #FBFBFB;
 }
+.header_workflow {
+  white-space: nowrap;
+}aaaaaa
+
 .crumbs {
   height: 40px;
   margin: 0;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #138 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポート作成画面において画面幅が狭いときに改行されてしまい、綺麗に表示されなかった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インライン要素に設定されているため通常時は正しく表示されるのだが、画面の幅が狭くなると領域が足りず改行されてしまう。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 強制的に横に並ぶように一つの要素で括り、関数を適用して横並びになるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/148036613-8ce8bac5-db56-4550-9d21-2e2f521ead5f.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポート追加の範囲のみ
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
CSSファイルに.header_workflowという変数を作ったため、この先この名前の変数を用いる