### PR TITLE
#450 ワークフローのモジュール選択時は活動とTODOにもかかわらず、保存後は活動とカレンダーとなる不具合を修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/EditView.tpl
+++ b/layouts/v7/modules/Settings/Workflows/EditView.tpl
@@ -52,7 +52,12 @@
                      <div class="col-sm-5 controls">
                          {if $MODE eq 'edit'}
                              <div class="pull-left">
-                                <input type='text' disabled='disabled' class="inputElement" value="{vtranslate($MODULE_MODEL->getName(), $MODULE_MODEL->getName())}" >
+                                 {if $SELECTED_MODULE == "Calendar" || $SELECTED_MODULE == "Events"}
+                                    {assign var=SINGLE_SELECTED_MODULE value="SINGLE_$SELECTED_MODULE"}
+                                    <input type='text' disabled='disabled' class="inputElement" value="{vtranslate($SINGLE_SELECTED_MODULE, $SELECTED_MODULE)}" >
+                                 {else}
+                                    <input type='text' disabled='disabled' class="inputElement" value="{vtranslate($MODULE_MODEL->getName(), $MODULE_MODEL->getName())}" >
+                                 {/if}
                                 <input type='hidden' id="module_name" name='module_name' value="{$MODULE_MODEL->get('name')}" >
                              </div>
                          {else}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #450

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローを作成する際に選択できるモジュールはTODOと活動で別れているが、保存したあとはカレンダーと活動になり見分けづらい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ｢Calendar｣の翻訳は｢カレンダー｣だが、｢Single_Calendar｣の翻訳は｢TODO｣であり食い違っている
##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ｢Single_XXX｣の形に統一

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
before
![image](https://user-images.githubusercontent.com/53038605/151332866-4da74dd3-f6f4-4c73-bdf6-ecf3e2350d7c.png)
after
![image](https://user-images.githubusercontent.com/53038605/151332904-18254afe-6dc8-4bdc-b14f-6e1441f886bf.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフロー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
コミットメッセージは不正確