### PR TITLE
#518 見積印刷時に下部に線が入ってしまう箇所の修正

### DIFF
--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -307,6 +307,7 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 
 		$tcpdf = new TCPDF();
 		$tcpdf->setPrintHeader(false);
+		$tcpdf->setPrintFooter(false);
 		$tcpdf->AddPage();
 		$tcpdf->SetFont('ume-tgo4','B');
 		$tcpdf->writeHTML($template);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #518 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 見積印刷時に下部に線が入ってしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ページ・フッターが表示されてしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ページ・フッターを出力しないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/162889064-9927233c-25af-4244-ac82-cf7cd659109e.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
以下のPDF出力に影響があります。
 - 発注書
 - 注文請書
 - 請求書
 - 見積書

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->