### PR TITLE
#461 メニュー設定においてのモジュールアイコンの表示位置の修正

### DIFF
--- a/layouts/v7/modules/Settings/MenuEditor/Index.tpl
+++ b/layouts/v7/modules/Settings/MenuEditor/Index.tpl
@@ -16,43 +16,44 @@
 			<div class=" vt-default-callout vt-info-callout">
 				<h4 class="vt-callout-header"><span class="fa fa-info-circle"></span>{vtranslate('LBL_INFO', $QUALIFIED_MODULE_NAME)}</h4>
 				<p>{vtranslate('LBL_MENU_EDITOR_INFO', $QUALIFIED_MODULE_NAME)}</p>
-			</div>
-		</div>
-	</div>
-	<div class="col-lg-12" style="margin-top: 10px;">
-		<div class="row" style="margin-left: -28px;">
-			{assign var=APP_LIST value=Vtiger_MenuStructure_Model::getAppMenuList()}
-			{foreach item=APP_IMAGE key=APP_NAME from=$APP_IMAGE_MAP name=APP_MAP}
-				{if !in_array($APP_NAME, $APP_LIST)} {continue} {/if}
-				<div class="col-lg-2{if $smarty.foreach.APP_MAP.index eq 0 or count($APP_LIST) eq 1}{/if}">
-					<div class="menuEditorItem app-{$APP_NAME}" data-app-name="{$APP_NAME}">
-						<span class="fa {$APP_IMAGE}"></span>
-						{assign var=TRANSLATED_APP_NAME value={vtranslate("LBL_$APP_NAME")}}
-						<div class="textOverflowEllipsis" title="{$TRANSLATED_APP_NAME}">{$TRANSLATED_APP_NAME}</div>
-					</div>
-					<div class="sortable appContainer" data-appname="{$APP_NAME}">
-						{foreach key=moduleName item=moduleModel from=$APP_MAPPED_MODULES[$APP_NAME]}
-							<div class="modules noConnect" data-module="{$moduleName}">
-								<i data-appname="{$APP_NAME}" class="fa fa-times pull-right whiteIcon menuEditorRemoveItem" style="margin: 5%;padding-top:15px;"></i>
-								<div class="menuEditorItem menuEditorModuleItem">
-									<span class="pull-left marginRight10px marginTop5px">
-										<img class="alignMiddle cursorDrag" src="{vimage_path('drag.png')}"/>
-									</span>
-									{assign var='translatedModuleLabel' value=vtranslate($moduleModel->get('label'),$moduleName )}
-									<span>
-										<span class="marginRight10px marginTop5px pull-left IconSize">{$moduleModel->getModuleIcon()}</span>
-									</span>
-									<div class="textOverflowEllipsis marginTop5px textAlignLeft" title="{$translatedModuleLabel}">{$translatedModuleLabel}</div>
+				</div>
+				<div class="col-lg-12" style="margin-top: 10px;">
+					<div class="row" style="margin-left: -28px;">
+						{assign var=APP_LIST value=Vtiger_MenuStructure_Model::getAppMenuList()}
+						{foreach item=APP_IMAGE key=APP_NAME from=$APP_IMAGE_MAP name=APP_MAP}
+							{if !in_array($APP_NAME, $APP_LIST)} {continue} {/if}
+							<div class="col-lg-2{if $smarty.foreach.APP_MAP.index eq 0 or count($APP_LIST) eq 1}{/if}">
+								<div class="menuEditorItem app-{$APP_NAME}" data-app-name="{$APP_NAME}">
+									<span class="fa {$APP_IMAGE}"></span>
+									{assign var=TRANSLATED_APP_NAME value={vtranslate("LBL_$APP_NAME")}}
+									<div class="textOverflowEllipsis" title="{$TRANSLATED_APP_NAME}">{$TRANSLATED_APP_NAME}</div>
+								</div>
+								<div class="sortable appContainer" data-appname="{$APP_NAME}">
+									{foreach key=moduleName item=moduleModel from=$APP_MAPPED_MODULES[$APP_NAME]}
+										<div class="modules noConnect" data-module="{$moduleName}">
+											<i data-appname="{$APP_NAME}" class="fa fa-times pull-right whiteIcon menuEditorRemoveItem" style="margin: 5%;padding-top:15px;"></i>
+											<div class="menuEditorItem menuEditorModuleItem">
+												<span class="pull-left marginRight10px marginTop5px">
+													<img class="alignMiddle cursorDrag" src="{vimage_path('drag.png')}"/>
+												</span>
+												{assign var='translatedModuleLabel' value=vtranslate($moduleModel->get('label'),$moduleName )}
+												<span>
+													<span class="marginRight10px marginTop5px pull-left IconSize">{$moduleModel->getModuleIcon()}</span>
+												</span>
+												<div class="textOverflowEllipsis marginTop5px textAlignLeft" title="{$translatedModuleLabel}">{$translatedModuleLabel}</div>
+											</div>
+										</div>
+									{/foreach}
+									<div class="menuEditorItem menuEditorModuleItem menuEditorAddItem" data-appname="{$APP_NAME}">
+										<i class="fa fa-plus pull-left marginTop5px"></i>
+										<div class="marginTop10px">{vtranslate('LBL_SELECT_HIDDEN_MODULE', $QUALIFIED_MODULE_NAME)}</div>
+									</div> 
 								</div>
 							</div>
 						{/foreach}
-						<div class="menuEditorItem menuEditorModuleItem menuEditorAddItem" data-appname="{$APP_NAME}">
-							<i class="fa fa-plus pull-left marginTop5px"></i>
-							<div class="marginTop10px">{vtranslate('LBL_SELECT_HIDDEN_MODULE', $QUALIFIED_MODULE_NAME)}</div>
-						</div> 
-					</div>
+					
 				</div>
-			{/foreach}
+			</div>
 		</div>
 	</div>
 </div>

--- a/layouts/v7/modules/Settings/MenuEditor/Index.tpl
+++ b/layouts/v7/modules/Settings/MenuEditor/Index.tpl
@@ -18,7 +18,7 @@
 				<p>{vtranslate('LBL_MENU_EDITOR_INFO', $QUALIFIED_MODULE_NAME)}</p>
 				</div>
 				<div class="col-lg-12" style="margin-top: 10px;">
-					<div class="row" style="margin-left: -28px;">
+					<div class="row" style="margin-left: -28px; display: flex;flex-wrap: wrap;">
 						{assign var=APP_LIST value=Vtiger_MenuStructure_Model::getAppMenuList()}
 						{foreach item=APP_IMAGE key=APP_NAME from=$APP_IMAGE_MAP name=APP_MAP}
 							{if !in_array($APP_NAME, $APP_LIST)} {continue} {/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #461 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ウィンドウの横幅が特定の幅になったときにメニュー設定においてマーケティングのアイコンの表示の位置がおかしい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. cssにてposition:relativeに設定されていたが、relativeの基準となる位置がほかのタグと被ってしまっていたため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. relativeの基準がうまくいくようにタグの範囲を直した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/150296411-140f23e3-da69-4dba-8696-1d287a03ac73.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
システム構成>メニュー設定の範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->