### PR TITLE
#544 カレンダーの日付形式をmm-dd-yyyyにするとカレンダーが使えなくなる箇所の修正

### DIFF
--- a/include/fields/DateTimeField.php
+++ b/include/fields/DateTimeField.php
@@ -255,7 +255,9 @@ class DateTimeField {
 			$user = $current_user;
 		}
 		$timeZone = $user->time_zone ? $user->time_zone : $default_timezone;
-		$value = self::sanitizeDate($value, $user);
+		if(!preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/',$value)) {
+			$value = self::sanitizeDate($value, $user);
+		}
 		return DateTimeField::convertTimeZone($value, $timeZone, self::getDBTimeZone() );
 	}
 
@@ -380,7 +382,7 @@ class DateTimeField {
 					case 'mm.dd.yyyy': list($m, $d, $y) = explode('.', $date); break;
 					case 'dd.mm.yyyy': list($d, $m, $y) = explode('.', $date); break;
 					case 'dd/mm/yyyy': list($d, $m, $y) = explode('/', $date); break;
-					case 'mm/dd/yyyy': list($d, $m, $y) = explode('/', $date); break;
+					case 'mm/dd/yyyy': list($m, $d, $y) = explode('/', $date); break;
 					case 'mm-dd-yyyy': list($m, $d, $y) = explode('-', $date); break;
 					case 'dd-mm-yyyy': list($d, $m, $y) = explode('-', $date); break;
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #544 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーの日付形式をmm-dd-yyyyにするとカレンダーが使えなくなる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. リクエストの日付形式は"yyyy-mm-dd"であるにも関わらず、ユーザーの設定している日付形式を参照して"yyyy-mm-dd"に書き換えようとする(サニタイズ)ため
(例) 
受信したリクエスト : 2022-06-21
↓
日付形式(mm-dd-yyyy)を参照してサニタイズ
↓
21-2022-06 ⇒無効な形式であるためカレンダーが使えなくなる

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. サニタイズ前にリクエストの日付形式が"yyyy-○○-○○"かどうかチェックする
2. sanitizeDate()にて条件が不適切であったので修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* DateTimeField::convertToDBTimeZone()を使用する箇所であるため影響範囲は広い
  * カレンダー
  * ワークフロー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->