### PR TITLE
カレンダー設定を開いたときに、画面の幅が狭いとカレンダー共有の表示が崩れる。

### DIFF
--- a/layouts/v7/modules/Calendar/CalendarSettings.tpl
+++ b/layouts/v7/modules/Calendar/CalendarSettings.tpl
@@ -116,8 +116,8 @@
 							</div>
 							{assign var=SHARED_TYPE value=$SHAREDTYPE}
 							<div class="form-group">
-								<label class="fieldLabel col-lg-4">{vtranslate('LBL_CALENDAR_SHARING',$MODULE)}</label>
-								<div class="fieldValue col-lg-8 col-sm-8 col-xs-8" style="margin-top: -8px; padding-left: 35px;">
+								<label class="fieldLabel col-lg-4 col-sm-4 col-xs-4">{vtranslate('LBL_CALENDAR_SHARING',$MODULE)}</label>
+								<div class="fieldValue col-lg-8 col-sm-8 col-xs-8" style="margin-top: -8px; padding-left: 35px;"> 
 									<label class="radio inline"><input type="radio" value="private"{if $SHARED_TYPE == 'private'} checked="" {/if} name="sharedtype" />&nbsp;{vtranslate('Private',$MODULE)}&nbsp;</label>
 									<label class="radio inline"><input type="radio" value="public" {if $SHARED_TYPE == 'public'} checked="" {/if} name="sharedtype" />&nbsp;{vtranslate('Public',$MODULE)}&nbsp;</label>
 									<label class="radio inline"><input type="radio" value="selectedusers" {if $SHARED_TYPE == 'selectedusers'} checked="" {/if} data-sharingtype="selectedusers" name="sharedtype" id="selectedUsersSharingType" />&nbsp;{vtranslate('Selected Users',$MODULE)}</label><br><br>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #579  

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーの設定画面を開いたときに、画面の幅を狭めると「カレンダー共有」の表示が崩れる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. グリッド幅の指定にミスがあった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. カレンダー共有ラベルのグリッド幅指定を変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
[
![カレンダー設定画面](https://user-images.githubusercontent.com/107910164/178464742-861f22bf-9625-4080-962e-9d6176f855a1.png)
](url)
## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー設定の画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->