### PR TITLE
#472 メールアドレス項目が途中で切れて保存される不具合を修正

### DIFF
--- a/modules/Migration/schema/735_to_736.php
+++ b/modules/Migration/schema/735_to_736.php
@@ -36,4 +36,15 @@ if (defined('VTIGER_UPGRADE')) {
         $tablename_old = $tablename;
         $columnname_old = $columnname;
     }
+
+    //メールアドレスのサイズ上限を拡大
+    $getEmailFieldsQuery = "SELECT tablename, fieldname FROM vtiger_field WHERE uitype IN (13, 104)";
+    $emailFieldsResult = $adb->pquery($getEmailFieldsQuery);
+    $emailFieldsRows = $adb->num_rows($emailFieldsResult);
+    for ($i = 0; $i < $emailFieldsRows; $i++) {
+        $emailFieldsTable = $adb->query_result($emailFieldsResult, $i, 'tablename');
+        $emailFieldsField = $adb->query_result($emailFieldsResult, $i, 'fieldname');
+        $emailFieldsUpdateQuery = "ALTER TABLE ".$emailFieldsTable." MODIFY ".$emailFieldsField." varchar(256)";
+        $db->query($emailFieldsUpdateQuery);
+    }
 }

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -270,7 +270,7 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 							   break;
 			   Case 'Email' :
 							   $uitype = 13;
-							   $type = "VARCHAR(50) default '' "; //adodb type
+							   $type = "VARCHAR(256) default '' "; //adodb type
 							   $uichekdata='E~O';
 							   break;
 			   Case 'Time' :


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #472

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. デフォルトのメールアドレス項目は100字、カスタムフィールドのメールアドレス項目は50字までしか登録できない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. MySQLでuitypeがメールアドレスのフィールドは型が`varchar(100)`または`varchar(50)`となっている
2. RFC準拠のメールアドレスは256字まで存在する

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. uitypeが13または104のフィールドを探し、`varchar(256)`とするスクリプトを記述
2. カスタムフィールドでメールアドレス項目を作成する際のデフォルトを`varchar(256)`とした

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カスタムフィールド以外では
* 顧客企業
* リード
* 顧客担当者
* 発注先
* ユーザー
にデフォルトのメールアドレス項目が存在

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* メールアドレスは基本的にuitype=13であるが、ユーザーモジュールの必須のメールアドレスのみuitype=104となっている