### PR TITLE
#146 webフォームの項目に×が表示されない問題の修正

### DIFF
--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,7 +222,7 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		fieldsListSelect2Element.find('.select2-search-choice div:match("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
+		fieldsListSelect2Element.find('.select2-search-choice div:contains("'+mandatoryFieldLabel+'*")').closest('li').find('a').remove();
 	},
 	
 	/**

--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,7 +222,7 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		fieldsListSelect2Element.find('.select2-search-choice div:contains("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
+		fieldsListSelect2Element.find('.select2-search-choice div:match("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
 	},
 	
 	/**

--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,12 +222,10 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		console.log('Aaaaaaaaaa');
 		var fieldsListSelect2Elementcontext =fieldsListSelect2Element.find('.select2-search-choice');
 		for(var fieldsListSelect2Elementcontextindex =0;fieldsListSelect2Elementcontextindex < fieldsListSelect2Elementcontext.length;fieldsListSelect2Elementcontextindex++){
 
 			if(mandatoryFieldLabel+'*'==fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].innerText && fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].querySelector('a')){
-			console.log('fasdfa');
 			fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].querySelector('a').remove();
 			}
 		}

--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,7 +222,15 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		fieldsListSelect2Element.find('.select2-search-choice div:contains("'+mandatoryFieldLabel+'*")').closest('li').find('a').remove();
+		console.log('Aaaaaaaaaa');
+		var fieldsListSelect2Elementcontext =fieldsListSelect2Element.find('.select2-search-choice');
+		for(var fieldsListSelect2Elementcontextindex =0;fieldsListSelect2Elementcontextindex < fieldsListSelect2Elementcontext.length;fieldsListSelect2Elementcontextindex++){
+
+			if(mandatoryFieldLabel+'*'==fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].innerText && fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].querySelector('a')){
+			console.log('fasdfa');
+			fieldsListSelect2Elementcontext[fieldsListSelect2Elementcontextindex].querySelector('a').remove();
+			}
+		}
 	},
 	
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #146 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. webフォームの一部項目の×ボタンが表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. その項目が必須項目であった場合に×ボタンを表示させないようにするモジュールにおいて、判別方法が必須項目の文字列を含むかどうかになっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  モジュールの判別方法を完全一致に変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/155046471-24792ebc-eb70-470f-9942-6298c0f938ad.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
webフォームにおいてそれぞれの項目が必須項目かどうかを判断する箇所。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
