### PR TITLE
#456 完了済みTODOのアイコンから新規作成すると完了状態のTODOが作られる問題の修正

### DIFF
--- a/modules/Calendar/actions/SaveFollowupAjax.php
+++ b/modules/Calendar/actions/SaveFollowupAjax.php
@@ -49,7 +49,7 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
         $recordModel->set('subject',$followupSubject);
         //followup event is Planned
         $recordModel->set('eventstatus',"Planned");
-		$recordModel->set('taskstatus',"plannd");
+		$recordModel->set('taskstatus',"Planned");
 
         $activityType = $recordModel->get('activitytype');
         if($activityType == "Call")

--- a/modules/Calendar/actions/SaveFollowupAjax.php
+++ b/modules/Calendar/actions/SaveFollowupAjax.php
@@ -49,7 +49,8 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
         $recordModel->set('subject',$followupSubject);
         //followup event is Planned
         $recordModel->set('eventstatus',"Planned");
-        
+		$recordModel->set('taskstatus',"plannd");
+
         $activityType = $recordModel->get('activitytype');
         if($activityType == "Call")
             $eventDuration = $request->get('defaultCallDuration');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #456 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 完了済みのTODOの「次の予定を登録する」のアイコンからTODOを新規作成すると完了状態で新規作成されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 新規作成する際に元のTODOのステータス情報をそのまま引き継いでしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 新規作成する際にステータスを計画済みとして登録されるように修正した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/156113153-2a10338e-cc2f-402a-8b8b-0535e8b81c85.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
TODOをfollowupとして登録する際。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->