### PR TITLE
#480 同じファイルを選択した際の警告の翻訳漏れを修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -2104,6 +2104,7 @@ $jsLanguageStrings = array(
 	'JS_INVALID_STRENGTH_PASSWORDS'=>'複雑なパスワードを指定してください（アルファベット大文字・小文字、数字、記号を含む8文字以上）',
 	'Changed password successfully'=>'パスワードの変更に成功しました',
 	'LBL_MASS_PDF_EXPORT_CONFIRMATION' => '選択したレコードに関するPDFを生成してもよろしいですか？',
+	'JS_THIS_FILE_HAS_ALREADY_BEEN_SELECTED' => 'このファイルは既に選択されています', 
 
 	//個人カレンダー
 	'Planned' => '計画済み',

--- a/libraries/jquery/multiplefileupload/jquery_MultiFile.js
+++ b/libraries/jquery/multiplefileupload/jquery_MultiFile.js
@@ -866,7 +866,7 @@ if (window.jQuery)(function ($) {
 			denied: 'You cannot select a $ext file.\nTry again...',
 			file: '$file',
 			selected: 'File selected: $file',
-			duplicate: 'This file has already been selected:\n$file',
+			duplicate: app.vtranslate('JS_THIS_FILE_HAS_ALREADY_BEEN_SELECTED')+':\n$file',
 			toomuch: 'The files selected exceed the maximum size permited ($size)',
 			toomany: 'Too many files selected (max: $max)',
 			toobig: '$file is too big (max $size)'


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #480

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 同じファイルを選択した際に出る警告が英語

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 言語ファイルとvtranslateの追加

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/152493326-252458cd-da16-44b4-87b9-609deafcb939.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 製品の編集
- コメント

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->