### PR TITLE
fiexd #121 活動の招待メールに添付されるiCalendarファイルのTIMEZONEをUTCからAsia/Tokyoに修正

### DIFF
--- a/modules/Calendar/CalendarCommon.php
+++ b/modules/Calendar/CalendarCommon.php
@@ -247,6 +247,7 @@ function generateIcsAttachment($record, $inviteeid) {
 		$userOffset = str_pad(str_replace("-" , "", $userOffset), 2, 0, STR_PAD_LEFT);
 
     // add timezone
+	fwrite($fp, "BEGIN:VCALENDAR\n");
     fwrite($fp, "BEGIN:VTIMEZONE\n");
     fwrite($fp, "TZID:".$time_zone."\n");
     fwrite($fp, "BEGIN:STANDARD\n");
@@ -256,7 +257,7 @@ function generateIcsAttachment($record, $inviteeid) {
     fwrite($fp, "END:STANDARD\n");
     fwrite($fp, "END:VTIMEZONE\n");
 
-    fwrite($fp, "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\n");
+    fwrite($fp, "VERSION:2.0\nBEGIN:VEVENT\n");
     fwrite($fp, "ORGANIZER;CN=".$lastName." ".$firstName.":MAILTO:".$email."\n");
     fwrite($fp, "DTSTART;TZID=".$time_zone.":".date('Ymd\THis', strtotime($stDatetime))."\n");
     fwrite($fp, "DTEND;TZID=".$time_zone.":".date('Ymd\THis', strtotime($endDatetime))."\n");


### PR DESCRIPTION
GoogleカレンダーからICSファイルをインポートできない件を修正。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #121 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. GoogleカレンダーにてICSファイルのインポートに失敗する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 先頭箇所にBIGIN:VCALENDARが記載されておらず、BEGIN:VTIMEZONEから始まっている。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 先頭箇所にBIGIN:VCALENDARを記載するように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
招待メール内に添付されているICSファイル

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->