### PR TITLE
#326 カレンダーにてリロードした際に閲覧していた日付を表示する

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1813,14 +1813,16 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			},
 			viewRender: function (view, element) {
 				var lastviewday;
+				var URL_Serarch_view = new URLSearchParams(location.search);
+				var lastviewtype = URL_Serarch_view.get('view');
 				if(document.getElementsByClassName('fc-day-header').item(1)==null){
 					if(document.getElementsByClassName('fc-day-header').item(0)){
 						lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
-						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday + "&Viewtype=day");
+						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday + "&Viewtype=day");
 						
 					}
 					else{
-						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + "&Viewtype=list");
+						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + "&Viewtype=list");
 					}
 
 				}
@@ -1828,14 +1830,14 @@ Vtiger.Class("Calendar_Calendar_Js", {
 					var URL_Serarch = new URLSearchParams(location.search);
 					if(URL_Serarch.get('lastVIewDate')!=null){
 						lastviewday =document.getElementsByClassName('fc-day-top').item(7).dataset.date;
-						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday.substr(0, lastviewday.lastIndexOf('-')) + "&Viewtype=month");
+						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday.substr(0, lastviewday.lastIndexOf('-')) + "&Viewtype=month");
 
 					}
 					
 				}
 				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date){
 					lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
-					history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday + "&Viewtype=week");
+					history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday + "&Viewtype=week");
 				}
 				if (view.name === 'vtAgendaList') {
 					jQuery(".sidebar-essentials").addClass("hide");

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1679,7 +1679,10 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var URL_Serarch = new URLSearchParams(location.search);
 		if(location.href.match(/last/)){
 			defaultDate=URL_Serarch.get('lastVIewDate');
-		}switch(URL_Serarch.get('Viewtype')){
+		}else{
+			defaultView = userDefaultActivityView;
+		}
+		switch(URL_Serarch.get('Viewtype')){
 			case 'day':
 				defaultView = 'agendaDay';
 				break;

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1674,6 +1674,28 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var HEADER_HEIGHT = 200;
 		var CalendarHeight = $(window).height() - HEADER_HEIGHT;
 		CalendarHeight = (CalendarHeight < MIN_CALENDAR_HEIGHT) ? MIN_CALENDAR_HEIGHT : CalendarHeight;
+		var defaultDate;
+		var defaultView;
+		var URL_Serarch = new URLSearchParams(location.search);
+		if(location.href.match(/last/)){
+			defaultDate=URL_Serarch.get('lastVIewDate');
+		}switch(URL_Serarch.get('Viewtype')){
+			case 'day':
+				defaultView = 'agendaDay';
+				break;
+			case 'week':
+				defaultView = 'agendaWeek';
+				break;
+			case 'month':
+				defaultView = 'month';
+				break;
+			case 'list':
+				defaultView = 'vtAgendaList';
+				break
+		}
+		if(window.innerWidth < 1020){
+			defaultView = "agendaDay";
+		}
 
 		var calenderConfigs = {
 			header: {
@@ -1709,7 +1731,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			scrollTime: thisInstance.getUserPrefered('start_hour'),
 			editable: true,
 			eventLimit: true,
-			defaultView: ($(window).width() > 1020 ? userDefaultActivityView : 'agendaDay'),
+			defaultDate:defaultDate,
+			defaultView:defaultView,
 			slotLabelFormat: userDefaultTimeFormat,
 			timeFormat: userDefaultTimeFormat,
 			events: [],
@@ -1786,6 +1809,31 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				thisInstance.performMouseOutActions(event, jsEvent, view);
 			},
 			viewRender: function (view, element) {
+				var lastviewday;
+				if(document.getElementsByClassName('fc-day-header').item(1)==null){
+					if(document.getElementsByClassName('fc-day-header').item(0)){
+						lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
+						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday + "&Viewtype=day");
+						
+					}
+					else{
+						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + "&Viewtype=list");
+					}
+
+				}
+				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date==undefined){
+					var URL_Serarch = new URLSearchParams(location.search);
+					if(URL_Serarch.get('lastVIewDate')!=null){
+						lastviewday =document.getElementsByClassName('fc-day-top').item(7).dataset.date;
+						history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday.substr(0, lastviewday.lastIndexOf('-')) + "&Viewtype=month");
+
+					}
+					
+				}
+				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date){
+					lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
+					history.replaceState('', '','index.php?module=Calendar&view=Calendar&lastVIewDate=' + lastviewday + "&Viewtype=week");
+				}
 				if (view.name === 'vtAgendaList') {
 					jQuery(".sidebar-essentials").addClass("hide");
 					jQuery(".content-area").addClass("full-width");

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1677,27 +1677,62 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var defaultDate;
 		var defaultView;
 		var URL_Serarch = new URLSearchParams(location.search);
-		if(location.href.match(/last/)){
-			defaultDate=URL_Serarch.get('lastVIewDate');
-		}else{
+		var URL_Serarch_PRE = new URLSearchParams(document.referrer);
+		if(location.href.match(/default/)){//ヘッダーのカレンダーボタンからの処理
 			defaultView = userDefaultActivityView;
-		}
-		switch(URL_Serarch.get('Viewtype')){
-			case 'day':
-				defaultView = 'agendaDay';
-				break;
-			case 'week':
-				defaultView = 'agendaWeek';
-				break;
-			case 'month':
-				defaultView = 'month';
-				break;
-			case 'list':
-				defaultView = 'vtAgendaList';
-				break
-		}
-		if(window.innerWidth < 1020){
-			defaultView = "agendaDay";
+			if(URL_Serarch.get('view') ==  'SharedCalendar'){
+				if(userDefaultActivityView == 'vtAgendaList'){
+					defaultView = 'month';
+				}
+			}
+			
+		}else{
+			if(location.href.match(/lastViewDate/)){//リフレッシュしたときの処理
+				switch(URL_Serarch.get('Viewtype')){
+					case 'day':
+						defaultView = 'agendaDay';
+						defaultDate=URL_Serarch.get('lastViewDate');
+						break;
+					case 'week':
+						defaultView = 'agendaWeek';
+						defaultDate=URL_Serarch.get('lastViewDate');
+						break;
+					case 'month':
+						defaultView = 'month';
+						defaultDate=URL_Serarch.get('lastViewDate');
+						break;
+					case 'list':
+						defaultView = 'vtAgendaList';
+						if(URL_Serarch.get('lastViewDate')){
+							defaultDate=URL_Serarch.get('lastViewDate');
+						}
+						break
+				}
+				if(window.innerWidth < 1020){
+					defaultView = "agendaDay";
+				}
+			}else{//個人,共有カレンダー間の遷移
+				switch(URL_Serarch_PRE.get('Viewtype')){
+					case 'day':
+						defaultView = 'agendaDay';
+						defaultDate = URL_Serarch_PRE.get('lastViewDate');
+						break;
+					case 'week':
+						defaultView = 'agendaWeek';
+						defaultDate = URL_Serarch_PRE.get('lastViewDate');
+						break;
+					case 'month':
+						defaultView = 'month';
+						defaultDate = URL_Serarch_PRE.get('lastViewDate');
+						break;
+					case 'list':
+						defaultView = 'month';
+						if(URL_Serarch.get('lastViewDate')){
+							defaultDate=URL_Serarch.get('lastViewDate');
+						}
+						break;
+				}
+			}
 		}
 
 		var calenderConfigs = {
@@ -1813,31 +1848,24 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			},
 			viewRender: function (view, element) {
 				var lastviewday;
-				var URL_Serarch_view = new URLSearchParams(location.search);
-				var lastviewtype = URL_Serarch_view.get('view');
+				var URL_Serarch = new URLSearchParams(location.search);
+				var lastviewtype = URL_Serarch.get('view');
 				if(document.getElementsByClassName('fc-day-header').item(1)==null){
-					if(document.getElementsByClassName('fc-day-header').item(0)){
+					if(document.getElementsByClassName('fc-day-header').item(0)){//表示が日の時の処理
 						lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
-						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday + "&Viewtype=day");
-						
+						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' + lastviewday + "&Viewtype=day");
 					}
-					else{
-						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + "&Viewtype=list");
+					else{//表示が概要の時の処理
+						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' +"&Viewtype=list");
 					}
-
 				}
-				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date==undefined){
-					var URL_Serarch = new URLSearchParams(location.search);
-					if(URL_Serarch.get('lastVIewDate')!=null){
-						lastviewday =document.getElementsByClassName('fc-day-top').item(7).dataset.date;
-						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday.substr(0, lastviewday.lastIndexOf('-')) + "&Viewtype=month");
-
-					}
-					
+				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date==undefined){//表示が月の時の処理
+					lastviewday =document.getElementsByClassName('fc-day-top').item(7).dataset.date;
+					history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' + lastviewday.substr(0, lastviewday.lastIndexOf('-')) + "&Viewtype=month");
 				}
-				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date){
+				else if(document.getElementsByClassName('fc-day-header').item(1).dataset.date){//表示が週の時の処理
 					lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
-					history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastVIewDate=' + lastviewday + "&Viewtype=week");
+					history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' + lastviewday + "&Viewtype=week");
 				}
 				if (view.name === 'vtAgendaList') {
 					jQuery(".sidebar-essentials").addClass("hide");

--- a/layouts/v7/modules/Vtiger/partials/Topbar.tpl
+++ b/layouts/v7/modules/Vtiger/partials/Topbar.tpl
@@ -178,7 +178,7 @@
 						{assign var=USER_PRIVILEGES_MODEL value=Users_Privileges_Model::getCurrentUserPrivilegesModel()}
 						{assign var=CALENDAR_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Calendar')}
 						{if $USER_PRIVILEGES_MODEL->hasModulePermission($CALENDAR_MODULE_MODEL->getId())}
-							<li><div><a href="index.php?module=Calendar&view={$CALENDAR_MODULE_MODEL->getDefaultViewName()}" class="fa fa-calendar" title="{vtranslate('Calendar','Calendar')}" aria-hidden="true"></a></div></li>
+							<li><div><a href="index.php?module=Calendar&view={$CALENDAR_MODULE_MODEL->getDefaultViewName()}&lastViewDate=default" class="fa fa-calendar" title="{vtranslate('Calendar','Calendar')}" aria-hidden="true"></a></div></li>  
 						{/if}
 						{assign var=REPORTS_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Reports')}
 						{if $USER_PRIVILEGES_MODEL->hasModulePermission($REPORTS_MODULE_MODEL->getId())}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #326 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーにおいてリロードをしてしまうと表示している日付が今日に戻ってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. defaultdateが今日になっているため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. defaultdateとdefaultviewを今見ている日付と表示に毎回更新するようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
fullcalendarの範囲。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
#387 のissueとコンフリクトが起きそう
