### PR TITLE
#531 ストが多数登録されているモジュールにて、スマホ画面がリスト一覧で埋まってしまう箇所の修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1528,6 +1528,13 @@ $languageStrings = array(
 	'Templates' => 'テンプレート',
 	//請求
 	'Member Of' => '親企業',
+	//スマホ画面で折りたたまれるリスト
+	'LBL_SHOW_LIST' => 'リストを表示',
+	'LBL_HIDE_LIST' => 'リストを非表示',
+	'LBL_SHOW_FOLDER' => 'フォルダを表示',
+	'LBL_HIDE_FOLDER' => 'フォルダを非表示',
+	'LBL_SHOW_MODULE' => 'モジュールの表示',
+	'LBL_HIDE_MODULE' => 'モジュールの非表示',
 );
 
 $jsLanguageStrings = array(

--- a/layouts/v7/modules/RecycleBin/ListViewContents.tpl
+++ b/layouts/v7/modules/RecycleBin/ListViewContents.tpl
@@ -11,7 +11,7 @@
     {include file="PicklistColorMap.tpl"|vtemplate_path:$MODULE}
     <div class="col-sm-12 col-xs-12">
         {assign var=LEFTPANELHIDE value=$CURRENT_USER_MODEL->get('leftpanelhide')}
-        <div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}">
+        <div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}" style="display: none;">
             <span class="essentials-toggle-marker fa {if $LEFTPANELHIDE eq '1'}fa-chevron-right{else}fa-chevron-left{/if} cursorPointer"></span>
         </div>
         <input type="hidden" id="pageStartRange" value="{$PAGING_MODEL->getRecordStartRange()}" />

--- a/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
@@ -14,7 +14,13 @@
             <div>
                 <input class="search-list" type="text" placeholder="Search for Modules">
             </div>
-            <div class="list-menu-content">
+            <div class="navbar-header">
+                <button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
+                    <div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_MODULE',$MODULE)}</div>
+                    <div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_MODULE',$MODULE)}</div>
+                </button>
+            </div>
+            <div class="list-menu-content" id="listMenu-collapse">
                 <div class="list-group">   
                     <ul class="lists-menu" style="list-style-type: none; padding-left: 0px;">
                         {if $MODULE_LIST|@count gt 0}

--- a/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
@@ -17,7 +17,7 @@
                     <div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_MODULE',$MODULE)}</div>
                 </button>
             </div>
-            <div class="list-menu-content" id="listMenu-collapse">
+            <div class="list-menu-content collapse" id="listMenu-collapse">
                 <div>
                     <input class="search-list" type="text" placeholder="Search for Modules">
                 </div>

--- a/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/RecycleBin/partials/SidebarEssentials.tpl
@@ -11,9 +11,6 @@
         <div class="sidebar-container lists-menu-container">
             <h5 class="sidebar-header"> {vtranslate('LBL_MODULES', 'Settings:$MODULE')} </h5>
             <hr>
-            <div>
-                <input class="search-list" type="text" placeholder="Search for Modules">
-            </div>
             <div class="navbar-header">
                 <button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
                     <div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_MODULE',$MODULE)}</div>
@@ -21,6 +18,9 @@
                 </button>
             </div>
             <div class="list-menu-content" id="listMenu-collapse">
+                <div>
+                    <input class="search-list" type="text" placeholder="Search for Modules">
+                </div>
                 <div class="list-group">   
                     <ul class="lists-menu" style="list-style-type: none; padding-left: 0px;">
                         {if $MODULE_LIST|@count gt 0}

--- a/layouts/v7/modules/Reports/ListViewContents.tpl
+++ b/layouts/v7/modules/Reports/ListViewContents.tpl
@@ -10,7 +10,7 @@
 {strip}
 	<div class="col-sm-12 col-xs-12 ">
 		{assign var=LEFTPANELHIDE value=$CURRENT_USER_MODEL->get('leftpanelhide')}
-		<div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}">
+		<div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}" style="display: none;">
 			<span class="essentials-toggle-marker fa {if $LEFTPANELHIDE eq '1'}fa-chevron-right{else}fa-chevron-left{/if} cursorPointer"></span>
 		</div>
 		<input type="hidden" name="view" id="view" value="{$VIEW}" />

--- a/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
@@ -24,7 +24,7 @@
 						<div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_FOLDER',$MODULE)}</div>
 					</button>
 				</div>
-				<div class="menu-scroller mCustomScrollBox" data-mcs-theme="dark" id="listMenu-collapse">
+				<div class="menu-scroller mCustomScrollBox collapse" data-mcs-theme="dark" id="listMenu-collapse">
 					<div>
 						<input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_FOLDERS',$MODULE)}">
 					</div>

--- a/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
@@ -21,7 +21,13 @@
 				<div>
 					<input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_FOLDERS',$MODULE)}">
 				</div>
-				<div class="menu-scroller mCustomScrollBox" data-mcs-theme="dark">
+				<div class="navbar-header">
+					<button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
+						<div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_FOLDER',$MODULE)}</div>
+						<div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_FOLDER',$MODULE)}</div>
+					</button>
+				</div>
+				<div class="menu-scroller mCustomScrollBox" data-mcs-theme="dark" id="listMenu-collapse">
 					<div class="mCustomScrollBox mCS-light-2 mCSB_inside" tabindex="0">
 						<div class="mCSB_container" style="position:relative; top:0; left:0;">
 							<div class="list-menu-content">

--- a/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Reports/partials/SidebarEssentials.tpl
@@ -18,9 +18,6 @@
 					</button> 
 				</div>
 				<hr>
-				<div>
-					<input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_FOLDERS',$MODULE)}">
-				</div>
 				<div class="navbar-header">
 					<button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
 						<div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_FOLDER',$MODULE)}</div>
@@ -28,6 +25,9 @@
 					</button>
 				</div>
 				<div class="menu-scroller mCustomScrollBox" data-mcs-theme="dark" id="listMenu-collapse">
+					<div>
+						<input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_FOLDERS',$MODULE)}">
+					</div>
 					<div class="mCustomScrollBox mCS-light-2 mCSB_inside" tabindex="0">
 						<div class="mCSB_container" style="position:relative; top:0; left:0;">
 							<div class="list-menu-content">

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -14,7 +14,7 @@
 <div class="col-sm-12 col-xs-12 ">
 	{if $MODULE neq 'EmailTemplates' && $MODULE neq 'PDFTemplates' && $SEARCH_MODE_RESULTS neq true}
 		{assign var=LEFTPANELHIDE value=$CURRENT_USER_MODEL->get('leftpanelhide')}
-		<div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}">
+		<div class="essentials-toggle" title="{vtranslate('LBL_LEFT_PANEL_SHOW_HIDE', 'Vtiger')}" style="display: none;">
 			<span class="essentials-toggle-marker fa {if $LEFTPANELHIDE eq '1'}fa-chevron-right{else}fa-chevron-left{/if} cursorPointer"></span>
 		</div>
 	{/if}

--- a/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
@@ -16,9 +16,6 @@
                 </button> 
             </div>
             <hr>
-            <div>
-                <input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_LIST',$MODULE)}">
-            </div>
             <div class="navbar-header">
                 <button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
                     <div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_LIST',$MODULE)}</div>
@@ -26,6 +23,9 @@
                 </button>
             </div>
             <div class="menu-scroller scrollContainer" style="position:relative; top:0; left:0;" id="listMenu-collapse">
+                <div>
+                    <input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_LIST',$MODULE)}">
+                </div>
                 <div class="list-menu-content">
                         {assign var="CUSTOM_VIEW_NAMES" value=array()}
                         {if $CUSTOM_VIEWS && count($CUSTOM_VIEWS) > 0}

--- a/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
@@ -22,7 +22,7 @@
                     <div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_LIST',$MODULE)}</div>
                 </button>
             </div>
-            <div class="menu-scroller scrollContainer" style="position:relative; top:0; left:0;" id="listMenu-collapse">
+            <div class="menu-scroller scrollContainer collapse" style="position:relative; top:0; left:0;" id="listMenu-collapse">
                 <div>
                     <input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_LIST',$MODULE)}">
                 </div>

--- a/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
@@ -19,9 +19,15 @@
             <div>
                 <input class="search-list" type="text" placeholder="{vtranslate('LBL_SEARCH_FOR_LIST',$MODULE)}">
             </div>
-            <div class="menu-scroller scrollContainer" style="position:relative; top:0; left:0;">
-				<div class="list-menu-content">
-						{assign var="CUSTOM_VIEW_NAMES" value=array()}
+            <div class="navbar-header">
+                <button type="button" class="listMenu-toggle navbar-toggle btn-group-justified collapsed border0" data-toggle="collapse" data-target="#listMenu-collapse" aria-expanded="false" id="collapse-button">
+                    <div id="collapse-button-on" style="display: block;">{vtranslate('LBL_SHOW_LIST',$MODULE)}</div>
+                    <div id="collapse-button-off" style="display: none;">{vtranslate('LBL_HIDE_LIST',$MODULE)}</div>
+                </button>
+            </div>
+            <div class="menu-scroller scrollContainer" style="position:relative; top:0; left:0;" id="listMenu-collapse">
+                <div class="list-menu-content">
+                        {assign var="CUSTOM_VIEW_NAMES" value=array()}
                         {if $CUSTOM_VIEWS && count($CUSTOM_VIEWS) > 0}
                             {foreach key=GROUP_LABEL item=GROUP_CUSTOM_VIEWS from=$CUSTOM_VIEWS}
                             {if $GROUP_LABEL neq 'Mine' && $GROUP_LABEL neq 'Shared'}
@@ -42,14 +48,14 @@
                                 {foreach item="CUSTOM_VIEW" from=$GROUP_CUSTOM_VIEWS name="customView"}
                                     {assign var=IS_DEFAULT value=$CUSTOM_VIEW->isDefault()}
 									{assign var="CUSTOME_VIEW_RECORD_MODEL" value=CustomView_Record_Model::getInstanceById($CUSTOM_VIEW->getId())}
-									{assign var="MEMBERS" value=$CUSTOME_VIEW_RECORD_MODEL->getMembers()}
-									{assign var="LIST_STATUS" value=$CUSTOME_VIEW_RECORD_MODEL->get('status')}
-									{foreach key=GROUP_LABEL item="MEMBER_LIST" from=$MEMBERS}
-										{if $MEMBER_LIST|@count gt 0}
-										{assign var="SHARED_MEMBER_COUNT" value=1}
-										{/if}
-									{/foreach}
-									<li style="font-size:12px;" class='listViewFilter {if $VIEWID eq $CUSTOM_VIEW->getId() && ($CURRENT_TAG eq '')} active {if $smarty.foreach.customView.iteration gt 10} {assign var=count value=1} {/if} {else if $smarty.foreach.customView.iteration gt 10} filterHidden hide{/if} '> 
+                                    {assign var="MEMBERS" value=$CUSTOME_VIEW_RECORD_MODEL->getMembers()}
+                                    {assign var="LIST_STATUS" value=$CUSTOME_VIEW_RECORD_MODEL->get('status')}
+                                    {foreach key=GROUP_LABEL item="MEMBER_LIST" from=$MEMBERS}
+                                        {if $MEMBER_LIST|@count gt 0}
+                                        {assign var="SHARED_MEMBER_COUNT" value=1}
+                                        {/if}
+                                    {/foreach}
+                                    <li style="font-size:12px;" class='listViewFilter {if $VIEWID eq $CUSTOM_VIEW->getId() && ($CURRENT_TAG eq '')} active {if $smarty.foreach.customView.iteration gt 10} {assign var=count value=1} {/if} {else if $smarty.foreach.customView.iteration gt 10} filterHidden hide{/if} '>
                                         {assign var=VIEWNAME value={vtranslate($CUSTOM_VIEW->get('viewname'), $MODULE)}}
 										{append var="CUSTOM_VIEW_NAMES" value=$VIEWNAME}
                                          <a class="filterName listViewFilterElipsis" href="{$LISTVIEW_URL|cat:'&viewname='|cat:$CUSTOM_VIEW->getId()|cat:'&app='|cat:$SELECTED_MENU_CATEGORY}" oncontextmenu="return false;" data-filter-id="{$CUSTOM_VIEW->getId()}" title="{$VIEWNAME|@escape:'html'}">{$VIEWNAME|@escape:'html'}</a> 
@@ -68,15 +74,15 @@
                                             </li>
                                         {/foreach}
                                     </ul>
-								<div class='clearfix'> 
-									{if $smarty.foreach.customView.iteration - 10 - $count} 
-										<a class="toggleFilterSize" data-more-text=" {$smarty.foreach.customView.iteration - 10 - $count} {vtranslate('LBL_MORE',Vtiger)|@strtolower}" data-less-text="Show less">
-											{if $smarty.foreach.customView.iteration gt 10} 
-												{$smarty.foreach.customView.iteration - 10 - $count} {vtranslate('LBL_MORE',Vtiger)|@strtolower} 
-											{/if} 
-										</a>{/if} 
-									</div>
-                             </div>
+                            <div class='clearfix'> 
+                                {if $smarty.foreach.customView.iteration - 10 - $count} 
+                                    <a class="toggleFilterSize" data-more-text=" {$smarty.foreach.customView.iteration - 10 - $count} {vtranslate('LBL_MORE',Vtiger)|@strtolower}" data-less-text="Show less">
+                                        {if $smarty.foreach.customView.iteration gt 10} 
+                                            {$smarty.foreach.customView.iteration - 10 - $count} {vtranslate('LBL_MORE',Vtiger)|@strtolower} 
+                                        {/if} 
+                                    </a>{/if} 
+                                </div>
+                            </div>
 					{/foreach}
 								
 							<input type="hidden" id='allFilterNames'  value='{Vtiger_Util_Helper::toSafeHTML(Zend_JSON::encode($CUSTOM_VIEWS_NAMES))}'/>

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2856,15 +2856,15 @@ Vtiger.Class("Vtiger_List_Js", {
 	},
 	// フィルターの表示/非表示
 	initializeListFilter: function () {
-		// 画面サイズが991px以下の時だけフィルターを初期非表示にする
-		if (window.innerWidth < 991) {
-			var listMenu = jQuery('#listMenu-collapse');
-			listMenu.addClass('collapse');
-		}
 		// 表示/非表示ボタンの文言切替イベントを設定
 		jQuery('#collapse-button').click(function() {
 			jQuery('#collapse-button-on').toggle();
 			jQuery('#collapse-button-off').toggle();
 		});
+		
+		// 画面サイズが991pxより大きい場合は表示/非表示ボタンを発火してフィルターを表示させる
+		if (window.innerWidth > 991) {
+			jQuery('#collapse-button').click();
+		}
 	}
 });

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2621,6 +2621,8 @@ Vtiger.Class("Vtiger_List_Js", {
 		//For Pagination
 		thisInstance.initializePaginationEvents();
 		//END
+
+		this.initializeListFilter();
 	},
 	registerHeaderReflowOnListSearchSelections: function () {
 		var listViewContentDiv = this.getListViewContainer();
@@ -2851,5 +2853,18 @@ Vtiger.Class("Vtiger_List_Js", {
 		}
 
 		return count;
+	},
+	// フィルターの表示/非表示
+	initializeListFilter: function () {
+		// 画面サイズが991px以下の時だけフィルターを初期非表示にする
+		if (window.innerWidth < 991) {
+			var listMenu = jQuery('#listMenu-collapse');
+			listMenu.addClass('collapse');
+		}
+		// 表示/非表示ボタンの文言切替イベントを設定
+		jQuery('#collapse-button').click(function() {
+			jQuery('#collapse-button-on').toggle();
+			jQuery('#collapse-button-off').toggle();
+		});
 	}
 });

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2623,6 +2623,8 @@ Vtiger.Class("Vtiger_List_Js", {
 		//END
 
 		this.initializeListFilter();
+		this.initializeSidebarEssentials();
+		this.registerWindowResize();
 	},
 	registerHeaderReflowOnListSearchSelections: function () {
 		var listViewContentDiv = this.getListViewContainer();
@@ -2866,5 +2868,60 @@ Vtiger.Class("Vtiger_List_Js", {
 		if (window.innerWidth > 991) {
 			jQuery('#collapse-button').click();
 		}
+	},
+
+	// サイドメニューの表示/非表示
+	initializeSidebarEssentials : function() {
+		// 画面サイズが991pxより大きい場合
+		if (window.innerWidth > 991) {
+			// サイドメニューの表示・非表示切り替えボタンの表示
+			jQuery('.main-container .essentials-toggle').show();
+			return;
+		}
+		// 991px以下の場合、サイドメニューが表示されていない場合は表示させる
+		if(jQuery('.sidebar-essentials').hasClass('hide')) {
+			jQuery('.main-container .essentials-toggle').click();
+		}
+	},
+	// 画面リサイズ時
+	registerWindowResize : function() {
+		// 画面サイズが991pxの場合はPCサイズ表示のフラグを立てておく
+		if (window.innerWidth > 991) {
+			__window_size_pc_flg = true;
+		}
+		jQuery(window).resize(function() {
+			if (__window_resize_timer > 0) {
+				clearTimeout(__window_resize_timer);
+			}
+			__window_resize_timer = setTimeout(function () {
+				// 991pxより大きい場合
+				if (window.innerWidth > 991) {
+					// サイドメニューのON/OFF用のトグルボタンを表示
+					jQuery('.main-container .essentials-toggle').show();
+					// フィルターが非表示の場合はフィルター表示ボタンを発火
+					if (!jQuery('#listMenu-collapse').hasClass('in')) {
+						jQuery('#collapse-button').click();
+					}
+					__window_size_pc_flg = true;
+				}
+				// 991px以下の場合
+				else {
+					// サイドメニューを表示させる
+					if(jQuery('.sidebar-essentials').hasClass('hide')) {
+						jQuery('.main-container .essentials-toggle').click();
+					}
+					// 991pxより大きい状態からサイズを縮めた場合のみ、フィルター非表示ボタンを発火させてフィルターを非表示にする
+					if (__window_size_pc_flg) {
+						jQuery('#collapse-button').click();
+						// 991px以下から更に縮めた場合に動作しないようにフラグを落とす
+						__window_size_pc_flg = false;
+					}
+					// サイドメニューのON/OFF用のトグルボタンを非表示
+					jQuery('.main-container .essentials-toggle').hide();
+				}
+			}, 200);
+		});
 	}
 });
+var __window_size_pc_flg = false;
+var __window_resize_timer = 0;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #531

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ストが多数登録されているモジュールにて、スマホ画面がリスト一覧で埋まってしまう

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. リスト・フィルター(レポート)・モジュール(ゴミ箱)をアコーディオン化
2. 検索欄をアコーディオンの中に移動
3. 画像サイズが大きい(991pxより大)場合、フィルターを表示させる
4. サイドメニューのON/OFFボタンを表示/非表示する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/75693720/168767427-d5c6c47c-666b-4087-97d9-b702077ed455.png"></td>
<td><img src="https://user-images.githubusercontent.com/75693720/168767510-2537818f-f058-4a6e-9ca8-433ff750ed22.png"></td>
<\trt>
<\table>

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->