### PR TITLE
#326 ホーム画面をカレンダーに設定したときにデフォルト表示になるように修正

### DIFF
--- a/includes/main/WebUI.php
+++ b/includes/main/WebUI.php
@@ -167,7 +167,7 @@ class Vtiger_WebUI extends Vtiger_EntryPoint {
 							} else {
 								$view = "Calendar";
 							}
-							$header = 'Location:index.php?module=Calendar&view='.$view;
+							$header = 'Location:index.php?module=Calendar&view='.$view.'&lastViewDate=default';
 							$qualifiedModuleName = 'Calendar';
 							header($header);
 						}

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1871,7 +1871,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 					if(document.getElementsByClassName('fc-day-header').item(0)){//表示が日の時の処理
 						lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
 						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' + lastviewday + "&Viewtype=day");
-						thisInstance.updateSideberCalendarLinks(lastviewtype, lastviewday);
+						thisInstance.updateSideberCalendarLinks('day', lastviewday);
 					}
 					else{//表示が概要の時の処理
 						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' +"&Viewtype=list");


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #326 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ホーム画面のカレンダーにユーザー設定したデフォルト表示が反映されていない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ホーム画面へのリンクにViewtypeやviewの情報が入っていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ホーム画面へのリンクにlastViewDate=defaultを追加した。
2. day表示から個人カレンダーや共有カレンダーに遷移した時に表示形式を保持するように修正した。


## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/95267222/172335841-cfc8d237-bef4-4404-92ab-76048dc78f9c.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーの表示の範囲。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->