### PR TITLE
#362 カレンダーのリストビューにおいて｢次の予定を登録する｣アイコンが表示されなくなる不具合を修正

### DIFF
--- a/layouts/v7/modules/Calendar/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/Calendar/ListViewRecordActions.tpl
@@ -30,11 +30,11 @@
 			</span>
 		{/if}
 		{assign var=EDIT_VIEW_URL value={$LISTVIEW_ENTRY->getEditViewUrl()}}
-		{if $IS_MODULE_EDITABLE && $EDIT_VIEW_URL && $LISTVIEW_ENTRY->get('taskstatus') neq vtranslate('Held', $MODULE) && $LISTVIEW_ENTRY->get('taskstatus') neq vtranslate('Completed', $MODULE)}
-			<span class="fa fa-check icon action markAsHeld" title="{vtranslate('LBL_MARK_AS_HELD', $MODULE)}" onclick="Calendar_Calendar_Js.markAsHeld('{$LISTVIEW_ENTRY->getId()}');"></span>
-		{/if}
-		{if $IS_CREATE_PERMITTED && $EDIT_VIEW_URL && $LISTVIEW_ENTRY->get('taskstatus') eq vtranslate('Held', $MODULE)}
+		{assign var="CALENDAR_RECORD_MODEL" value=Vtiger_Record_Model::getInstanceById($LISTVIEW_ENTRY->get("id"))}
+		{if $IS_CREATE_PERMITTED && $EDIT_VIEW_URL && ( $CALENDAR_RECORD_MODEL->get('eventstatus') eq 'Held' || $CALENDAR_RECORD_MODEL->get('taskstatus') eq 'Completed' )}
 			<span class="fa fa-flag icon action holdFollowupOn" title="{vtranslate('LBL_HOLD_FOLLOWUP_ON', "Events")}" onclick="Calendar_Calendar_Js.holdFollowUp('{$LISTVIEW_ENTRY->getId()}');"></span>
+		{elseif $IS_MODULE_EDITABLE && $EDIT_VIEW_URL }
+			<span class="fa fa-check icon action markAsHeld" title="{vtranslate('LBL_MARK_AS_HELD', $MODULE)}" onclick="Calendar_Calendar_Js.markAsHeld('{$LISTVIEW_ENTRY->getId()}');"></span>
 		{/if}
 		<span class="more dropdown action">
 			<span href="javascript:;" class="dropdown-toggle" data-toggle="dropdown">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #362 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーのリストビューにおいて、｢次の予定を登録する｣アイコンがステータス(TODO)がリストに含まれる場合のみでしか表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. テンプレートファイルでアイコンの表示を制御する際に、表示するリストからステータスを取得しているため、リストにステータスがない場合、たとえステータスが｢完了｣でも｢次の予定を登録する｣アイコンが表示されない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. レコードIDからステータスを取得し、ステータスがリストに無い場合でも表示できるように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーのリスト表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- リストビューの｢ステータス｣には内部的に｢ステータス(活動)｣と｢ステータス(TODO)｣が存在する
- ｢ステータス(活動)｣は活動のステータスのみを表示する
- ｢ステータス(TODO)｣は活動とTODO両方のステータスを表示する