### PR TITLE
#570 同名のレポートが存在した場合の警告文を変更。

### DIFF
--- a/languages/ja_jp/Reports.php
+++ b/languages/ja_jp/Reports.php
@@ -231,6 +231,7 @@ $languageStrings = array(
 );
 $jsLanguageStrings = array(
 	'JS_DUPLICATE_RECORD' => 'レポートの複製',
+	'JS_SAME_REPORT_NAME' => '同名のレポートが存在します。',
 	'JS_CALCULATION_LINE_ITEM_FIELDS_SELECTION_LIMITATION' => '制限事項：  品目の項目 ( 定価、割引と数量 ) は、他の計算項目が選択されていない場合にのみ使用できます',
 	'JS_NO_CHART_DATA_AVAILABLE' => 'データは利用できません。選択した項目を確認してください。',
     'JS_CHART_PINNED_TO_DASHBOARD' => 'グラフをダッシュボードに追加しました',

--- a/layouts/v7/modules/Reports/resources/Edit1.js
+++ b/layouts/v7/modules/Reports/resources/Edit1.js
@@ -197,7 +197,7 @@ Reports_Edit_Js("Reports_Edit1_Js",{},{
 					title: app.vtranslate('JS_DUPLICATE_RECORD'),
 					text: data['message']
 				};
-				app.helper.showErrorNotification({"message":app.vtranslate("JS_DUPLICATE_RECORD")});
+				app.helper.showErrorNotification({"message":app.vtranslate("JS_SAME_REPORT_NAME")});
 				aDeferred.reject();
 			}
 			);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #570 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートを作成する際、同名のレポートが存在した場合に出る警告文が「レポートの複製」であるため、原因がわかりずらい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 存在するレポート名を入力した際に出る警告文が「レポートの複製」と設定されている。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「同名のレポートが存在します。」という警告文を作成し、存在するレポート名を入力した際に表示するようにする。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (12)](https://user-images.githubusercontent.com/86254425/176114023-273cc926-0075-48c6-8ef9-a8bacbd5c645.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
その他の警告文の表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->