### PR TITLE
#474 ユーザーをインポートするとカレンダー設定のタイムゾーンがSamoaになる箇所の修正

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1814,8 +1814,19 @@ class Users extends CRMEntity {
 							}
 						}
 						if(empty($selectedValue) && !in_array($fieldName, $emptyValuedPicklistFields)) {
-							$picklistValues = array_keys($picklistValues);
-							$selectedValue = reset($picklistValues);
+							// 空のデータがインポートされた場合、$picklistValuesの先頭要素が格納される
+							// 本来はvtiger_fieldのdefaultvalueを参照すべきであるが、time_zoneとdate_formatは空であったため以下のようにデフォルト値を設定した
+							if($fieldName == 'time_zone'){
+								$selectedValue = date_default_timezone_get();
+								if(empty($selectedValue)) {
+									$selectedValue = '(UTC) Coordinated Universal Time, Greenwich Mean Time';
+								}
+							}else if($fieldName == 'date_format'){
+								$selectedValue = 'yyyy-mm-dd';
+							}else{
+								$picklistValues = array_keys($picklistValues);
+								$selectedValue = reset($picklistValues);
+							}
 						}
 						$fieldValue = $selectedValue;
 						unset($selectedValue);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #474 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザーをインポートするとカレンダー設定のタイムゾーンがSamoaになる
2. 日付形式がdd-mm-yyyyになる

##  原因 / Cause
<!-- バグの原因を記述 -->
各テーブルの先頭の要素が設定されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
空である場合の値を設定した。
 - タイムゾーン
   - スクリプト中の日付
 - 日付形式
   - yyyy-mm-dd

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/152305330-225117c5-8603-4a1d-a8f4-0ffd059d218a.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー登録時の処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
### チェック内容
 - インポート時、正常に動作するかどうか→ok
 - TZが設定されていても正常に動作するか→ok
 - 日付形式が設定されていても正常に動作するか→ok
 - TZ, 日付形式が設定されていても正常に動作するか→ok
## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
 - 今回の修正ではタイムゾーンと日付形式のみの対応となっている。添付画像のように**英語表記**になってしまうバグも存在する
 - 本来はデータベース(vtiger_field)のデフォルト値を参照すべきであるが、どちらのカラムも空であったためphp側で設定した
