### PR TITLE
#477 インポートしたユーザーのデフォルトの言語を日本語にする修正

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1786,7 +1786,7 @@ class Users extends CRMEntity {
 							}
 						}
 							if(empty($lang)) {
-								$lang = 'en_us';
+								$lang = 'ja_jp';
 							}
 							$fieldValue = $lang;
 							unset($lang);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #477 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インポートしたユーザーのデフォルトの言語が英語である
2. vtiger_fieldテーブル内のタイムゾーン、日付形式にデフォルト値が設定されていない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. php側でインポートしたデータが空の場合、英語になるように記述されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 設定値を英語から日本語に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザーインポート時の処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
 - 本来はデフォルト値をvtiger_fieldから参照するべきであるが、すべての項目にそれを適応して良いのかわからないので今回はphp側での設定で解決とする