### PR TITLE
#542 日報の概要画面にある活動の「削除」ボタンを削除&その他モジュールの概要画面にある活動の「削除」ボタンの表示を「関連を外す」アイコンに変更

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1559,6 +1559,7 @@ $jsLanguageStrings = array(
 	'INVALID_NUMBER_OF' => '無効な数字：',
 	'INVALID_NUMBER' => '無効な数字',
 	'JS_LBL_ARE_YOU_SURE_YOU_WANT_TO_DELETE' => '削除しますか？',
+	'JS_LBL_DELETE_RELATED_ACTIVITY' => '関連を外しますか？',
 
 	'OVERWRITE_EXISTING_MSG1' => '既存住所を選択した住所の詳細 ( ',
 	'OVERWRITE_EXISTING_MSG2' => ') で上書きしますか？',

--- a/layouts/v7/modules/Vtiger/RelatedActivities.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedActivities.tpl
@@ -52,7 +52,7 @@
 									<div class="summaryViewEntries">
 										{if $DETAILVIEW_PERMITTED == 'yes'}<a href="{$RECORD->getDetailViewUrl()}" title="{$RECORD->get('subject')}">{$RECORD->get('subject')}</a>{else}{$RECORD->get('subject')}{/if}&nbsp;&nbsp;
 										{if $EDITVIEW_PERMITTED == 'yes'}<a href="{$RECORD->getEditViewUrl()}&sourceModule={$SOURCE_MODEL->getModuleName()}&sourceRecord={$SOURCE_MODEL->getId()}&relationOperation=true" class="fieldValue"><i class="summaryViewEdit fa fa-pencil" title="{vtranslate('LBL_EDIT',$MODULE_NAME)}"></i></a>{/if}&nbsp;
-										{if $DELETE_PERMITTED == 'yes'}<a onclick="Vtiger_Detail_Js.deleteRelatedActivity(event);" data-id="{$RECORD->getId()}" data-recurring-enabled="{$RECORD->isRecurringEnabled()}" class="fieldValue"><i class="summaryViewEdit fa fa-trash " title="{vtranslate('LBL_DELETE',$MODULE_NAME)}"></i></a>{/if}
+										{if $DELETE_PERMITTED == 'yes' && $IS_DAILYREPORT == false}<a onclick="Vtiger_Detail_Js.deleteRelatedActivity(event);" data-id="{$RECORD->getId()}" data-recurring-enabled="{$RECORD->isRecurringEnabled()}" class="fieldValue"><i style="font-size: 12px;" class="summaryViewEdit vicon-linkopen" title="{vtranslate('LBL_UNLINK',$MODULE_NAME)}"></i></a>{/if}
 									</div>
 								{assign var=START_DATE_AND_TIME value=Vtiger_Util_Helper::formatDateTimeIntoDayString("$START_DATE $START_TIME")}
 								{assign var=OWNER value=$RECORD->get('smownerid')}

--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -73,7 +73,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			function(error, err) {
 			});
 		} else {
-			var message = app.vtranslate('JS_LBL_ARE_YOU_SURE_YOU_WANT_TO_DELETE');
+			var message = app.vtranslate('JS_LBL_DELETE_RELATED_ACTIVITY');
 			app.helper.showConfirmationBox({'message' : message}).then(function(data) {
 				thisInstance.deleteActivityRelation(postData);
 			},

--- a/modules/Dailyreports/views/Detail.php
+++ b/modules/Dailyreports/views/Detail.php
@@ -185,6 +185,7 @@ class Dailyreports_Detail_View extends Vtiger_Detail_View {
 			$viewer->assign('PAGING_MODEL', $pagingModel);
 			$viewer->assign('PAGE_NUMBER', $pageNumber);
 			$viewer->assign('ACTIVITIES', $relatedActivities);
+			$viewer->assign('IS_DAILYREPORT', True);
 
 			return $viewer->view('RelatedActivities.tpl', $moduleName, true);
 		}


### PR DESCRIPTION
日報の概要画面にある活動の「削除」ボタンを削除
その他モジュールの概要画面にある活動の「削除」ボタンの表示を「関連を外す」アイコンに変更

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #542

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 日報以外のモジュールの概要画面に表示される関連活動は削除ボタンで削除しても関連が外れるだけで削除されない
2. 日報の概要画面に表示される活動は削除ボタンを押しても削除されない


##  原因 / Cause
<!-- バグの原因を記述 -->
1. 内部的には関連付けを外す処理になっている
1. 日報の概要画面に表示される活動は日報に紐づいているのではなく、当日にログインユーザーが担当の活動が表示されているだけなので削除ボタンを押しても表示され続ける

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. アイコンと文字を｢関連を外す｣に変更
2. 日報モジュールにおいては｢削除｣も｢関連を外す｣も非表示に修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
関連に活動を登録できるモジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
概要画面の確認モーダルは関連活動のみで表示されるため｢関連を外しますか？｣に修正したが、関連モジュールの一覧表示においては影響範囲が読めないため｢削除しますか？｣(なぜか顧客企業のみは｢削除してもよろしいですか？｣)のままになっている。
![image](https://user-images.githubusercontent.com/53038605/171829916-25d76211-d1f4-4e41-9d37-8c2d49f947f5.png)

![image](https://user-images.githubusercontent.com/53038605/171830092-933c4f4c-fec0-4195-81bd-98dba4140bdf.png)
