### PR TITLE
#577 PDFテンプレートに画像をコピー＆ペーストで貼り付けると、PDFが出力されない箇所の修正

### DIFF
--- a/libraries/tcpdf/tcpdf.php
+++ b/libraries/tcpdf/tcpdf.php
@@ -18885,6 +18885,9 @@ Putting 1 is equivalent to putting 0 and calling Ln() just after. Default value:
 					// data stream
 					$imgsrc = '@'.base64_decode(substr($imgsrc, 1));
 					$type = '';
+				} elseif(preg_match('#^data:image/[^;]+;base64,#', $imgsrc)){
+					$imgsrc = '@'.base64_decode(preg_replace('#^data:image/[^;]+;base64,#', '', $imgsrc));
+					$type = '';
 				} else {
 					if (($imgsrc[0] === '/') AND !empty($_SERVER['DOCUMENT_ROOT']) AND ($_SERVER['DOCUMENT_ROOT'] != '/')) {
 						// fix image path

--- a/modules/Migration/schema/736_to_737.php
+++ b/modules/Migration/schema/736_to_737.php
@@ -1,0 +1,17 @@
+<?php
+/*+********************************************************************************
+* The contents of this file are subject to the vtiger CRM Public License Version 1.0
+* ("License"); You may not use this file except in compliance with the License
+* The Original Code is: vtiger CRM Open Source
+* The Initial Developer of the Original Code is vtiger.
+* Portions created by vtiger are Copyright (C) vtiger.
+* All Rights Reserved.
+*********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+	global $current_user, $adb;
+	$db = PearDatabase::getInstance();
+
+    // PDFテンプレートに大きなサイズの画像を張り付ける場合、bodyが途切れるのでtextからlongtextへ変更する
+    $db->query('ALTER TABLE vtiger_pdftemplates MODIFY body longtext;');
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #577 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 画像を添付した場合、PDFが出力されないもしくは出力されたPDFに画像が添付されてない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 画像ファイルのデコードに失敗していた
2. preg_split()にて検索結果が多いため、処理落ちしていた
3. 大きな画像ファイルを張り付けた場合、DBのカラムサイズの上限に引っかかっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. base64のデコード処理を追加
2. preg_split()前にimgタグを置換する
3. DBのカラム型をtextからlongtextへ変更する(7.3.6→7.3.7のマイグレーション)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- PDFテンプレートのプレビュー表示
- PDFテンプレートの出力

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->