### PR TITLE
#92 Webフォームのソースコードの表示機能を見やすくなるよう修正

### DIFF
--- a/layouts/v7/modules/Settings/Webforms/ShowForm.tpl
+++ b/layouts/v7/modules/Settings/Webforms/ShowForm.tpl
@@ -24,108 +24,109 @@
 			</div>
 			<input type="hidden" class="allowedAllFilesSize" value="{$ALLOWED_ALL_FILES_SIZE}">
 			<textarea id="showFormContent" class="input-xxlarge" style="min-height:400px;width: 100%" readonly></textarea>
+{/strip}
+<code>
+<pre>
+<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+<form id="__vtigerWebForm" name="{$RECORD_MODEL->getName()}" action="{$ACTION_PATH}" method="post" accept-charset="utf-8" enctype="multipart/form-data">
+<input type="hidden" name="publicid" value="{$RECORD_MODEL->get('publicid')}" />
+<input type="hidden" name="urlencodeenable" value="1" />
+<input type="hidden" name="name" value="{$RECORD_MODEL->getName()}" />
+{assign var=IS_CAPTCHA_ENABLED value=$RECORD_MODEL->isCaptchaEnabled()}
+  <table>
+{foreach item=FIELD_MODEL key=FIELD_NAME from=$SELECTED_FIELD_MODELS_LIST}
+{assign var=SOURCE_MODULE value=$FIELD_MODEL->getModuleName()}
+{assign var=DATA_TYPE value=$FIELD_MODEL->getFieldDataType()}
+{assign var=HIDDEN_STATUS value=$FIELD_MODEL->get('hidden')}
+{assign var=TYPE value=""}
+   <tr>
+{if $FIELD_MODEL->get('hidden') neq 1}
+   <td><label>{vtranslate(decode_html($FIELD_MODEL->get('label')), {$SOURCE_MODULE})}{if $FIELD_MODEL->get('required') eq 1}*{/if}</label></td>
+{/if}
+    <td>
+{if ($DATA_TYPE eq 'picklist' || $DATA_TYPE eq 'multipicklist')}
+{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+{assign var=PICKLIST_VALUES value=$FIELD_INFO['picklistvalues']}
+{assign var=FIELD_INFO value=Vtiger_Util_Helper::toSafeHTML(Zend_Json::encode($FIELD_INFO))}
+{assign var="SPECIAL_VALIDATOR" value=$FIELD_MODEL->getValidator()}
+{assign var=PICKLIST_NAME value=$FIELD_MODEL->get('name')}
+{if Settings_Webforms_Record_Model::isCustomField($FIELD_NAME)}
+{assign var=FIELD_LABEL value="{urlencode($FIELD_MODEL->get('label'))}"}
+{assign var=PICKLIST_DATA_LABEL value="label:{$FIELD_LABEL|replace:' ':'_'}"}
+{else}
+{assign var=PICKLIST_DATA_LABEL value=$FIELD_MODEL->get('name')}
+{/if}
+{else if ($DATA_TYPE eq "salutation") or ($DATA_TYPE eq "string") or ($DATA_TYPE eq "time") or ($DATA_TYPE eq "currency") or ($DATA_TYPE eq "url") or ($DATA_TYPE eq "phone")}
+{assign var=TYPE value="text"}
+{else if ($DATA_TYPE eq "text")}
+{assign var=TYPE value="text"}
+<textarea name="{urlencode($FIELD_MODEL->getFieldName())}" {if $FIELD_MODEL->get('required') eq 1} required{/if} 
+{if $FIELD_MODEL->get('hidden') eq 1} hidden{/if} >{$FIELD_MODEL->get('fieldvalue')}</textarea>
+{else if ($DATA_TYPE eq "email")}
+{assign var=TYPE value="email"}
+{else if ($DATA_TYPE eq "image")}
+{assign var=TYPE value="image"}
+{else if (($DATA_TYPE eq "integer") or ($DATA_TYPE eq "double"))}
+{assign var=TYPE value="number"}
+{else if ($DATA_TYPE eq "boolean")}
+{assign var=TYPE value="checkbox"}
+{else if ($DATA_TYPE eq "date")}
+{assign var=TYPE value="date"}
+{/if}
+{if $HIDDEN_STATUS eq 1}
+{assign var=TYPE value=hidden}
+{/if}
+{if $DATA_TYPE eq 'picklist'}
+<select name="{$PICKLIST_NAME}" data-label="{$PICKLIST_DATA_LABEL}" {if $FIELD_MODEL->get('required') eq 1} required{/if} {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if}>
+	<option value>{vtranslate('LBL_SELECT_VALUE',$QUALIFIED_MODULE)}</option>
+{foreach item=PICKLIST_VALUE key=PICKLIST_NAME from=$PICKLIST_VALUES}
+	<option value="{$PICKLIST_NAME}" {if trim(decode_html($FIELD_MODEL->get('fieldvalue'))) eq trim($PICKLIST_NAME)} selected {/if}>{$PICKLIST_VALUE}</option>
+{/foreach}
+</select>
+{else if $DATA_TYPE eq 'multipicklist'}
+{assign var="FIELD_VALUE_LIST" value=explode(' |##| ',$FIELD_MODEL->get('fieldvalue'))}
+<select name="{$PICKLIST_NAME}[]" data-label="{$PICKLIST_DATA_LABEL}" {if $FIELD_MODEL->get('required') eq 1} required{/if} multiple style="width: 60%;" {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if}>
+{foreach item=PICKLIST_VALUE from=$PICKLIST_VALUES}
+	<option value="{$PICKLIST_VALUE}" {if in_array(Vtiger_Util_Helper::toSafeHTML($PICKLIST_VALUE), $FIELD_VALUE_LIST)} selected {/if}>{vtranslate($PICKLIST_VALUE, $MODULE)}</option>
+{/foreach}
+</select>
+{elseif $DATA_TYPE eq "reference"}
+     <input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value="{$FIELD_MODEL->get('fieldvalue')}" />
+{assign var=EXPLODED_FIELD_VALUES value='x'|explode:$FIELD_MODEL->get('fieldvalue')}
+     <input type="{$TYPE}" value="{$FIELD_MODEL->getEditViewDisplayValue($EXPLODED_FIELD_VALUES[1])}" readonly= />
+{elseif $DATA_TYPE eq "image"}
+     <input type="file" name="{urlencode($FIELD_MODEL->getFieldName())}[]" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if} {if $FIELD_MODEL->get('required') eq 1} required{/if}/>
+{else if $DATA_TYPE eq "boolean"}
+     <input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=0 />
+{if ($HIDDEN_STATUS eq 1) and ($FIELD_MODEL->get('fieldvalue') eq "on")}
+     <input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=1 checked />
+{elseif ($HIDDEN_STATUS neq 1)}
+     <input type="{$TYPE}" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=1 {if $FIELD_MODEL->get('fieldvalue') eq "on"} checked {/if} {if ($FIELD_MODEL->get('required') eq 1) || ($FIELD_MODEL->isMandatory(true))} required{/if}/>
+{/if}
+{elseif ($DATA_TYPE neq "text") and ($DATA_TYPE neq "boolean")}
+     <input type="{$TYPE}" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value="{$FIELD_MODEL->get('fieldvalue')}" {if ($FIELD_MODEL->get('required') eq 1) || ($FIELD_MODEL->isMandatory(true))} required{/if} {if ($DATA_TYPE eq "double")} datatype="{$DATA_TYPE}" step="any" {/if}/>{if ($DATA_TYPE eq "date") and ($FIELD_MODEL->get('hidden') neq 1)}(yyyy-mm-dd){/if}
+{/if}
 
-			<code>
-				<pre>
-					<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-					<form id="__vtigerWebForm" name="{$RECORD_MODEL->getName()}" action="{$ACTION_PATH}" method="post" accept-charset="utf-8" enctype="multipart/form-data">
-						<input type="hidden" name="publicid" value="{$RECORD_MODEL->get('publicid')}" />
-						<input type="hidden" name="urlencodeenable" value="1" />
-						<input type="hidden" name="name" value="{$RECORD_MODEL->getName()}" />
-						{assign var=IS_CAPTCHA_ENABLED value=$RECORD_MODEL->isCaptchaEnabled()}
-						<table>
-							{foreach item=FIELD_MODEL key=FIELD_NAME from=$SELECTED_FIELD_MODELS_LIST}
-								{assign var=SOURCE_MODULE value=$FIELD_MODEL->getModuleName()}
-								{assign var=DATA_TYPE value=$FIELD_MODEL->getFieldDataType()}
-								{assign var=HIDDEN_STATUS value=$FIELD_MODEL->get('hidden')}
-								{assign var=TYPE value=""}
-								<tr>
+    </td>
+   </tr>
+{/foreach}
+{foreach from=$DOCUMENT_FILE_FIELDS item=DOCUMENT_FILE_FIELD}
+  <tr>
+  <td><label>{$DOCUMENT_FILE_FIELD['fieldlabel']} {if $DOCUMENT_FILE_FIELD['required']}*{/if}</label></td>
+  <td><input type="file" name="{$DOCUMENT_FILE_FIELD['fieldname']}" {if $DOCUMENT_FILE_FIELD['required']}required='required'{/if}></td>
+</tr>
+{/foreach}
+</table>
+{if $IS_CAPTCHA_ENABLED}
+ <div id="captchaField"></div>
+ <input type="hidden" id="captchaUrl" value="{$CAPTCHA_PATH}">
+ <input type="hidden" id="recaptcha_validation_value" >
+{/if}
+ <input type="submit" value="Submit" ></input>
+</form>
+</pre>
+</code>
 
-									{if $FIELD_MODEL->get('hidden') neq 1}<td><label>{vtranslate(decode_html($FIELD_MODEL->get('label')), {$SOURCE_MODULE})}{if $FIELD_MODEL->get('required') eq 1}*{/if}</label></td>{/if}
-									<td>
-										{if ($DATA_TYPE eq 'picklist' || $DATA_TYPE eq 'multipicklist')}
-											{assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
-											{assign var=PICKLIST_VALUES value=$FIELD_INFO['picklistvalues']}
-											{assign var=FIELD_INFO value=Vtiger_Util_Helper::toSafeHTML(Zend_Json::encode($FIELD_INFO))}
-											{assign var="SPECIAL_VALIDATOR" value=$FIELD_MODEL->getValidator()}
-											{assign var=PICKLIST_NAME value=$FIELD_MODEL->get('name')}
-											{if Settings_Webforms_Record_Model::isCustomField($FIELD_NAME)}
-												{assign var=FIELD_LABEL value="{urlencode($FIELD_MODEL->get('label'))}"}
-												{assign var=PICKLIST_DATA_LABEL value="label:{$FIELD_LABEL|replace:' ':'_'}"}
-											{else}
-												{assign var=PICKLIST_DATA_LABEL value=$FIELD_MODEL->get('name')}
-											{/if}
-										{else if ($DATA_TYPE eq "salutation") or ($DATA_TYPE eq "string") or ($DATA_TYPE eq "time") or ($DATA_TYPE eq "currency") or ($DATA_TYPE eq "url") or ($DATA_TYPE eq "phone")}
-											{assign var=TYPE value="text"}
-										{else if ($DATA_TYPE eq "text")}
-											{assign var=TYPE value="text"}
-											<textarea name="{urlencode($FIELD_MODEL->getFieldName())}" {if $FIELD_MODEL->get('required') eq 1} required{/if} 
-													{if $FIELD_MODEL->get('hidden') eq 1} hidden{/if} >{$FIELD_MODEL->get('fieldvalue')}</textarea>
-										{else if ($DATA_TYPE eq "email")}
-											{assign var=TYPE value="email"}
-										{else if ($DATA_TYPE eq "image")}
-											{assign var=TYPE value="image"}
-										{else if (($DATA_TYPE eq "integer") or ($DATA_TYPE eq "double"))}
-											{assign var=TYPE value="number"}
-										{else if ($DATA_TYPE eq "boolean")}
-											{assign var=TYPE value="checkbox"}
-										{else if ($DATA_TYPE eq "date")}
-											{assign var=TYPE value="date"}
-										{/if}
-										{if $HIDDEN_STATUS eq 1}
-											{assign var=TYPE value=hidden}
-										{/if}
-										{if $DATA_TYPE eq 'picklist'}
-											<select name="{$PICKLIST_NAME}" data-label="{$PICKLIST_DATA_LABEL}" {if $FIELD_MODEL->get('required') eq 1} required{/if} {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if}>
-												<option value>{vtranslate('LBL_SELECT_VALUE',$QUALIFIED_MODULE)}</option>
-												{foreach item=PICKLIST_VALUE key=PICKLIST_NAME from=$PICKLIST_VALUES}
-													<option value="{$PICKLIST_NAME}" {if trim(decode_html($FIELD_MODEL->get('fieldvalue'))) eq trim($PICKLIST_NAME)} selected {/if}>{$PICKLIST_VALUE}</option>
-												{/foreach}
-											</select>
-
-										{else if $DATA_TYPE eq 'multipicklist'}
-											{assign var="FIELD_VALUE_LIST" value=explode(' |##| ',$FIELD_MODEL->get('fieldvalue'))}
-											<select name="{$PICKLIST_NAME}[]" data-label="{$PICKLIST_DATA_LABEL}" {if $FIELD_MODEL->get('required') eq 1} required{/if} multiple style="width: 60%;" {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if}>
-												{foreach item=PICKLIST_VALUE from=$PICKLIST_VALUES}
-													<option value="{$PICKLIST_VALUE}" {if in_array(Vtiger_Util_Helper::toSafeHTML($PICKLIST_VALUE), $FIELD_VALUE_LIST)} selected {/if}>{vtranslate($PICKLIST_VALUE, $MODULE)}</option>
-												{/foreach}
-											</select>
-										{elseif $DATA_TYPE eq "reference"}
-											<input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value="{$FIELD_MODEL->get('fieldvalue')}" />
-											{assign var=EXPLODED_FIELD_VALUES value='x'|explode:$FIELD_MODEL->get('fieldvalue')}
-											<input type="{$TYPE}" value="{$FIELD_MODEL->getEditViewDisplayValue($EXPLODED_FIELD_VALUES[1])}" readonly= />
-										{elseif $DATA_TYPE eq "image"}
-											<input type="file" name="{urlencode($FIELD_MODEL->getFieldName())}[]" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" {if $FIELD_MODEL->get('hidden') eq 1} hidden{/if} {if $FIELD_MODEL->get('required') eq 1} required{/if}/>
-										{else if $DATA_TYPE eq "boolean"}
-											<input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=0 />
-											{if ($HIDDEN_STATUS eq 1) and ($FIELD_MODEL->get('fieldvalue') eq "on")}
-												<input type="hidden" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=1 checked />
-											{elseif ($HIDDEN_STATUS neq 1)}
-												<input type="{$TYPE}" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value=1 {if $FIELD_MODEL->get('fieldvalue') eq "on"} checked {/if} {if ($FIELD_MODEL->get('required') eq 1) || ($FIELD_MODEL->isMandatory(true))} required{/if}/>
-											{/if}
-										{elseif ($DATA_TYPE neq "text") and ($DATA_TYPE neq "boolean")}
-											<input type="{$TYPE}" name="{urlencode($FIELD_MODEL->getFieldName())}" data-label="{$FIELD_MODEL->get('neutralizedFieldName')}" value="{$FIELD_MODEL->get('fieldvalue')}" {if ($FIELD_MODEL->get('required') eq 1) || ($FIELD_MODEL->isMandatory(true))} required{/if} {if ($DATA_TYPE eq "double")} datatype="{$DATA_TYPE}" step="any" {/if}/>
-											{if ($DATA_TYPE eq "date") and ($FIELD_MODEL->get('hidden') neq 1)}(yyyy-mm-dd){/if}
-										{/if}
-									</td>
-								</tr>
-						{/foreach}
-						{foreach from=$DOCUMENT_FILE_FIELDS item=DOCUMENT_FILE_FIELD}
-							<tr>
-								<td><label>{$DOCUMENT_FILE_FIELD['fieldlabel']} {if $DOCUMENT_FILE_FIELD['required']}*{/if}</label></td>
-								<td><input type="file" name="{$DOCUMENT_FILE_FIELD['fieldname']}" {if $DOCUMENT_FILE_FIELD['required']}required='required'{/if}></td>
-							</tr>
-						{/foreach}
-					</table>
-					{if $IS_CAPTCHA_ENABLED}
-						<div id="captchaField"></div>
-						<input type="hidden" id="captchaUrl" value="{$CAPTCHA_PATH}">
-						<input type="hidden" id="recaptcha_validation_value" >
-					{/if}
-					<input type="submit" value="Submit" ></input>
-				</form>
-				</pre>
-			</code>
 			<input type="hidden" name="isCaptchaEnabled" value="{$IS_CAPTCHA_ENABLED}">
 		</div>
 		<div class="modal-footer">
@@ -134,4 +135,4 @@
 			</center>
 		</div>
 	</div>
-{/strip}
+

--- a/layouts/v7/modules/Settings/Webforms/resources/Detail.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Detail.js
@@ -48,82 +48,82 @@ Settings_Vtiger_Detail_Js('Settings_Webforms_Detail_Js', {
                     //show html without rendering
 					var allowedAllFilesSize = container.find('.allowedAllFilesSize').val();
 					var showFormContents = container.find('pre').html();
-					showFormContents = showFormContents + '<script  type="text/javascript">'+
-					'window.onload = function() { '+
-					'var N=navigator.appName, ua=navigator.userAgent, tem;'+
-					'var M=ua.match(/(opera|chrome|safari|firefox|msie)\\/?\\s*(\\.?\\d+(\\.\\d+)*)/i);'+
-					'if(M && (tem= ua.match(/version\\/([\\.\\d]+)/i))!= null) M[2]= tem[1];'+
-					 'M=M? [M[1], M[2]]: [N, navigator.appVersion, "-?"];'+
-					'var browserName = M[0];'+
+					showFormContents = showFormContents + '<script  type="text/javascript">'+'\n'+
+					'window.onload = function() { '+'\n'+
+					'var N=navigator.appName, ua=navigator.userAgent, tem;'+'\n'+
+					'var M=ua.match(/(opera|chrome|safari|firefox|msie)\\/?\\s*(\\.?\\d+(\\.\\d+)*)/i);'+'\n'+
+					'if(M && (tem= ua.match(/version\\/([\\.\\d]+)/i))!= null) M[2]= tem[1];'+'\n '+
+					 'M=M? [M[1], M[2]]: [N, navigator.appVersion, "-?"];'+'\n'+
+					'var browserName = M[0];'+'\n '+
 
-						'var form = document.getElementById("__vtigerWebForm"), '+
-						'inputs = form.elements; '+
-						'form.onsubmit = function() { '+
-							'var required = [], att, val; '+
-							'for (var i = 0; i < inputs.length; i++) { '+
-								'att = inputs[i].getAttribute("required"); '+
-								'val = inputs[i].value; '+
-								'type = inputs[i].type; '+
-								'if(type == "email") {'+
-									'if(val != "") {'+
-										'var elemLabel = inputs[i].getAttribute("label");'+
-										'var emailFilter = /^[_/a-zA-Z0-9]+([!"#$%&()*+,./:;<=>?\\^_`{|}~-]?[a-zA-Z0-9/_/-])*@[a-zA-Z0-9]+([\\_\\-\\.]?[a-zA-Z0-9]+)*\\.([\\-\\_]?[a-zA-Z0-9])+(\\.?[a-zA-Z0-9]+)?$/;'+
-										'var illegalChars= /[\\(\\)\\<\\>\\,\\;\\:\\\"\\[\\]]/ ;'+
-										'if (!emailFilter.test(val)) {'+
-											'alert("For "+ elemLabel +" field please enter valid email address"); return false;'+
-										'} else if (val.match(illegalChars)) {'+
-											'alert(elemLabel +" field contains illegal characters");return false;'+
-										'}'+
-									'}'+
-								'}'+
-								'if (att != null) { '+
-										'if (val.replace(/^\\s+|\\s+$/g, "") == "") { '+
-												'required.push(inputs[i].getAttribute("label")); '+
-										'} '+
-								'} '+
-							'} '+
-							'if (required.length > 0) { '+
-								'alert("The following fields are required: " + required.join()); '+
-								'return false; '+
-							'} '+
-							'var numberTypeInputs = document.querySelectorAll("input[type=number]");'+
-							'for (var i = 0; i < numberTypeInputs.length; i++) { '+
-                                'val = numberTypeInputs[i].value;'+
-                                'var elemLabel = numberTypeInputs[i].getAttribute("label");'+
-								'var elemDataType = numberTypeInputs[i].getAttribute("datatype");'+
-								'if(val != "") {'+
-									'if(elemDataType == "double") {'+
-										'var numRegex = /^[+-]?\\d+(\\.\\d+)?$/;'+
-									'}else{'+
-									'var numRegex = /^[+-]?\\d+$/;'+ 
-									'}'+
-									'if (!numRegex.test(val)) {'+
-										'alert("For "+ elemLabel +" field please enter valid number"); return false;'+
-									'}'+
-                                '}'+
-							'}'+
-							'var dateTypeInputs = document.querySelectorAll("input[type=date]");' +
-							'for (var i = 0; i < dateTypeInputs.length; i++) {' +
-							'dateVal = dateTypeInputs[i].value;' +
-							'var elemLabel = dateTypeInputs[i].getAttribute("label");' +
-							'if(dateVal != "") {' +
-							'var dateRegex = /^[1-9][0-9]{3}-(0[1-9]|1[0-2]|[1-9]{1})-(0[1-9]|[1-2][0-9]|3[0-1]|[1-9]{1})$/;' +
-							'if(!dateRegex.test(dateVal)) {' +
-							'alert("For "+ elemLabel +" field please enter valid date in required format"); return false;' +
-							'}}}'+
-							'var inputElems = document.getElementsByTagName("input");'+
-							'var totalFileSize = 0;'+
-							'for(var i = 0; i < inputElems.length; i++) {'+
-								'if(inputElems[i].type.toLowerCase() === "file") {'+
-									'var file = inputElems[i].files[0];'+
-									'if(typeof file !== "undefined") {'+
-										'var totalFileSize = totalFileSize + file.size;'+
-									'}'+
-								'}'+
-							'}'+
-							'if(totalFileSize > '+allowedAllFilesSize+') {'+
-								'alert("Maximum allowed file size including all files is 50MB.");'+
-								'return false;'+
+						'var form = document.getElementById("__vtigerWebForm"), '+'\n '+
+						'inputs = form.elements; '+'\n '+
+						'form.onsubmit = function() { '+'\n  '+
+							'var required = [], att, val; '+'\n  '+
+							'for (var i = 0; i < inputs.length; i++) { '+'\n   '+
+								'att = inputs[i].getAttribute("required"); '+'\n   '+
+								'val = inputs[i].value; '+'\n   '+
+								'type = inputs[i].type; '+'\n   '+
+								'if(type == "email") {'+'\n    '+
+									'if(val != "") {'+'\n     '+
+										'var elemLabel = inputs[i].getAttribute("label");'+'\n     '+
+										'var emailFilter = /^[_/a-zA-Z0-9]+([!"#$%&()*+,./:;<=>?\\^_`{|}~-]?[a-zA-Z0-9/_/-])*@[a-zA-Z0-9]+([\\_\\-\\.]?[a-zA-Z0-9]+)*\\.([\\-\\_]?[a-zA-Z0-9])+(\\.?[a-zA-Z0-9]+)?$/;'+'\n     '+
+										'var illegalChars= /[\\(\\)\\<\\>\\,\\;\\:\\\"\\[\\]]/ ;'+'\n     '+
+										'if (!emailFilter.test(val)) {'+'\n      '+
+											'alert("For "+ elemLabel +" field please enter valid email address");' +'\n     '+'return false;'+'\n     '+
+										'} else if (val.match(illegalChars)) {'+'\n      '+
+											'alert(elemLabel +" field contains illegal characters");return false;'+'\n     '+
+										'}'+'\n    '+
+									'}'+'\n   '+
+								'}'+'\n   '+
+								'if (att != null) { '+'\n    '+
+										'if (val.replace(/^\\s+|\\s+$/g, "") == "") { '+'\n     '+
+												'required.push(inputs[i].getAttribute("label")); '+'\n    '+
+										'} '+'\n   '+
+								'} '+'\n  '+
+							'} '+'\n  '+
+							'if (required.length > 0) { '+'\n   '+
+								'alert("The following fields are required: " + required.join()); '+'\n   '+
+								'return false; '+'\n  '+
+							'} '+'\n  '+
+							'var numberTypeInputs = document.querySelectorAll("input[type=number]");'+'\n  '+
+							'for (var i = 0; i < numberTypeInputs.length; i++) { '+'\n  '+
+                                'val = numberTypeInputs[i].value;'+'\n   '+
+                                'var elemLabel = numberTypeInputs[i].getAttribute("label");'+'\n   '+
+								'var elemDataType = numberTypeInputs[i].getAttribute("datatype");'+'\n   '+
+								'if(val != "") {'+'\n    '+
+									'if(elemDataType == "double") {'+'\n     '+
+										'var numRegex = /^[+-]?\\d+(\\.\\d+)?$/;'+'\n    '+
+									'}else{'+'\n    '+
+									'var numRegex = /^[+-]?\\d+$/;'+ '\n    '+
+									'}'+'\n    '+
+									'if (!numRegex.test(val)) {'+'\n     '+
+										'alert("For "+ elemLabel +" field please enter valid number"); return false;'+'\n    '+
+									'}'+'\n   '+
+                                '}'+'\n  '+
+							'}'+'\n  '+
+							'var dateTypeInputs = document.querySelectorAll("input[type=date]");' +'\n  '+
+							'for (var i = 0; i < dateTypeInputs.length; i++) {' +'\n  '+
+							'dateVal = dateTypeInputs[i].value;' +'\n  '+
+							'var elemLabel = dateTypeInputs[i].getAttribute("label");' +'\n  '+
+							'if(dateVal != "") {' +'\n  '+
+							'var dateRegex = /^[1-9][0-9]{3}-(0[1-9]|1[0-2]|[1-9]{1})-(0[1-9]|[1-2][0-9]|3[0-1]|[1-9]{1})$/;' +'\n  '+
+							'if(!dateRegex.test(dateVal)) {' +'\n  '+
+							'alert("For "+ elemLabel +" field please enter valid date in required format"); return false;' +'\n  '+
+							'}}}'+'\n  '+
+							'var inputElems = document.getElementsByTagName("input");'+'\n  '+
+							'var totalFileSize = 0;'+'\n  '+
+							'for(var i = 0; i < inputElems.length; i++) {'+'\n   '+
+								'if(inputElems[i].type.toLowerCase() === "file") {'+'\n    '+
+									'var file = inputElems[i].files[0];'+'\n    '+
+									'if(typeof file !== "undefined") {'+'\n     '+
+										'var totalFileSize = totalFileSize + file.size;'+'\n    '+
+									'}'+'\n    '+
+								'}'+'\n   '+
+							'}'+'\n  '+
+							'if(totalFileSize > '+allowedAllFilesSize+') {'+'\n   '+
+								'alert("Maximum allowed file size including all files is 50MB.");'+'\n   '+
+								'return false;'+'\n  '+
 							'}';
                     if(container.find('[name=isCaptchaEnabled]').val() == true) {
                         showFormContents = Settings_Webforms_Detail_Js.getCaptchaCode(showFormContents);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #92 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Webフォームの「Webフォームを表示する」を選択すると表示されるソースコードが一行で表示されるため、内容が確認しずらい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. smartyのstripタグの影響でpreタグ内の改行や空白が削除されてしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. stripタグの範囲を変更
2. インデントの調整
3. 改行の追加

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/95267222/168995534-c277dddc-827e-463b-b984-3cbc5acf11f2.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
「Webフォームを表示」の範囲
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->