### PR TITLE
#564 TODOを編集した場合のメッセージの不具合を修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1066,14 +1066,14 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				if (e.isDefaultPrevented()) {
 					return false;
 				}
-				var formData = jQuery(form).serialize();
+				var formData = jQuery(form).serializeFormData();
 				app.helper.showProgress();
 				app.request.post({data: formData}).then(function (err, data) {
 					app.helper.hideProgress();
 					if (!err) {
 						jQuery('.vt-notification').remove();
 						app.helper.hideModal();
-						var message = typeof formData.record !== 'undefined' ? app.vtranslate('JS_EVENT_UPDATED') : app.vtranslate('JS_RECORD_CREATED');
+						var message = formData.record !== "" ? app.vtranslate('JS_EVENT_UPDATED') : app.vtranslate('JS_RECORD_CREATED');
 						app.helper.showSuccessNotification({"message": message});
 						thisInstance.showEventOnCalendar(data);
 					} else {
@@ -1409,7 +1409,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			app.helper.hideProgress();
 			if (!err) {
 				jQuery('.vt-notification').remove();
-				app.helper.showSuccessNotification({"message": ''});
+				var message = typeof formData.record !== "" ? app.vtranslate('JS_EVENT_UPDATED') : app.vtranslate('JS_RECORD_CREATED');
+				app.helper.showSuccessNotification({"message": message});
 				app.event.trigger("post.QuickCreateForm.save", data, jQuery(form).serializeFormData());
 				app.helper.hideModal();
 			} else {

--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -606,14 +606,14 @@ Vtiger.Class('Vtiger_Index_Js', {
 				if(this.numberOfInvalids() > 0) {
 					return false;
 				}
-				var formData = jQuery(form).serialize();
+				var formData = jQuery(form).serializeFormData();
 				app.request.post({data:formData}).then(function(err,data){
 					app.helper.hideProgress();
 					if(err === null) {
 						jQuery('.vt-notification').remove();
 						app.event.trigger("post.QuickCreateForm.save",data,jQuery(form).serializeFormData());
 						app.helper.hideModal();
-						var message = typeof formData.record !== 'undefined' ? app.vtranslate('JS_RECORD_UPDATED'):app.vtranslate('JS_RECORD_CREATED');
+						var message = formData.record !== "" ? app.vtranslate('JS_RECORD_UPDATED'):app.vtranslate('JS_RECORD_CREATED');
 						app.helper.showSuccessNotification({"message":message},{delay:4000});
 						invokeParams.callbackFunction(data, err);
 						//To unregister onbefore unload event registered for quickcreate


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #564 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー画面でTODOを編集した際に不適切なメッセージが表示されていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. typeofでの場合分けがうまく機能していなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. typeofを使わずに、recordの値が適切か否かで場合分けをした。
2. 本来、活動の編集でも「活動を更新しました。」のメッセージが表示されるべきであったが表示されていなかったため、TODOと同じように場合分けをしてメッセージが表示されるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
・TODOを編集した際のメッセージ
![スクリーンショット (17)](https://user-images.githubusercontent.com/86254425/179704625-83630aad-f311-44e8-aaf7-184ad7746be2.png)
・活動を編集した際のメッセージ
![スクリーンショット (18)](https://user-images.githubusercontent.com/86254425/179704980-2a79dace-1518-4df2-a2f7-2907ffda50f2.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
その他のメッセージの表示
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->