### PR TITLE
#501 カレンダーの繰り返しの日付選択画面の翻訳漏れ

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -430,7 +430,7 @@ $languageStrings = array(
 	'LBL_SHOW' => '表示',
 	'LBL_MY' => '自分の',
 	'LBL_SELECT_DATE_RANGE' => '日付の範囲',
- 
+
 	// Basic Strings- custom view
 	'LBL_VIEW_NAME' => 'リスト名',
 	'LBL_CREATE_VIEW' => '新しいリストを作る',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -430,7 +430,7 @@ $languageStrings = array(
 	'LBL_SHOW' => '表示',
 	'LBL_MY' => '自分の',
 	'LBL_SELECT_DATE_RANGE' => '日付の範囲',
-
+ 
 	// Basic Strings- custom view
 	'LBL_VIEW_NAME' => 'リスト名',
 	'LBL_CREATE_VIEW' => '新しいリストを作る',
@@ -2077,6 +2077,7 @@ $jsLanguageStrings = array(
 	'LBL_LIST_DELETE_CONFIRMATION' => '消去してもよろしいですか？',
 	'JS_WIDGET_RESIZING_WAIT_MSG' => 'ウィジェットのコンテンツは、サイズ変更後にロードされます。',
 	'JS_COPIED_SUCCESSFULLY' => 'コピーをしました',
+	'JS_REPEAT_DATE_SHOULD_BE_GREATER_THAN_START_DATE' =>'繰り返しの日付は、開始日以降である必要があります。',
 
 	// F-RevoCRM 7
 	'This field is required.' => '必須入力です',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #501 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダーの繰り返しの日付選択画面において翻訳漏れがあった。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 翻訳を追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/156117033-37b02ec7-b665-4813-89e5-3565d716ed44.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->