### PR TITLE
#555 レポートの副モジュールの最大選択数の拡張

### DIFF
--- a/layouts/v7/modules/Reports/Step1.tpl
+++ b/layouts/v7/modules/Reports/Step1.tpl
@@ -66,7 +66,7 @@
             </div>
             <div class="row">
                 <div class="form-group">
-                    <label class="col-lg-3 control-label textAlignLeft">{vtranslate('LBL_SELECT_RELATED_MODULES',$MODULE)}&nbsp;({vtranslate('LBL_MAX',$MODULE)}&nbsp;2)</label>
+                    <label class="col-lg-3 control-label textAlignLeft">{vtranslate('LBL_SELECT_RELATED_MODULES',$MODULE)}&nbsp;({vtranslate('LBL_MAX',$MODULE)}&nbsp;4)</label>
                     <div class="col-lg-4">
                         {assign var=SECONDARY_MODULES_ARR value=explode(':',$REPORT_MODEL->getSecondaryModules())}
                         {assign var=PRIMARY_MODULE value=$REPORT_MODEL->getPrimaryModule()}

--- a/layouts/v7/modules/Reports/resources/Edit1.js
+++ b/layouts/v7/modules/Reports/resources/Edit1.js
@@ -209,7 +209,7 @@ Reports_Edit_Js("Reports_Edit1_Js",{},{
 	 */
 	registerSelect2ElementForSecondaryModulesSelection : function() {
 		var secondaryModulesContainer = this.getSecondaryModuleContainer();
-		vtUtils.showSelect2ElementView(secondaryModulesContainer,{maximumSelectionSize: 2});
+		vtUtils.showSelect2ElementView(secondaryModulesContainer,{maximumSelectionSize: 4});
 	},
 	
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #555

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートの関連モジュールの数を2個から4個に変更したい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. レポートの関連モジュールの最大選択数が2に設定されている。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  レポートの関連モジュールの最大選択数を4に変更する。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (4)](https://user-images.githubusercontent.com/86254425/173793524-84395ef7-0335-44cb-967e-16b0fe3232ba.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポート結果の表示量の増加。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->