### PR TITLE
#503 リスト作成時の項目選択にモジュール名を表示する修正

### DIFF
--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -79,7 +79,9 @@
 															{assign var=NUMBER_OF_COLUMNS_SELECTED value=$NUMBER_OF_COLUMNS_SELECTED + 1}
 														{/if}
 													{/if}
-													>{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE))}
+													{assign var=WITH_MODULENAME value="("|cat:{vtranslate($FIELD_MODULE_NAME, $SOURCE_MODULE)}|cat:")-"}
+													>{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE)|replace:"-":$WITH_MODULENAME)}
+													
 													{if $FIELD_MODEL->isMandatory() eq true} <span>*</span> {/if}
 												</option>
 											{/foreach}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #503 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リスト作成時の項目選択に関連モジュール名がなく、わかりずらかった

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 選択肢を「uitype10の項目名(モジュール名)-項目名」に表示を修正した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/159408028-6b0702f8-55c9-4c7c-ac21-278f69df798f.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リスト作成時の項目選択の範囲
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->