### PR TITLE
#538 活動を複製するときにEnterキーを連打すると活動が複数作成される問題を修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1437,6 +1437,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 					});
 				} else {
 					thisInstance._updateEvent(form);
+					jQuery("button[name='saveButton']").prop("disabled", true);
 				}
 			}
 		};


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #538 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動の複製を行うときにクイック作成画面でEnterキーを連打すると複数活動が複製されてしまっていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動をアップデートする関数内でsaveButtonのdisableを解除してから活動の保存を行っていたが、その後にdisableを付け足されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動を複製した最後にsaveButtonにdisable属性を付与した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/173527219-ac979b2c-05ec-4ef7-94c1-0640c95f1808.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーの活動の保存編集複製の範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
編集時になぜdisableを解除していたのかがわからなかった。
テストは一通り行ったがdisableをつけると動かない箇所があるのかもしれない。