### PR TITLE
#440 クイック作成→詳細入力の遷移でfromQuickCreateフラグを削除する修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -461,6 +461,7 @@ Vtiger.Class('Vtiger_Index_Js', {
 	 * @param accepts form element as parameter
 	 */
 	quickCreateGoToFullForm: function(form, editViewUrl) {
+		jQuery('[name=fromQuickCreate]').val("");
 		var formData = form.serializeFormData();
 		//As formData contains information about both view and action removed action and directed to view
 		delete formData.module;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #400 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
* クイック作成→詳細入力＆保存の操作で、活動を作成した日に戻らない

##  原因 / Cause
<!-- バグの原因を記述 -->
* クイック作成ボタンをクリック→詳細画面ボタンをクリックの流れであるため`fromQuickCreate`フラグがtrueのまま

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* 詳細画面クリック時のイベント(quickCreateGoToFullForm)にてnullにする
* falseではなくnullなのは、Save.phpの44行目の判定を通過してしまうため。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## テスト項目
<!-- その他、特記すべき事項を記述 -->
* カレンダー一覧表示から予定を作成し、保存後その活動日に遷移する
* 共有カレンダーから遷移した場合、共有カレンダーに戻る
* クイック作成から詳細入力に遷移＆保存した場合、その活動日に遷移する
* 詳細画面→キャンセルでは本日の日付に遷移する