### PR TITLE
#452 F-RevoCRMのワークフロー機能にて送信されるメールにて、TEXT形式部分のマルチバイト文字が欠落している箇所の修正

### DIFF
--- a/modules/com_vtiger_workflow/tasks/VTEmailTask.inc
+++ b/modules/com_vtiger_workflow/tasks/VTEmailTask.inc
@@ -141,7 +141,6 @@ class VTEmailTask extends VTTask{
 			$plainBody = decode_html($content);
 			$plainBody = preg_replace(array("/<p>/i","/<br>/i","/<br \/>/i"),array("\n","\n","\n"),$plainBody);
 			$plainBody = strip_tags($plainBody);
-			$plainBody = Emails_Mailer_Model::convertToAscii($plainBody);
 			$plainBody = $emailRecord->convertUrlsToTrackUrls($plainBody,$entityId,'plain');
 			$mailerInstance->AltBody = $plainBody;
 			


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #452 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
- ワークフローで送信されるメールにて、プレーンテキスト部分のマルチバイト文字が欠落している

##  原因 / Cause
<!-- バグの原因を記述 -->
- プレーンテキスト作成時、ASCIIに変換する処理が入っていた。プレーンテキストの生成処理は以下の通り
  1. HTMLメールからタグを取り除き、`<body>～</body>`部分を抽出する
  2. ASCIIへ変換する
  3. トラッキングURLへ変換

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
- ASCIIへ変換する処理を削除

## テスト内容
- 日本語を含むURL
- htmlで装飾した日本語文字列

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- ワークフローにて送信されるメール(プレーンテキスト)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->