### PR TITLE
#490 文語変更において変更する箇所のリストまで変更されてしまう

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
@@ -81,7 +81,7 @@
 											{assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER->get('name')}
 											{assign var=LAST_COLUMN value=$LISTVIEW_HEADER@last}
 											<td class="listViewEntryValue textOverflowEllipsis {$WIDTHTYPE}" width="{$WIDTH}%" nowrap>
-												{vtranslate($LISTVIEW_ENTRY->getDisplayValue($LISTVIEW_HEADERNAME))}
+												{$LISTVIEW_ENTRY->getDisplayValue($LISTVIEW_HEADERNAME)}
 												{if $LAST_COLUMN && $LISTVIEW_ENTRY->getRecordLinks()}
 													</td>
 												{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #490 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 文語変更において翻訳する文字の一覧のリストにも文語の翻訳がかかってしまい変更前の文字が何だったのかわからなくなってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. リスト内の変更前の文字にも翻訳がかかってしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtranslateによる翻訳を解除した。
2. 翻訳の解除はリスト内だけだのでリストの項目名などはそのまま翻訳される。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/155066507-6e58ce60-c1f1-4947-a56c-dd8f7a9e2759.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
文語変更におけるリスト内
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->