### PR TITLE
#424 カスタムフィールドを追加する上限を設定できるように修正

### DIFF
--- a/config.template.php
+++ b/config.template.php
@@ -171,6 +171,9 @@ $php_max_execution_time = 0;
 // Set the default timezone as per your preference
 $default_timezone = 'Asia/Tokyo';
 
+// Set the maximum number of custom fields per module
+$custom_field_limit = 200;
+
 /** If timezone is configured, try to set it */
 if(isset($default_timezone) && function_exists('date_default_timezone_set')) {
 	@date_default_timezone_set($default_timezone);

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1140,6 +1140,7 @@ $languageStrings = array(
 	'LBL_UNLINK'=>'関連を外す',
 	'LBL_SWITCH_TO_OLD'=>'過去のバージョンに戻す',
 	'LBL_SLA_INFORMATION' => 'SLA情報',
+	'LBL_CUSTOM_FIELD_LIMIT' => 'カスタムフィールドの登録数上限に達しています',
 
 	//configure columns
 	'LBL_UPDATE_LIST' => 'リストの更新',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #424

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カスタムフィールドを無制限に追加できるため、DB側の許容量を超過する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. カスタムフィールドの上限数が存在しない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. モジュールあたり200個をデフォルトのカスタムフィールド上限に設定
2. config.inc.php (config.template.php)に上限数のグローバル変数`$custom_field_limit`を追加
3. ` $custom_field_limit`を超過した場合カスタムフィールドの追加がエラーとなるように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カスタムフィールド関連、全モジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- config.inc.phpはインストール時に生成されるため、既存の環境では自ら`$custom_field_limit = 200;`を追加する必要あり
- `$custom_field_limit`が設定されていない環境では修正を適用しても上限は適用されずに追加可能
- インストール時に`$custom_field_limit = 200;`が生成されることは確認済み