### PR TITLE
#190 ユーザー詳細画面でアイコンが隠れる不具合の修正

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
@@ -11,8 +11,8 @@
 
 {strip}
 	<div class="col-sm-12 col-xs-12 module-action-bar coloredBorderTop">
-		<div class="module-action-content clearfix">
-			<div class="col-lg-7 col-md-7">
+		<div class="module-action-content clearfix ">
+			<div class="col-lg-7 col-md-7 textOverflowTest">
 				{if $USER_MODEL->isAdminUser()}
 					<a title="{vtranslate('Home', $MODULE)}" href='index.php?module=Vtiger&parent=Settings&view=Index'>
 						<h4 class="module-title pull-left text-uppercase">{vtranslate('LBL_HOME', $MODULE)} </h4>

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -249,6 +249,10 @@ div.detailview-content.container-fluid span.value img {
 }
 .module-action-bar.coloredBorderTop {
   width: calc(100% - 42px);
+  height: 90px;
+}
+.textOverflowTest{
+	width: 600px;
 }
 @media all and (min-width:992px) and (max-width: 1290px) {
     .global-nav .app-list {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #190 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. スマホで利用する際にユーザー詳細画面でアイコンが隠れてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 画面幅が小さいと名前などの文字が折り返されてしまい、ヘッダーが下のほうまで伸びてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 折り返されないように表示領域を大きくした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/149295581-cf813548-d3c7-4d8c-be93-d56aca654500.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー詳細画面のヘッダーに関する範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->