### PR TITLE
リスト作成後に項目名を変更した項目もリストの編集・複製時に引き継がれるようにしてほしい箇所の修正

### DIFF
--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -576,7 +576,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 	}
 
     /**
-	 * DBのfieldlabelを直接変更した場合、getSelectedFields()で取得してきたfieldLabelと変更後の名前が異なるため選択項目として表示されないバグがあった。
+	 * fieldlabelをDBで直接変更した場合、getSelectedFields()で取得してきたfieldLabelと変更後の名前が異なるため選択項目として表示されないバグがあった。
 	 * そこで、取得してきたfieldLabelをvtiger_fieldテーブルと比較し変更する。
 	 */
 	function renameSelectedFields($selectedFields){
@@ -587,7 +587,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				if($columnlist[$i][0]){
 					$moduleFieldLabel_array = explode('_', $columnlist[$i][3]);
 					$fieldlabelLinking = $moduleFieldLabel_array[1];
-					for($j=1; $j<count($moduleFieldLabel_array)-1; ++$j){
+					for($j=1; $j<count($moduleFieldLabel_array)-1; $j++){
 						$fieldlabelLinking .= '_'.$moduleFieldLabel_array[$j+1];
 					}
 					array_push($columnlist[$i],$moduleFieldLabel_array[0],$fieldlabelLinking);
@@ -603,7 +603,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				$params = array($table_array[$i]);
 				$result = $db->pquery($query, $params);
 				$rows = $db->num_rows($result);
-				for($j=0; $j<$rows; ++$j){
+				for($j=0; $j<$rows; $j++){
 					$tabid[$i][] = $db->query_result($result, $j, 'tabid');
 					$columnname[$i][] = $db->query_result($result, $j, 'columnname');
 					$tablename[$i][] = $db->query_result($result, $j, 'tablename');
@@ -615,14 +615,14 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				$table_key = array_search($columnlist[$i][0],$table_array);
 				$fieldlabel_key = array();
 				//DBのfieldlabelと比較する
-				for($j=0; $j<count($fieldlabel[$table_key]); ++$j){
+				for($j=0; $j<count($fieldlabel[$table_key]); $j++){
 					if(str_replace(' ', '_', $fieldlabel[$table_key][$j]) == $columnlist[$i][6]){
 						array_push($fieldlabel_key, $j);
 					}
 				}
 				// DBに一致するfieldlabelが無かった場合、$columnname,$tabid,$fieldnameを元にfieldlabelを変更する(3項目が全て一致していなければ変更しない)
 				if(empty($fieldlabel_key)){
-					for($k=0; $k<count($columnname[$table_key]); ++$k){
+					for($k=0; $k<count($columnname[$table_key]); $k++){
 						if($columnname[$table_key][$k] == $columnlist[$i][1]){
 							$columnname_key = $k;
 							break;
@@ -630,8 +630,12 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 					}
 					$ExistenceCheck = true;
 					if(isset($columnname_key)){
-						if($tabid[$table_key][$columnname_key] != getTabid($columnlist[$i][5]))$ExistenceCheck = ($ExistenceCheck && false);
-						if($fieldname[$table_key][$columnname_key] != $columnlist[$i][2])$ExistenceCheck = ($ExistenceCheck && false);
+						if($tabid[$table_key][$columnname_key] != getTabid($columnlist[$i][5])){
+							$ExistenceCheck = ($ExistenceCheck && false);
+						}
+						if($fieldname[$table_key][$columnname_key] != $columnlist[$i][2]){
+							$ExistenceCheck = ($ExistenceCheck && false);
+						}
 						if($ExistenceCheck){
 							$selectedFields[$i] = $columnlist[$i][0].':'.$columnlist[$i][1].':'.$columnlist[$i][2].':'.$columnlist[$i][5].'_'.$fieldlabel[$table_key][$columnname_key].':'.$columnlist[$i][4];
 						}

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -565,7 +565,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$result = $db->pquery($query, $params);
 		$noOfFields = $db->num_rows($result);
 		$selectedFields = array();
-		for($i=0; $i<$noOfFields; ++$i) {
+		for($i=0; $i<$noOfFields; $i++) {
 			$columnIndex = $db->query_result($result, $i, 'columnindex');
 			$columnName = $db->query_result($result, $i, 'columnname');
 			if($i == 0)$num = $columnIndex; //$columnIndexが0から始まらないケースがあるため
@@ -582,7 +582,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 	function renameSelectedFields($selectedFields){
 		if(isset($selectedFields)){
 			$table_array = array();
-			for($i=0; $i<count($selectedFields); ++$i){
+			for($i=0; $i<count($selectedFields); $i++){
 				$columnlist[$i] = explode(':', $selectedFields[$i]);
 				if($columnlist[$i][0]){
 					$moduleFieldLabel_array = explode('_', $columnlist[$i][3]);
@@ -597,7 +597,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				}
 			}
 			// クエリを何度も飛ばすことを避けるため、$tabid等をまとめて取得する
-			for($i=0; $i<count($table_array); ++$i){
+			for($i=0; $i<count($table_array); $i++){
 				$db = PearDatabase::getInstance();
 				$query = 'SELECT tabid,columnname,tablename,fieldname,fieldlabel FROM vtiger_field WHERE tablename = ?';
 				$params = array($table_array[$i]);
@@ -611,7 +611,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 					$fieldlabel[$i][] = $db->query_result($result, $j, 'fieldlabel');
 				}
 			}
-			for($i=0; $i<count($columnlist); ++$i){
+			for($i=0; $i<count($columnlist); $i++){
 				$table_key = array_search($columnlist[$i][0],$table_array);
 				$fieldlabel_key = array();
 				//DBのfieldlabelと比較する
@@ -1187,7 +1187,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$result = $db->pquery($sql, $params);
 		$noOfCVs = $db->num_rows($result);
 		$customViews = array();
-		for ($i=0; $i<$noOfCVs; ++$i) {
+		for ($i=0; $i<$noOfCVs; $i++) {
 			$row = $db->query_result_rowdata($result, $i);
 			$customView = new self();
 			$cv = $customView->setData($row)->setModule($row['entitytype']);

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -568,7 +568,71 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		for($i=0; $i<$noOfFields; ++$i) {
 			$columnIndex = $db->query_result($result, $i, 'columnindex');
 			$columnName = $db->query_result($result, $i, 'columnname');
-			$selectedFields[$columnIndex] = decode_html($columnName);
+			if($i == 0)$num = $columnIndex; //$columnIndexが0から始まらないケースがあるため
+			$selectedFields[$columnIndex-$num] = decode_html($columnName);
+		}
+		$selectedFields = self::renameSelectedFields($selectedFields);
+		return $selectedFields;
+	}
+
+    /**
+	 * DBのfieldlabelを直接変更した場合、getSelectedFields()で取得してきたfieldLabelと変更後の名前が異なるため選択項目として表示されないバグがあった。
+	 * そこで、取得してきたfieldLabelをvtiger_fieldテーブルと比較し変更する。
+	 */
+	function renameSelectedFields($selectedFields){
+		if(isset($selectedFields)){
+			$table_array = array();
+			for($i=0; $i<count($selectedFields); ++$i){
+				$columnlist[$i] = explode(':', $selectedFields[$i]);
+				if($columnlist[$i][0]){
+					$moduleFieldLabel_array = explode('_', $columnlist[$i][3]);
+					$fieldlabelLinking = $moduleFieldLabel_array[1];
+					for($j=1; $j<count($moduleFieldLabel_array)-1; ++$j){
+						$fieldlabelLinking .= '_'.$moduleFieldLabel_array[$j+1];
+					}
+					array_push($columnlist[$i],$moduleFieldLabel_array[0],$fieldlabelLinking);
+					if(!in_array($columnlist[$i][0],$table_array)){
+						array_push($table_array,$columnlist[$i][0]);
+					}
+				}
+			}
+			// クエリを何度も飛ばすことを避けるため、$tabid等をまとめて取得する
+			for($i=0; $i<count($table_array); ++$i){
+				$db = PearDatabase::getInstance();
+				$query = 'SELECT tabid,columnname,tablename,fieldname,fieldlabel FROM vtiger_field WHERE tablename = ?';
+				$params = array($table_array[$i]);
+				$result = $db->pquery($query, $params);
+				$rows = $db->num_rows($result);
+				for($j=0; $j<$rows; ++$j){
+					$tabid[$i][] = $db->query_result($result, $j, 'tabid');
+					$columnname[$i][] = $db->query_result($result, $j, 'columnname');
+					$tablename[$i][] = $db->query_result($result, $j, 'tablename');
+					$fieldname[$i][] = $db->query_result($result, $j, 'fieldname');
+					$fieldlabel[$i][] = $db->query_result($result, $j, 'fieldlabel');
+				}
+			}
+			for($i=0; $i<count($columnlist); ++$i){
+				$table_key = array_search($columnlist[$i][0],$table_array);
+				$fieldlabel_key = array();
+				//DBのfieldlabelと比較する
+				for($j=0; $j<count($fieldlabel[$table_key]); ++$j){
+					if(str_replace(' ', '_', $fieldlabel[$table_key][$j]) == $columnlist[$i][6])array_push($fieldlabel_key, $j);
+				}
+				// DBに一致するfieldlabelが無かった場合、$columnname,$tabid,$fieldnameを元にfieldlabelを変更する(3項目が全て一致していなければ変更しない)
+				if(empty($fieldlabel_key)){
+					for($k=0; $k<count($columnname[$table_key]); ++$k){
+						if($columnname[$table_key][$k] == $columnlist[$i][1])$columnname_key = $k; break;
+					}
+					$ExistenceCheck = true;
+					if(isset($columnname_key)){
+						if($tabid[$table_key][$columnname_key] != getTabid($columnlist[$i][5]))$ExistenceCheck = ($ExistenceCheck && false);
+						if($fieldname[$table_key][$columnname_key] != $columnlist[$i][2])$ExistenceCheck = ($ExistenceCheck && false);
+						if($ExistenceCheck){
+							$selectedFields[$i] = $columnlist[$i][0].':'.$columnlist[$i][1].':'.$columnlist[$i][2].':'.$columnlist[$i][5].'_'.$fieldlabel[$table_key][$columnname_key].':'.$columnlist[$i][4];
+						}
+					}
+				}
+			}			
 		}
 		return $selectedFields;
 	}

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -1196,7 +1196,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$result = $db->pquery($sql, $params);
 		$noOfCVs = $db->num_rows($result);
 		$customViews = array();
-		for ($i=0; $i<$noOfCVs; $i++) {
+		for ($i=0; $i<$noOfCVs; ++$i) {
 			$row = $db->query_result_rowdata($result, $i);
 			$customView = new self();
 			$cv = $customView->setData($row)->setModule($row['entitytype']);

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -616,12 +616,17 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 				$fieldlabel_key = array();
 				//DBのfieldlabelと比較する
 				for($j=0; $j<count($fieldlabel[$table_key]); ++$j){
-					if(str_replace(' ', '_', $fieldlabel[$table_key][$j]) == $columnlist[$i][6])array_push($fieldlabel_key, $j);
+					if(str_replace(' ', '_', $fieldlabel[$table_key][$j]) == $columnlist[$i][6]){
+						array_push($fieldlabel_key, $j);
+					}
 				}
 				// DBに一致するfieldlabelが無かった場合、$columnname,$tabid,$fieldnameを元にfieldlabelを変更する(3項目が全て一致していなければ変更しない)
 				if(empty($fieldlabel_key)){
 					for($k=0; $k<count($columnname[$table_key]); ++$k){
-						if($columnname[$table_key][$k] == $columnlist[$i][1])$columnname_key = $k; break;
+						if($columnname[$table_key][$k] == $columnlist[$i][1]){
+							$columnname_key = $k;
+							break;
+						}
 					}
 					$ExistenceCheck = true;
 					if(isset($columnname_key)){


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #495 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストに選択した項目名をリスト作成時と異なるものに変更してしまうと、編集・複製時該当項目が引き継がれず表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. vtiger_cvcolumnlistに各リストの項目が登録されており、このテーブルが変更されないため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_cvcolumnlistの情報とvtiger_fieldの情報を比較し、vtiger_fieldのfieldlabelを優先するようにする
2. クエリを何度も送信しないようにデータをキャッシュする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - リスト編集画面
 - 各モジュールの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
 - これは標準の機能ではないため、DBを直接書き換えることによって修正・テストを行いました。