### PR TITLE
#455 ヘッダー部分におけるモジュール名の表示の乱れを修正

### DIFF
--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -377,7 +377,7 @@ body > .mCSB_inside > .mCSB_container {
   overflow: hidden;
   max-width: 223px;
   text-overflow: ellipsis;
-  font-size: 15px;
+  font-size: 12px;
 }
 .module-action-bar .module-breadcrumb {
   padding-left: 11px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #455 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画面左上のモジュール名のフォントの大きさが一部乱れていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. cssのフォントサイズが間違っていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. cssのmodule-titleの部分を修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/150275000-529fa80c-fd2d-4a2b-888b-798ec28fe92a.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
すべてのモジュールのヘッダー部分の範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->