### PR TITLE
#561 スマホでカレンダーを表示した際に、日表示になるように修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1786,7 +1786,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			editable: true,
 			eventLimit: true,
 			defaultDate:defaultDate,
-			defaultView:defaultView,
+			defaultView: ($(window).width() > 1020 ? userDefaultActivityView : 'agendaDay'),
 			slotLabelFormat: userDefaultTimeFormat,
 			timeFormat: userDefaultTimeFormat,
 			defaultDate: defaultDate,
@@ -1871,7 +1871,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 					if(document.getElementsByClassName('fc-day-header').item(0)){//表示が日の時の処理
 						lastviewday =document.getElementsByClassName('fc-day-header').item(0).dataset.date;
 						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' + lastviewday + "&Viewtype=day");
-						thisInstance.updateSideberCalendarLinks(lastviewtype, lastviewday);
+						thisInstance.updateSideberCalendarLinks('day', lastviewday);
 					}
 					else{//表示が概要の時の処理
 						history.replaceState('', '','index.php?module=Calendar&view='+ lastviewtype +'&lastViewDate=' +"&Viewtype=list");


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #561 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. スマートフォンでカレンダーを閲覧した際に、日表示ではなくカレンダー設定のデフォルト表示で表示するようになっていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  前回の修正でカレンダー設定のデフォルト表示を表示するようにしてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 表示形式をスクリーンの幅は1020px以下の場合に日付表示にするように変更した。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/95267222/173501301-b818e516-d998-48f5-9aad-f74f86624121.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーの表示範囲
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->