### PR TITLE
#440 顧客企業の概要画面で非公開の活動の「詳細内容」が確認できてしまう問題を修正

### DIFF
--- a/modules/Accounts/models/Module.php
+++ b/modules/Accounts/models/Module.php
@@ -373,7 +373,7 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 			$model = Vtiger_Record_Model::getCleanInstance('Calendar');
 			$ownerId = $newRow['smownerid'];
 			$currentUser = Users_Record_Model::getCurrentUserModel();
-			$visibleFields = array('activitytype','date_start','time_start','due_date','time_end','assigned_user_id','visibility','smownerid','crmid', 'description');
+			$visibleFields = array('activitytype','date_start','time_start','due_date','time_end','assigned_user_id','visibility','smownerid','crmid');
 			$visibility = true;
 			if(in_array($ownerId, $groupsIds)) {
 				$visibility = false;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #440

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 顧客企業モジュールでのみ非公開の活動の詳細内容が権限のないユーザーで閲覧可能となっている。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 顧客企業モジュールのみ`getCalendarActivities`関数の配列`$visibleFields`に`'description'`が含まれているため、非公開であっても詳細内容が表示される

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 配列`$visibleFields`から`'description'`を削除

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/148317898-9cbf22d0-1226-40fb-819e-fd308ef8f768.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
顧客企業の詳細表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 関連のリストビューでは`modules\Vtiger\models\RelationListView.php`の`getEntries`関数でカレンダーを取得している
- `getCalendarActivities`関数をoverrideしている主要モジュールは顧客企業と顧客担当者のみ