### PR TITLE
#427 ワークフロー作成時の条件において、モジュール＝活動のカラム選択に開始時間・終了時間が選択できない箇所の修正

### DIFF
--- a/modules/Settings/Workflows/models/Field.php
+++ b/modules/Settings/Workflows/models/Field.php
@@ -74,7 +74,7 @@ class Settings_Workflows_Field_Model extends Vtiger_Field_Model {
 			'multipicklist' => array('is', 'is not','contains','does not contain', 'has changed', 'has changed to'),
 			'datetime' => array('is', 'is not', 'has changed', 'before', 'after', 'is today', 'is tomorrow', 'is yesterday', 'less than hours before', 'less than hours later',
 				'more than hours before', 'more than hours later', 'less than days ago', 'less than days later', 'more than days ago', 'more than days later', 'days ago', 'days later', 'is empty', 'is not empty'),
-			'time' => array('is', 'is not', 'has changed', 'is not empty'),
+			'time' => array('is', 'is not', 'less than', 'greater than', 'less than or equal to', 'greater than or equal to', 'between', 'before', 'after', 'is empty', 'is not empty'),
 			'date' => array('is', 'is not', 'has changed', 'between', 'before', 'after', 'is today', 'is tomorrow', 'is yesterday', 'less than days ago', 'more than days ago', 'less than days later',
 				'more than days later', 'in less than', 'in more than', 'days ago', 'days later', 'is empty', 'is not empty'),
 			'boolean' => array('is', 'is not', 'has changed'),

--- a/modules/Settings/Workflows/models/Field.php
+++ b/modules/Settings/Workflows/models/Field.php
@@ -74,7 +74,7 @@ class Settings_Workflows_Field_Model extends Vtiger_Field_Model {
 			'multipicklist' => array('is', 'is not','contains','does not contain', 'has changed', 'has changed to'),
 			'datetime' => array('is', 'is not', 'has changed', 'before', 'after', 'is today', 'is tomorrow', 'is yesterday', 'less than hours before', 'less than hours later',
 				'more than hours before', 'more than hours later', 'less than days ago', 'less than days later', 'more than days ago', 'more than days later', 'days ago', 'days later', 'is empty', 'is not empty'),
-			'time' => array('is', 'is not', 'less than', 'greater than', 'less than or equal to', 'greater than or equal to', 'between', 'before', 'after', 'is empty', 'is not empty'),
+			'time' => array('is', 'is not', 'less than', 'greater than', 'less than or equal to', 'greater than or equal to', 'between'),
 			'date' => array('is', 'is not', 'has changed', 'between', 'before', 'after', 'is today', 'is tomorrow', 'is yesterday', 'less than days ago', 'more than days ago', 'less than days later',
 				'more than days later', 'in less than', 'in more than', 'days ago', 'days later', 'is empty', 'is not empty'),
 			'boolean' => array('is', 'is not', 'has changed'),

--- a/modules/Settings/Workflows/models/FilterRecordStructure.php
+++ b/modules/Settings/Workflows/models/FilterRecordStructure.php
@@ -34,10 +34,14 @@ class Settings_Workflows_FilterRecordStructure_Model extends Settings_Workflows_
 					if($fieldModel->isViewableInFilterView()) {
 						if (in_array($moduleModel->getName(), array('Calendar', 'Events')) && $fieldModel->getDisplayType() == 3) {
 							/* Restricting the following fields(Event module fields) for "Calendar" module
-							 * time_start, time_end, eventstatus, activitytype,	visibility, duration_hours,
+							 * eventstatus, activitytype,	visibility, duration_hours,
 							 * duration_minutes, reminder_time, recurringtype, notime
 							 */
-							continue;
+							
+							// time_start(開始時間), time_end(終了時間)は追加してほしい要望があったので除外しない
+							if($fieldName != 'time_start' && $fieldName != 'time_end'){
+								continue;
+							}
 						}
 						if(!empty($recordId)) {
 							//Set the fieldModel with the valuetype for the client side.

--- a/modules/Settings/Workflows/models/FilterRecordStructure.php
+++ b/modules/Settings/Workflows/models/FilterRecordStructure.php
@@ -38,8 +38,12 @@ class Settings_Workflows_FilterRecordStructure_Model extends Settings_Workflows_
 							 * duration_minutes, reminder_time, recurringtype, notime
 							 */
 							
-							// time_start(開始時間), time_end(終了時間)は追加してほしい要望があったので除外しない
-							if($fieldName != 'time_start' && $fieldName != 'time_end'){
+							/* 活動にtime_start(開始時間), time_end(終了時間)を
+							 * TODOにtime_startを追加してほしい要望があったので除外しない
+							 */
+							if($moduleModel->getName() == 'Events' && $fieldName != 'time_start' && $fieldName != 'time_end'){
+								continue;
+							}else if($moduleModel->getName() == 'Calendar' && $fieldName != 'time_start'){
 								continue;
 							}
 						}

--- a/modules/com_vtiger_workflow/VTJsonCondition.inc
+++ b/modules/com_vtiger_workflow/VTJsonCondition.inc
@@ -211,12 +211,19 @@ class VTJsonCondition {
 		}
 
 		if($fieldInstance && $fieldInstance->getFieldDataType() == 'time') {
-			if(strpos($value,'AM') !== false || strpos($value,'PM') !== false){
-				$value = date('H:i', strtotime($value));
-			}
-
-			if($value){
-				$value = $value.':00';	// time fields will not have seconds appended to it, so we are adding 
+			if($condition != 'between'){
+				if(strpos($value,'AM') !== false || strpos($value,'PM') !== false){
+					$value = date('H:i', strtotime($value));
+				}
+	
+				if($value){
+					$value = $value.':00';	// time fields will not have seconds appended to it, so we are adding 
+				}
+			}else{ // 例) "12:00 AM,12:30 AM" → "12:00:00,12:30:00"
+				$values = explode(',', $value);
+				$values[0] = date('H:i', strtotime($values[0]));
+				$values[1] = date('H:i', strtotime($values[1]));
+				$value = $values[0].':00,'.$values[1].':00';
 			}
 		}
 
@@ -391,7 +398,9 @@ class VTJsonCondition {
 					return false;
 				}
 				$values = explode(',', $value);
-				$values = array_map('getValidDBInsertDateValue',$values);
+				if(preg_match('/^(0[0-9]{1}|1{1}[0-9]{1}|2{1}[0-3]{1}):(0[0-9]{1}|[1-5]{1}[0-9]{1}):(0[0-9]{1}|[1-5]{1}[0-9]{1})$/', $values[0]) == false){
+					$values = array_map('getValidDBInsertDateValue',$values);
+				}
 				if($fieldValue > $values[0] && $fieldValue < $values[1]) {
 					return true;
 				}

--- a/modules/com_vtiger_workflow/VTJsonCondition.inc
+++ b/modules/com_vtiger_workflow/VTJsonCondition.inc
@@ -211,6 +211,10 @@ class VTJsonCondition {
 		}
 
 		if($fieldInstance && $fieldInstance->getFieldDataType() == 'time') {
+			if(strpos($value,'AM') !== false || strpos($value,'PM') !== false){
+				$value = date('H:i', strtotime($value));
+			}
+
 			if($value){
 				$value = $value.':00';	// time fields will not have seconds appended to it, so we are adding 
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #427 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動とTODOにて開始時間・終了時間が選択できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 条件から開始時間・終了時間が除外されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動では開始時間・終了時間、TODOでは開始時間のみ選択できるように修正
2. 時刻同士の比較をできるように修正
 - Field.php>getAdvancedFilterOpsByFieldType()内のtimeに変更を加えているが、ワークフローにおいてtimeが出現するのは開始時間・終了時間だけであったので変更の影響はないと判断した
 - "範囲"の条件について、カンマ区切りで指定することで適応させるようにした(下画像)
![image](https://user-images.githubusercontent.com/75693720/149300940-588be01c-a6b6-4bad-9e17-7d1d140d0b76.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - ワークフローの編集画面
 - ワークフロー挙動

## チェックリスト / Check List
 - クイック作成/更新時/詳細編集/活動のマウス移動にてワークフローが実行されることを確認
 - 活動/TODOにて追加した条件全てでワークフローが実行されることを確認

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->