### PR TITLE
#515 WEBフォームから取り込まれた複数選択肢の区切り記号の修正

### DIFF
--- a/modules/com_vtiger_workflow/VTSimpleTemplate.inc
+++ b/modules/com_vtiger_workflow/VTSimpleTemplate.inc
@@ -311,13 +311,11 @@ class VTSimpleTemplate{
 									require_once 'includes/runtime/Globals.php';
 									if(strpos($fieldValue, '|##|') !== false){
 										$fieldValueParts = explode(' |##| ',$fieldValue);
-									}else{
-										$fieldValueParts = explode(';',$fieldValue);
 									}
 									foreach($fieldValueParts as $index=>$fieldValue) {
 										$fieldValueParts[$index] = vtranslate($fieldValue,$moduleName,$ownerObject->column_fields['language']);
 									}
-									$fieldValue = implode(';', $fieldValueParts);
+									$fieldValue = implode(',', $fieldValueParts);
 									break;
 			case 'boolean'		:  require_once 'includes/runtime/LanguageHandler.php';
 									require_once 'includes/runtime/Globals.php';

--- a/modules/com_vtiger_workflow/VTSimpleTemplate.inc
+++ b/modules/com_vtiger_workflow/VTSimpleTemplate.inc
@@ -309,7 +309,11 @@ class VTSimpleTemplate{
 
 			case 'multipicklist' :  require_once 'includes/runtime/LanguageHandler.php';
 									require_once 'includes/runtime/Globals.php';
-									$fieldValueParts = explode(';',$fieldValue);
+									if(strpos($fieldValue, '|##|') !== false){
+										$fieldValueParts = explode(' |##| ',$fieldValue);
+									}else{
+										$fieldValueParts = explode(';',$fieldValue);
+									}
 									foreach($fieldValueParts as $index=>$fieldValue) {
 										$fieldValueParts[$index] = vtranslate($fieldValue,$moduleName,$ownerObject->column_fields['language']);
 									}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #515 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローから複数選択肢の項目を含むメールを送信すると「選択肢１ |##| 選択肢２」のように送信される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「;」で分割する処理しか無かった。(「;」で分割した後、選択肢を和訳し「;」で結合して送信)

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「 |##| 」で分割する処理を追加。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
 - 選択肢「a、b、c、d」の場合
![image](https://user-images.githubusercontent.com/75693720/162869613-abef7f21-2a09-4e9f-8254-6aeada0bd1cc.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 - ワークフローによるメール送信
 
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->