### PR TITLE
#486 複数選択肢の項目を編集するとデフォルト値が削除される箇所の修正

### DIFF
--- a/modules/Settings/LayoutEditor/actions/Field.php
+++ b/modules/Settings/LayoutEditor/actions/Field.php
@@ -61,6 +61,7 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         $fieldInstance = Settings_LayoutEditor_Field_Model::getInstance($fieldId);
         
         $fieldLabel = $fieldInstance->get('label');
+        $uitype = $fieldInstance->get('uitype');
         $mandatory = $request->get('mandatory',null);
         $presence = $request->get('presence',null);
         $quickCreate = $request->get('quickcreate',null);
@@ -93,8 +94,12 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         if(!empty($massEditable)){
             $fieldInstance->set('masseditable', $massEditable);
         }
-
-		$defaultValue = decode_html($request->get('fieldDefaultValue'));
+        
+        if($uitype == 33){
+            $defaultValue = decode_html(implode(' |##| ', $request->get('fieldDefaultValue')));
+        }else{
+            $defaultValue = decode_html($request->get('fieldDefaultValue'));
+        }
 		$fieldInstance->set('defaultvalue', $defaultValue);
 		$response = new Vtiger_Response();
         try{


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #486 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 複数選択肢の項目を編集するとデフォルト値が削除される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. デフォルト値が配列要素として格納されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 配列要素を" |##| "により連結する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - uitype33の項目の保存

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->