### PR TITLE
#328 関連モジュール表示でコメントの削除ができない問題を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -2943,13 +2943,28 @@ Vtiger.Class("Vtiger_Detail_Js",{
 					app.request.post({'data': postData}).then(function (error, res) {
 					app.helper.hideProgress();
 					var commentsContainer = detailContentsHolder.find("[data-name='ModComments']");
-					self.loadWidget(commentsContainer).then(function() {
-					app.getModuleName();
-					currentTarget.removeAttr('disabled');
-					app.event.trigger('post.summarywidget.load',commentsContainer);
-					var indexInstance = Vtiger_Index_Js.getInstance();
-					indexInstance.registerMultiUpload();
-					});
+					var afterLoadComment = function () {
+						app.getModuleName();
+						currentTarget.removeAttr('disabled');
+						app.event.trigger('post.summarywidget.load', commentsContainer);
+						var indexInstance = Vtiger_Index_Js.getInstance();
+						indexInstance.registerMultiUpload();
+					}
+					if (commentsContainer.length == 0) {
+						var deleteRelatedModuleComment = function (commentId) {
+							var aDeferred = jQuery.Deferred();
+							try {
+								$('li.commentDetails:has(div.commentInfoHeader[data-commentid="' + commentId + '"])').remove();
+								aDeferred.resolve();
+							} catch (e) {
+								aDeferred.reject();
+							}
+							return aDeferred.promise();
+						}
+						deleteRelatedModuleComment(commentId).then(afterLoadComment);
+					} else {
+						self.loadWidget(commentsContainer).then(afterLoadComment);
+					}
 				},
 						function (error, err) {
 	


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #328 
- pullrequest #529 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連モジュールの場所に表示されるコメントの削除ができない問題を修正

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 概要画面のコメント部分と関連モジュールのコメント部分はHTML構成が異なるにも関わらず、同一のセレクタを適用して削除後の再読み込みを行おうとしていたためエラーが起きていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 関連モジュールの場合、再読み込みでなくjqueryのremove()で該当レコードの表示を削除するようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/53038605/171818207-fe0b2018-3352-4a7b-a399-e2e9e9ddbd03.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールのコメント欄

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->