### PR TITLE
#556 レポートの項目選択の最大数を60に拡張

### DIFF
--- a/layouts/v7/modules/Reports/resources/Edit2.js
+++ b/layouts/v7/modules/Reports/resources/Edit2.js
@@ -155,7 +155,7 @@ Reports_Edit_Js("Reports_Edit2_Js",{},{
 	 */
 	registerSelect2ElementForReportColumns : function() {
 		var selectElement = this.getReportsColumnsList();
-		vtUtils.showSelect2ElementView(selectElement,{maximumSelectionSize: 25});
+		vtUtils.showSelect2ElementView(selectElement,{maximumSelectionSize: 60});
 	},
 
 	/**

--- a/layouts/v7/modules/Reports/step2.tpl
+++ b/layouts/v7/modules/Reports/step2.tpl
@@ -42,7 +42,7 @@
         <input type="hidden" class="step" value="2" />
         <div class="" style="border:1px solid #ccc;padding:4%;">
             <div class="form-group">
-                <label>{vtranslate('LBL_SELECT_COLUMNS',$MODULE)}({vtranslate('LBL_MAX',$MODULE)} 25)</label>
+                <label>{vtranslate('LBL_SELECT_COLUMNS',$MODULE)}({vtranslate('LBL_MAX',$MODULE)} 60)</label>
                 <select data-placeholder="{vtranslate('LBL_ADD_MORE_COLUMNS',$MODULE)}" id="reportsColumnsList" style="width :100%;" class="select2-container select2 col-lg-11 columns"  data-rule-required="true" multiple="">
                     {foreach key=PRIMARY_MODULE_NAME item=PRIMARY_MODULE from=$PRIMARY_MODULE_FIELDS}
                         {foreach key=BLOCK_LABEL item=BLOCK from=$PRIMARY_MODULE}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #556 

##  不具合の内容 / Bug
1. レポートの項目選択の最大数を25個から60個に拡張したい。

##  原因 / Cause
1. 最大選択数が25個に設定されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. レポートの最大選択数'LBL_MAX'を60に変更した。

## スクリーンショット / Screenshot
![スクリーンショット (2)](https://user-images.githubusercontent.com/86254425/173781648-a70b8748-cdc7-4ea5-923d-8923dff8fba5.png)

#
## 影響範囲  / Affected Area
レポートに記載される結果の増加

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->