### PR TITLE
#489 文語変更の編集を行うと現れるスクロールバーのスタイルの修正

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
@@ -37,7 +37,7 @@
 			{/if}
 			<div class="list-content row">
 				<div class="col-sm-12 col-xs-12 ">
-					<div id="table-content" class="table-container" style="padding-top:0px !important;">
+					<div id="table-content" class="table-container table-container-of-translation" style="padding-top:0px !important;">
 						<table id="listview-table" class="table listview-table">
 							{assign var="NAME_FIELDS" value=$MODULE_MODEL->getNameFields()}
 							{assign var=WIDTHTYPE value=$CURRENT_USER_MODEL->get('rowheight')}

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -1476,9 +1476,25 @@ ul.unstyled {
   width: 100%;
   border: 1px solid #ddd;
   margin-top: 10px;
-  overflow: scroll;
+  overflow-y: scroll;
+  scrollbar-width: 8px;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
   border-width: thin;
 }
+.table-container-of-translation{
+  height:100%;
+  max-height:70vh;
+}
+.table-container::-webkit-scrollbar {
+  width: 8px;
+}
+.table-container::-webkit-scrollbar-track {
+  background: none;
+}
+.table-container::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  background: #c1c1c1;
+ }
 .listview-table {
   margin-bottom: 0;
   border-top: 0;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #489 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 文語変更の編集や削除を行うと不要なスクロールバーが表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 編集を行った後にjavascriptによって追加されるはずのクラスがうまく追加されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. cssを新しく書きなおした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/155473691-cf3f64a6-3082-4062-baab-f2c605036ac9.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
今回はjavascriptのクラスの追加の部分が特定できなかったためcssを新しく書くことで対応した。
javascriptのほうを修正すれば文語変更以外のモジュールで同様のバグが発生しても対応できると思われる。