### PR TITLE
#325 カレンダーのスケジュール削除時に共同参加者も削除する修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1394,6 +1394,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				message: app.vtranslate('LBL_DELETE_CONFIRMATION')
 			}).then(function () {
 				thisInstance._deleteCalendarEvent(eventId, sourceModule);
+				if(app.view() === 'SharedCalendar'){
+					thisInstance._updateAllOnCalendar("Calendar");
+				}
 			});
 		}
 	},


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #325 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーのスケジュール削除時に共同参加者が削除されない。リロードすることで削除される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 削除時にcalendarviewの更新が行われていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 削除後に共有カレンダーでcalendarviewの更新を行う。個人カレンダーでは行わない

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
共有カレンダーにて削除を行ったときの処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->