### PR TITLE
#195 繰り返し予定の編集を保存する際に出る警告文の修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Edit.js
+++ b/layouts/v7/modules/Calendar/resources/Edit.js
@@ -281,6 +281,7 @@ Vtiger_Edit_Js("Calendar_Edit_Js",{
 				var modalContainer = data.find('.recurringEventsUpdation');
 				modalContainer.removeClass('hide');
 				modalContainer.on('click', '.onlyThisEvent', function() {
+					window.onbeforeunload = null;
 					recurringEditMode.val('current');
 					app.helper.hideModal();
 					form.vtValidate({
@@ -291,6 +292,7 @@ Vtiger_Edit_Js("Calendar_Edit_Js",{
 					form.submit();
 				});
 				modalContainer.on('click', '.futureEvents', function() {
+					window.onbeforeunload = null;
 					recurringEditMode.val('future');
 					app.helper.hideModal();
 					form.vtValidate({
@@ -301,6 +303,7 @@ Vtiger_Edit_Js("Calendar_Edit_Js",{
 					form.submit();
 				});
 				modalContainer.on('click', '.allEvents', function() {
+					window.onbeforeunload = null;
 					recurringEditMode.val('all');
 					app.helper.hideModal();
 					form.vtValidate({


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #195 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーの繰り返し予定を編集し、保存するときに警告文が表示されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 保存する際にブラウザ側が画面遷移として自動で警告をつけてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 繰り返し予定の変更のいずれかをクリックした際にブラウザの警告を無効にするように修正した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/156088817-be212240-4f8f-4334-aeab-051ea2e372da.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->