### PR TITLE
#389 一覧画面で一部の区切り線が消える不具合を修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -19,8 +19,21 @@
     z-index: 1;
     left: 0;
     background: #fff;
-    transform: scale(0.999);
     background-clip: padding-box;
+  }
+  .listViewRecordActions.fix-data-column {
+    border-top: 0px !important;
+    border-bottom: 0px !important;
+  }
+  .listViewEntryValue {
+    border-top: 0px !important;
+    border-bottom: 0px !important;
+  }
+  .listViewEntries {
+    border-bottom: 1px solid #ddd;
+  }
+  .listViewEntries:last-child {
+    border-bottom: 0px;
   }
 }
 /*


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #389 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 各モジュールの一覧画面を開いたとき、先頭項目の区切り線が一部消えているものがある。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `transform: scale(0.999)`で表の要素を微妙に縮小していたため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 縮小を外し、行ごとに`margin-bottom`で線を引くように変更

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/150311107-720ee948-326e-4984-825a-c5ee951d99ea.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->