### PR TITLE
#393 カスタム項目「選択肢(単数)」のデフォルト値表示の不具合を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Field.js
+++ b/layouts/v7/modules/Vtiger/resources/Field.js
@@ -242,7 +242,7 @@ Vtiger_Field_Js('Vtiger_Picklist_Field_Js',{},{
 		var pickListValues = this.getPickListValues();
 		var selectedOption = app.htmlDecode(this.getValue());
 
-		if(typeof pickListValues[' '] == 'undefined' || pickListValues[' '].length <= 0 || pickListValues[' '] != 'Select an Option') {
+		if (typeof pickListValues[' '] == 'undefined' || pickListValues[' '].length <= 0 || pickListValues[' '] != app.vtranslate('JS_SELECT_OPTION')) {
 			html += '<option value="">'+app.vtranslate('JS_SELECT_OPTION')+'</option>';
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #393

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. フィールドエディタで「選択肢(単数)」のデフォルト値で｢オプションの選択｣が2つ表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
**英語を前提として条件文が書かれていたため**

- picklistの選択肢はサーバー側(`modules\Settings\LayoutEditor\models\Field.php`)とクライアント側(`layouts\v7\modules\Vtiger\resources\Field.js`)で制御されている
- サーバー側で`オプションの選択`が追加された場合はクライアント側で`オプションの選択`は追加しない仕様
- サーバー側で`オプションの選択`が追加されているかは`'Select an Option'`の有無で判定している
- `'Select an Option'`はサーバー側で翻訳されて`オプションの選択`となっていたため判定が漏れていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 翻訳を適用

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/53038605/152507095-bf41aa54-ab62-4da5-b3dc-7b94ac81f50d.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
設定のフィールドエディタ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->