### PR TITLE
#507 スマートフォンから活動のクイック編集を開くと表示が崩れる

### DIFF
--- a/layouts/v7/modules/Calendar/QuickCreate.tpl
+++ b/layouts/v7/modules/Calendar/QuickCreate.tpl
@@ -21,7 +21,7 @@
 				{/if}
 				{include file="ModalHeader.tpl"|vtemplate_path:$MODULE TITLE=$HEADER_TITLE}
 
-				<div class="modal-body" {if $MODULE=='Events'}style="max-height:800px;"{/if}>
+				<div class="modal-body pre-scrollable" {if $MODULE=='Events'}style="max-height:800px;"{/if}>
 					{if !empty($PICKIST_DEPENDENCY_DATASOURCE)}
 						<input type="hidden" name="picklistDependency" value='{Vtiger_Util_Helper::toSafeHTML($PICKIST_DEPENDENCY_DATASOURCE)}' />
 					{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #507 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. スマートフォンから活動のクイック編集を開くとスクロールした際に表示が崩れてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. クイック編集のいずれかの項目を選択してしまうとoverflowのスクロールが適用されなくなってしまう。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 親クラスのほうにoverflowの条件を追加した。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/158761135-0a8b4ebe-6c8e-4f8d-9c8e-dee3f6102c86.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
クイック編集の表示の範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
Androidを用いて修正の確認を行ったためiosによる確認はできていない。