### PR TITLE
#392 活動のインポート時に一般ユーザが表示できなくなる 問題を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -1045,7 +1045,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							} else {
 								$recordData[$fieldName] = false;
 							}
-						} else if (!in_array($fieldName, array('date_start', 'due_date'))) {
+						} else if (!in_array($fieldName, array('date_start', 'due_date', 'visibility', 'eventstatus', 'taskstatus', 'activitytype'))) {
 							if ($fieldModel) {
 								$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
 							}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #392 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動のインポート時に、項目：表示（公開、非公開）の値が"Public"ではなく"公開"とカラムに登録されるため、一般ユーザが表示できなくなる 

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポートしたレコードに翻訳がかけられて保存されてしまう

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 翻訳の例外に複数のフィールド('visibility', 'eventstatus', 'taskstatus', 'activitytype')を追加

## スクリーンショット / Screenshot
上が修正前に、下が修正後にインポートしたレコード
![image](https://user-images.githubusercontent.com/53038605/149256084-6d09dcdf-76b6-4f5b-a64c-2d16cb753a50.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーモジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->