### PR TITLE
#358 レコード保存時にワークフローで関連の活動を作成すると無限ループになる不具合を修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -1351,7 +1351,8 @@ function insertIntoRecurringTable(& $recurObj)
 			if ($accountid > 0) {
 				$accountids[] = $accountid;
 			}
-			$recordContactModel->save();
+			$updateQuery = "UPDATE vtiger_contactdetails SET last_action_date = ? WHERE contactid = ?";
+			$adb->pquery($updateQuery, array($this->getParentLastActionDate($contactid, $moduleName), $contactid));
 		}
 
 		$parent_id = $this->column_fields["parent_id"];
@@ -1359,19 +1360,15 @@ function insertIntoRecurringTable(& $recurObj)
 			$recordParentModel = Vtiger_Record_Model::getInstanceById($parent_id);
 			$moduleName = $recordParentModel->getModuleName();
 			if ($moduleName == 'Leads') {
-				$recordParentModel->set('id', $parent_id);
-				$recordParentModel->set('mode', 'edit');
-				$recordParentModel->set('last_action_date', $this->getParentLastActionDate($parent_id, $moduleName));
-				$recordParentModel->save();
+				$updateQuery = "UPDATE vtiger_leaddetails SET last_action_date = ? WHERE leadid = ?";
+				$adb->pquery($updateQuery, array($this->getParentLastActionDate($parent_id, $moduleName), $parent_id));
 			} elseif ($moduleName == "Potentials") {
-				$recordParentModel->set('id', $parent_id);
-				$recordParentModel->set('mode', 'edit');
-				$recordParentModel->set('last_action_date', $this->getParentLastActionDate($parent_id, $moduleName));
 				$accountid = $recordParentModel->get("related_to");
 				if($accountid > 0) {
 					$accountids[] = $accountid;
 				}
-				$recordParentModel->save();
+				$updateQuery = "UPDATE vtiger_potential SET last_action_date = ? WHERE potentialid = ?";
+				$adb->pquery($updateQuery, array($this->getParentLastActionDate($parent_id, $moduleName), $parent_id));
 			} elseif ($moduleName == "Accounts") {
 				$accountids[] = $parent_id;
 			}
@@ -1379,36 +1376,37 @@ function insertIntoRecurringTable(& $recurObj)
 
 		#顧客企業は関連の顧客担当者・案件の活動も含んで処理する
 		foreach($accountids as $accountid) {
-				$accountRecordModel = Vtiger_Record_Model::getInstanceById($accountid);
-				$relatedContactsIdList = $this->getAccountsRelatedIdList($accountid, "Contacts");
-				if ($relatedContactsIdList) {
-					$contactsLastActionDate = $this->getLastActionDateFromList($relatedContactsIdList, "Contacts");
-				}
-				$relatedPotentialsIdList = $this->getAccountsRelatedIdList($accountid, "Potentials");
-				if ($relatedPotentialsIdList) {
-					$potentialLastActionDate = $this->getLastActionDateFromList($relatedPotentialsIdList, "Potentials");
-				}
-				if (strtotime($contactsLastActionDate) > strtotime($potentialLastActionDate)) {
-					$parentLastActionDate = $contactsLastActionDate;
-				} elseif (strtotime($potentialLastActionDate) >= strtotime($contactsLastActionDate)) {
-				$parentLastActionDate =  $potentialLastActionDate;
+			$accountRecordModel = Vtiger_Record_Model::getInstanceById($accountid);
+			$relatedContactsIdList = $this->getAccountsRelatedIdList($accountid, "Contacts");
+			if ($relatedContactsIdList) {
+				$contactsLastActionDate = $this->getLastActionDateFromList($relatedContactsIdList, "Contacts");
+			}
+			$relatedPotentialsIdList = $this->getAccountsRelatedIdList($accountid, "Potentials");
+			if ($relatedPotentialsIdList) {
+				$potentialLastActionDate = $this->getLastActionDateFromList($relatedPotentialsIdList, "Potentials");
+			}
+			if (strtotime($contactsLastActionDate) > strtotime($potentialLastActionDate)) {
+				$parentLastActionDate = $contactsLastActionDate;
+			} elseif (strtotime($potentialLastActionDate) >= strtotime($contactsLastActionDate)) {
+			$parentLastActionDate =  $potentialLastActionDate;
+			} 
+			$accountLastActionDate = $this->getParentLastActionDate($accountid,"Accounts");
+			$accountRecordModel->set('mode', 'edit');
+			if (isset($parentLastActionDate) && isset($accountLastActionDate)) {
+				if (strtotime($parentLastActionDate) > strtotime($accountLastActionDate)) {
+					$last_action_date = $parentLastActionDate;
+				} elseif (strtotime($accountLastActionDate) >= strtotime($parentLastActionDate)) {
+					$last_action_date = $accountLastActionDate;
 				} 
-				$accountLastActionDate = $this->getParentLastActionDate($accountid,"Accounts");
-				$accountRecordModel->set('mode', 'edit');
-				if (isset($parentLastActionDate) && isset($accountLastActionDate)) {
-					if (strtotime($parentLastActionDate) > strtotime($accountLastActionDate)) {
-						$accountRecordModel->set('last_action_date', $parentLastActionDate);
-					} elseif (strtotime($accountLastActionDate) >= strtotime($parentLastActionDate)) {
-						$accountRecordModel->set('last_action_date', $accountLastActionDate);
-					} 
-				} elseif (isset($parentLastActionDate) && is_null($accountLastActionDate)) {
-					$accountRecordModel->set('last_action_date', $parentLastActionDate);
-				} elseif (isset($accountLastActionDate) && is_null($parentLastActionDate)) {
-					$accountRecordModel->set('last_action_date', $accountLastActionDate);
-				} else {
-					$accountRecordModel->set('last_action_date', null);
-				}
-				$accountRecordModel->save();
+			} elseif (isset($parentLastActionDate) && is_null($accountLastActionDate)) {
+				$last_action_date = $parentLastActionDate;
+			} elseif (isset($accountLastActionDate) && is_null($parentLastActionDate)) {
+				$last_action_date = $accountLastActionDate;
+			} else {
+				$last_action_date = null;
+			}
+			$updateQuery = "UPDATE vtiger_account SET last_action_date = ? WHERE accountid = ?";
+			$adb->pquery($updateQuery, array($last_action_date, $accountid));
 		}
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #358
- pullrequest #380 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 見込み客、顧客担当者、顧客企業、案件モジュールを更新する際に関連の活動を作成するワークフローを設定すると、該当モジュールのレコードの作成と編集時にエラーとなる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. レコードを作成→ワークフローによって活動が作成される→元レコードのlast action date が更新される→ワークフローによって活動が作成される→以下無限ループでエラー

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Record Modelでlast action dateを更新するとワークフローが発火してしまうため、クエリでの更新に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
見込み客、顧客担当者、顧客企業、案件、カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->