### PR TITLE
#569 レポートで画面サイズを縮小した時に、表示が崩れるバグを修正

### DIFF
--- a/layouts/v7/modules/Reports/RelatedFields.tpl
+++ b/layouts/v7/modules/Reports/RelatedFields.tpl
@@ -12,7 +12,7 @@
 {strip}
     <span>
         <div class="col-lg-6">
-            <select class="select2 col-lg-11 selectedSortFields " name="selectstep2dropdown_{$ROW_VAL}">
+            <select class="select2 col-lg-11 selectedSortFields " name="selectstep2dropdown_{$ROW_VAL}" style="float:left;">
                 <option value="none">{vtranslate('LBL_NONE',$MODULE)}</option>
                 {foreach key=PRIMARY_MODULE_NAME item=PRIMARY_MODULE from=$PRIMARY_MODULE_FIELDS}
                     {foreach key=BLOCK_LABEL item=BLOCK from=$PRIMARY_MODULE}
@@ -36,12 +36,12 @@
         </div>
     </span>
     <span class="col-lg-6">
-        <div class="row">
+        <span class="">
             <span class="col-lg-6">
                 {assign var=ROW value='row_'|cat:$ROW_VAL}
                 <input type="radio" name="{$ROW}" class="sortOrder" value="Ascending" {if $SELECTED_SORT_FIELD_VALUE eq Ascending} checked="" {/if} />&nbsp;<span>{vtranslate('LBL_ASCENDING',$MODULE)}</span>&nbsp;&nbsp;
                 <input type="radio" name="{$ROW}" class="sortOrder" value="Descending" {if $SELECTED_SORT_FIELD_VALUE eq Descending} checked="" {/if}/>&nbsp;<span>{vtranslate('LBL_DESCENDING',$MODULE)}</span>
             </span>
-        </div>
+        </span>
     </span>
 {/strip}

--- a/layouts/v7/modules/Reports/step2.tpl
+++ b/layouts/v7/modules/Reports/step2.tpl
@@ -80,7 +80,7 @@
                     {assign var=SELECTED_SORT_FEILDS_ARRAY value=$SELECTED_SORT_FIELDS}
                     {assign var=SELECTED_SORT_FIELDS_COUNT value=count($SELECTED_SORT_FEILDS_ARRAY)}
                     {while $SELECTED_SORT_FIELDS_COUNT lt 3 }
-                        <div class="row sortFieldRow" style="padding-bottom:10px;">
+                        <div class="row sortFieldRow" style="padding:10px;">
                             {include file='RelatedFields.tpl'|@vtemplate_path:$MODULE ROW_VAL=$ROW_VAL}
                             {assign var=ROW_VAL value=($ROW_VAL+1)}
                             {assign var=SELECTED_SORT_FIELDS_COUNT value=($SELECTED_SORT_FIELDS_COUNT+1)}

--- a/layouts/v7/skins/contact/style.css
+++ b/layouts/v7/skins/contact/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/inventory/style.css
+++ b/layouts/v7/skins/inventory/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -2894,6 +2894,7 @@ input[type="text"]:read-only {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/marketing_and_sales/style.css
+++ b/layouts/v7/skins/marketing_and_sales/style.css
@@ -2858,6 +2858,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/project/style.css
+++ b/layouts/v7/skins/project/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/sales/style.css
+++ b/layouts/v7/skins/sales/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/support/style.css
+++ b/layouts/v7/skins/support/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;

--- a/layouts/v7/skins/tools/style.css
+++ b/layouts/v7/skins/tools/style.css
@@ -2864,6 +2864,7 @@ th {
   cursor: pointer;
   position: relative;
   width: 18%;
+  min-width: 100px;
 }
 .crumbs li:first-child {
   border-top: 20px solid #ECECEC;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #569

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートで画面サイズを小さくすると表示が崩れてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. レイアウトの設定がうまくいっていなかった。
2. classの設定ミスで選択ボックスの高さにずれがあった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. classとstyleの設定を変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (10)](https://user-images.githubusercontent.com/86254425/174989718-a2d54e38-e6ca-4f26-bce8-2c37f9cd7402.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
変更箇所と同ページの表示
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->