### PR TITLE
fixed #498 登録/編集画面から別画面に遷移し、history.backで戻った際に一部のフィールドだけ入力中の値がクリアされていたのでリストアされるよう修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Edit.js
+++ b/layouts/v7/modules/Vtiger/resources/Edit.js
@@ -365,6 +365,91 @@ Vtiger_Index_Js("Vtiger_Edit_Js",{
         this.registerImageChangeEvent();
         this.registerValidation();
         app.event.trigger('post.editView.load', editViewContainer);
-		this.registerPageLeaveEvents();
+        this.registerPageLeaveEvents();
+
+        this.restoreDateAndTimeField(editViewContainer);
+        this.registerDateAndTimeFieldChangeEvent(editViewContainer);
+    },
+
+    restoreDateAndTimeField : function(container) {
+        thisInstance = this;
+        // onload後に復元対象のvalueが復元されるので少し遅延させる
+        setTimeout(function () {
+            thisInstance.restoreDateField();
+            thisInstance.restoreTimeField();
+            thisInstance.restoreReferenceField();
+            thisInstance.restorePicklistField();
+            thisInstance.restoreMultiPicklistField();
+        }, 10);
+    },
+
+    restoreDateField : function() {
+        var $fields = jQuery('input[data-fieldtype="date"]'+'input[name$="_historyback_restore"]');
+        $fields.each(function(index, element) {
+            var $element = jQuery(element);
+            if ($element.val()) {
+                var fieldname = $element.attr('name');
+                fieldname = fieldname.substring(0, fieldname.indexOf('_historyback_restore'));
+                jQuery('[name='+fieldname+']').val($element.val());
+            }
+        });
+    },
+
+    restoreTimeField : function() {
+        var $fields = jQuery('input[data-fieldtype="time"]'+'input[name$="_historyback_restore"]');
+        $fields.each(function(index, element) {
+            var $element = jQuery(element);
+            if ($element.val()) {
+                var fieldname = $element.attr('name');
+                fieldname = fieldname.substring(0, fieldname.indexOf('_historyback_restore'));
+                jQuery('[name='+fieldname+']').val($element.val());
+            }
+        });
+    },
+
+    restoreReferenceField : function() {
+        var $fields = jQuery('input[data-fieldtype="reference"]'+'input[name$="_historyback_restore"]');
+        $fields.each(function(index, element) {
+            var $element = jQuery(element);
+            if ($element.val()) {
+                var parent = $element.closest('td');
+
+                var fieldname = $element.attr('name');
+                var $name = jQuery('[name='+fieldname+'_name]');
+                thisInstance.setReferenceFieldValue(parent, {'name' : $name.val(), 'id' : $element.val()});
+            }
+        });
+    },
+
+    restorePicklistField : function() {
+        var $fields = jQuery('select[data-fieldtype="picklist"]');
+        $fields.each(function(index, element) {
+            $element = jQuery(element);
+            if ($element.val()) {
+                $element.trigger('change');
+            }
+        });
+    },
+
+    restoreMultiPicklistField : function() {
+        var $fields = jQuery('select[data-fieldtype="multipicklist"]');
+        $fields.each(function(index, element) {
+            $element = jQuery(element);
+            if ($element.val()) {
+                $element.trigger('change');
+            }
+        });
+    },
+
+    registerDateAndTimeFieldChangeEvent : function(container) {
+        container.on('change', 'input[data-fieldtype="date"],input[data-fieldtype="time"]', function(e) {
+            var $this = jQuery(this);
+            var fieldname = $this.attr('name');
+            var fieldvalue = $this.val();
+
+            jQuery('input[name="'+fieldname+'_historyback_restore'+'"]').val(fieldvalue);
+        });
     }
+
+
 });

--- a/layouts/v7/modules/Vtiger/resources/Edit.js
+++ b/layouts/v7/modules/Vtiger/resources/Edit.js
@@ -375,12 +375,20 @@ Vtiger_Index_Js("Vtiger_Edit_Js",{
         thisInstance = this;
         // onload後に復元対象のvalueが復元されるので少し遅延させる
         setTimeout(function () {
+            thisInstance.restoreAssignedUserIdField();
             thisInstance.restoreDateField();
             thisInstance.restoreTimeField();
             thisInstance.restoreReferenceField();
             thisInstance.restorePicklistField();
             thisInstance.restoreMultiPicklistField();
         }, 10);
+    },
+
+    restoreAssignedUserIdField : function() {
+        var $field = jQuery('[data-fieldname="assigned_user_id"]');
+        if ($field && $field.length > 0) {
+            $field.trigger('change');
+        }
     },
 
     restoreDateField : function() {

--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -885,6 +885,8 @@ Vtiger.Class('Vtiger_Index_Js', {
 			inputElement.data('value','');
 			inputElement.val("");
 			parentTdElement.find('input[name="'+fieldName+'"]').val("");
+			parentTdElement.find('input[name="'+fieldName+'_historyback_restore"]').val("");
+			parentTdElement.find('input[name="'+fieldName+'_historyback_restore_name"]').val("");
 			element.addClass('hide');
 			element.trigger(Vtiger_Edit_Js.referenceDeSelectionEvent);
 		});
@@ -1168,6 +1170,11 @@ Vtiger.Class('Vtiger_Index_Js', {
 		var selectedName = params.name;
 		var id = params.id;
 
+		var sourceFieldIdHidden = sourceField+"_historyback_restore";
+		var fieldIdHiddenElement = container.find('input[name="'+sourceFieldIdHidden+'"]');
+		var sourceFieldNameHidden = sourceField+"_historyback_restore_name";
+		var fieldNameHiddenElement = container.find('input[name="'+sourceFieldNameHidden+'"]');
+
 		if (id && selectedName) {
 			if(!fieldDisplayElement.length) {
 				fieldElement.attr('value',id);
@@ -1177,6 +1184,8 @@ Vtiger.Class('Vtiger_Index_Js', {
 				fieldElement.val(id);
 				fieldElement.data('value', id);
 				fieldDisplayElement.val(selectedName);
+				fieldIdHiddenElement.val(id);
+				fieldNameHiddenElement.val(selectedName);
 				if(selectedName) {
 					fieldDisplayElement.attr('readonly', 'readonly');
 				} else {

--- a/layouts/v7/modules/Vtiger/uitypes/Date.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Date.tpl
@@ -17,6 +17,7 @@
   {assign var="FIELD_NAME" value=$FIELD_MODEL->getFieldName()}
 {/if}
 <div class="input-group inputElement" style="margin-bottom: 3px">
+<input name="{$FIELD_NAME}_historyback_restore" data-fieldtype="date" style="display:none"></input>
 <input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" type="text" class="dateField form-control {if $IGNOREUIREGISTRATION}ignore-ui-registration{/if}" data-fieldname="{$FIELD_NAME}" data-fieldtype="date" name="{$FIELD_NAME}" data-date-format="{$dateFormat}"
     value="{$FIELD_MODEL->getEditViewDisplayValue($FIELD_MODEL->get('fieldvalue'))}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
     {if $MODE eq 'edit' && $FIELD_NAME eq 'due_date'} data-user-changed-time="true" {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -36,6 +36,8 @@
     {/if}
     {assign var="displayId" value=$FIELD_VALUE}
     <div class="input-group">
+        <input name="{$FIELD_MODEL->getFieldName()}_historyback_restore" data-fieldtype="reference" style="display:none"></input>
+        <input name="{$FIELD_MODEL->getFieldName()}_historyback_restore_name" data-fieldtype="reference" style="display:none"></input>
         <input name="{$FIELD_MODEL->getFieldName()}" type="hidden" value="{$FIELD_VALUE}" class="sourceField" data-displayvalue='{$FIELD_MODEL->getEditViewDisplayValue($FIELD_MODEL->get('fieldvalue'))}' {if $AUTOFILL_VALUE} data-autofill={Zend_Json::encode($AUTOFILL_VALUE)} {/if}/>
         <input id="{$FIELD_NAME}_display" name="{$FIELD_MODEL->getFieldName()}_display" data-fieldname="{$FIELD_MODEL->getFieldName()}" data-fieldtype="reference" type="text" 
             class="marginLeftZero autoComplete inputElement" 

--- a/layouts/v7/modules/Vtiger/uitypes/Time.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Time.tpl
@@ -16,7 +16,8 @@
 		{assign var="FIELD_NAME" value=$FIELD_MODEL->getFieldName()}
 	{/if}
 	<div class="input-group inputElement time" {if ($IS_ALLDAY == true) && ($FIELD_MODEL->getFieldName()=="time_start" || $FIELD_MODEL->getFieldName("time_end"))} style="display:none;" {/if}>
-		<input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" type="text" data-format="{$TIME_FORMAT}" class="timepicker-default form-control" value="{$FIELD_VALUE}" name="{$FIELD_NAME}"
+		<input name="{$FIELD_NAME}_historyback_restore" data-fieldtype="time" style="display:none"></input>
+		<input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" type="text" data-fieldtype="time" data-format="{$TIME_FORMAT}" class="timepicker-default form-control" value="{$FIELD_VALUE}" name="{$FIELD_NAME}"
 		{if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
 		{if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
 		{if count($FIELD_INFO['validator'])}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #498 

##  不具合の内容 / Bug
1. 登録/編集画面で入力を行い、関連項目の追加ボタン→詳細入力と進み、「戻る」ボタンや「キャンセル」ボタンで戻った際、一部のフィールドは編集していた内容が残り、一部のフィールドは編集していた内容が消えるといった状態となっていた。

##  原因 / Cause
1. ヒストリバックで編集画面に戻った際、画面描画時にJSで初期化しているフィールドについてはブラウザが復元したデータが削除されてしまっている。

##  変更内容 / Details of Change
1. 特定のフィールド（単数選択肢、複数選択肢、担当）について、編集画面を開いた際にchangeトリガを発火させることで編集中だった内容を復元
3. 特定のフィールド（関連、日付、時刻）について、編集時にchangeトリガを元にデータを保持し、ヒストリバックで戻ってきた際に保持していたデータを書き戻すように修正

## 影響範囲  / Affected Area
登録/編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
ヒストリバック時の編集フォームの復元はブラウザの仕様によるため、ブラウザの更新によって動作しなくなる可能性がある。