### PR TITLE
#458「非表示のモジュールを選択」を選択したときの表示の乱れの修正

### DIFF
--- a/languages/ja_jp/Settings/MenuEditor.php
+++ b/languages/ja_jp/Settings/MenuEditor.php
@@ -14,6 +14,7 @@ $languageStrings = array(
     'LBL_SELECT_INVENTORY_MODULES' => '販売管理に表示するモジュールを選択してください',
     'LBL_SELECT_SUPPORT_MODULES' => 'サポートに表示するモジュールを選択してください',
     'LBL_SELECT_PROJECT_MODULES' => 'プロジェクトに表示するモジュールを選択してください',
+    'LBL_SELECT_TOOLS_MODULES'   => 'ツールに表示するモジュールを選択してください',
     'LBL_SELECT_HIDDEN_MODULE' => '非表示のモジュールを選択',
     'LBL_INFO' => 'メモ',
     'LBL_MENU_EDITOR_INFO' => 'モジュールをドラッグ＆ドロップして、移動/並べ替えます。メニューからモジュールを削除して、後で再び追加することができます。',

--- a/layouts/v7/modules/Settings/MenuEditor/AddModule.tpl
+++ b/layouts/v7/modules/Settings/MenuEditor/AddModule.tpl
@@ -13,15 +13,15 @@
 		<div class="modal-content">
 			<input id="appname" type="hidden" name="appname" value="{$SELECTED_APP_NAME}" />
 			<div class="modal-header" >
-				<div class="clearfix">
+				<div class="clearfix textOverflowEllipsis">
 					<div class="pull-right">
 						<button type="button" class="close" aria-label="Close" data-dismiss="modal" style="color: inherit;">
 							<span aria-hidden="true" class='fa fa-close'></span>
 						</button>
 					</div>
-					<div class="btn-group">
+					<div class="btn-group" style="width: 100%;">
 						{assign var=APP_SELECTED_LABEL value="LBL_SELECT_`$SELECTED_APP_NAME`_MODULES"}
-						<h4 class="pull-left textOverflowEllipsis" style="word-break: break-all;max-width: 95%;">{vtranslate($APP_SELECTED_LABEL, $QUALIFIED_MODULE)}&nbsp;&nbsp;</h4>  
+						<h4 class="pull-left textOverflowEllipsis" style="word-break: break-all;width: 96%;">{vtranslate($APP_SELECTED_LABEL, $QUALIFIED_MODULE)}&nbsp;&nbsp;</h4>  
 					</div>
 				</div>
 			</div>

--- a/layouts/v7/modules/Settings/MenuEditor/AddModule.tpl
+++ b/layouts/v7/modules/Settings/MenuEditor/AddModule.tpl
@@ -19,9 +19,9 @@
 							<span aria-hidden="true" class='fa fa-close'></span>
 						</button>
 					</div>
-					<div class="btn-group" style="width: 100%;">
+					<div class="btn-group" style="width: 96%;">
 						{assign var=APP_SELECTED_LABEL value="LBL_SELECT_`$SELECTED_APP_NAME`_MODULES"}
-						<h4 class="pull-left textOverflowEllipsis" style="word-break: break-all;width: 96%;">{vtranslate($APP_SELECTED_LABEL, $QUALIFIED_MODULE)}&nbsp;&nbsp;</h4>  
+						<h4 class="pull-left textOverflowEllipsis" style="word-break: break-all;width: 100%;">{vtranslate($APP_SELECTED_LABEL, $QUALIFIED_MODULE)}&nbsp;&nbsp;</h4>  
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #458 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. メニュー設定において「非表示のモジュールを選択」を選択したときに一部不必要な文字の省略があった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 省略に設定されているタグの横幅がおかしかった。
##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 関係するタグの横幅を調整した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/150915789-c363bddf-c449-4c57-93ce-7fbaf6b2111a.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
メニュー設定における「非表示のモジュールを選択」を選択した際の表示に関する範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->