### PR TITLE
#536 顧客担当者概要画面からチケット作成を行った際に、担当者に紐づく顧客企業を自動的に登録する

### DIFF
--- a/modules/Contacts/models/RelationListView.php
+++ b/modules/Contacts/models/RelationListView.php
@@ -9,4 +9,18 @@
  *************************************************************************************/
 
 class Contacts_RelationListView_Model extends Vtiger_RelationListView_Model {
+    
+	public function getCreateViewUrl() {
+		$createViewUrl = parent::getCreateViewUrl();
+		
+		$relationModuleModel = $this->getRelationModel()->getRelationModuleModel();
+		if($relationModuleModel->getName() == 'HelpDesk') {
+			if($relationModuleModel->getField('parent_id')->isViewable()) {
+				$createViewUrl .='&parent_id='.$this->getParentRecordModel()->get('account_id');
+			}
+		}
+
+		return $createViewUrl;
+	}
+
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #536

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 顧客担当者概要画面からチケット作成を行った際に、担当者に紐づく顧客企業を自動的に登録してほしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 顧客担当者詳細画面からチケット作成の際、リクエストURLにparent_idが含まれていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 顧客担当者に関連する顧客企業idをURLに追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
顧客担当者->チケット(HelpDesk)作成・詳細入力画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->