### PR TITLE
#419 ワークフローの値の更新にて、関連項目に参照先の関連項目をセットすると別の関連先になる不具合を修正

### DIFF
--- a/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
+++ b/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
@@ -270,11 +270,8 @@ class VTUpdateFieldsTask extends VTTask {
 				}
 
 				if($fieldInstance && $fieldInstance->getFieldDataType() == 'reference') {
-						$referenceModuleList = $fieldInstance->getReferenceList();
-						$fieldReferenceModule = $referenceModuleList[0];
-						$recordId = Vtiger_Util_Helper::getRecordId($fieldValue, $fieldReferenceModule,true);
-						if(!empty($recordId)) {
-							$fieldValue = $recordId;
+						if(isset($fieldValueInDB)) {
+							$fieldValue = $fieldValueInDB;
 						} else {
 							$fieldValue = '';
 						}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #419

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
**以下→は関連を表す**

① まず以下のように3つのモジュールを関連付けるフィールドを作成する
<pre>
 案件            →         顧客企業

  ↓                           ↓

顧客担当者                 顧客担当者
</pre>
② 案件に関するワークフローを作成する
③ アクションで｢項目の値の更新｣を作成する
④ 更新するフィールドを案件→顧客担当者、取得する項目を案件→顧客企業→顧客担当者とする
⑤ 案件と案件→顧客企業をそれぞれ1つずつ作成する
⑥ 関連のない顧客担当者を1つ作成する
⑦ ⑥で作成した顧客担当者と同姓同名の案件→顧客企業→顧客担当者を1つ作成する
⑧ ⑤で作成した案件を編集する

以上の手順を実行した場合、ワークフローによって｢案件→顧客企業→顧客担当者｣の値が｢案件→顧客担当者｣の値を上書きするはずである。
しかし、実際は⑥で作成した同姓同名の顧客担当者となる。

**上記モジュール以外でも発生する**

##  原因 / Cause
<!-- バグの原因を記述 -->
ワークフローは更新するレコードIDからレコード名を取得し、関連項目の場合、レコード名とモジュール名からレコードIDを逆引きする。
ここで、同名のレコードがある場合、逆引きの際にレコードIDが若い方を優先する。
よって、同名のレコードが複数あると関連がおかしくなる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 項目が関連の場合、レコード名からレコードIDの逆引きをやめてレコードIDを直接使うように変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
関連項目を更新するワークフロー(全モジュール)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- いくつかのモジュールでテストしたが、網羅的に行うことが難しいため、特定のフィールドやレコードの組み合わせでバグが生じる可能性あり
- 修正箇所的には関連を更新する以外で問題は生じないと思われる