### PR TITLE
#354 プロジェクトタスクをカレンダー上のポップアップから完了にできるようにする修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -53,9 +53,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var instance = Calendar_Calendar_Js.getInstance();
 		instance.editCalendarTask(taskId);
 	},
-	markAsHeld: function (recordId,recordModel) {
+	markAsHeld: function (recordId,sourceModule) {
 		var instance = Calendar_Calendar_Js.getInstance();
-		instance.markAsHeld(recordId,recordModel);
+		instance.markAsHeld(recordId,sourceModule);
 	},
 	holdFollowUp: function (eventId) {
 		var instance = Calendar_Calendar_Js.getInstance();
@@ -143,7 +143,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			}
 		}
 	},
-	markAsHeld: function (recordId,recordModel) {
+	markAsHeld: function (recordId,sourceModule) {
 		var thisInstance = this;
 		app.helper.showConfirmationBox({
 			message: app.vtranslate('JS_CONFIRM_MARK_AS_HELD')
@@ -153,7 +153,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				action: "SaveFollowupAjax",
 				mode: "markAsHeldCompleted",
 				record: recordId,
-				recordModel:recordModel
+				sourceModule:sourceModule
 			};
 
 			app.request.post({'data': requestParams}).then(function (e, res) {
@@ -1571,7 +1571,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				if (eventObj.status !== 'Held' && eventObj.status !== 'Completed') {
 					popOverHTML += '' +
 							'<span class="pull-right cursorPointer"' +
-							'onClick="Calendar_Calendar_Js.markAsHeld(\'' + eventObj.id + '\',\'' + eventObj.module + '\');" title="' + app.vtranslate('JS_MARK_AS_HELD') + '">' +
+							'onClick="Calendar_Calendar_Js.markAsHeld(\'' + eventObj.id + '\',\'' + sourceModule + '\');" title="' + app.vtranslate('JS_MARK_AS_HELD') + '">' +
 							'<i class="fa fa-check"></i>' +
 							'</span>';
 				} else if (eventObj.status === 'Held') {

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -53,9 +53,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var instance = Calendar_Calendar_Js.getInstance();
 		instance.editCalendarTask(taskId);
 	},
-	markAsHeld: function (recordId) {
+	markAsHeld: function (recordId,recordModel) {
 		var instance = Calendar_Calendar_Js.getInstance();
-		instance.markAsHeld(recordId);
+		instance.markAsHeld(recordId,recordModel);
 	},
 	holdFollowUp: function (eventId) {
 		var instance = Calendar_Calendar_Js.getInstance();
@@ -143,7 +143,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			}
 		}
 	},
-	markAsHeld: function (recordId) {
+	markAsHeld: function (recordId,recordModel) {
 		var thisInstance = this;
 		app.helper.showConfirmationBox({
 			message: app.vtranslate('JS_CONFIRM_MARK_AS_HELD')
@@ -152,7 +152,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				module: "Calendar",
 				action: "SaveFollowupAjax",
 				mode: "markAsHeldCompleted",
-				record: recordId
+				record: recordId,
+				recordModel:recordModel
 			};
 
 			app.request.post({'data': requestParams}).then(function (e, res) {
@@ -1538,7 +1539,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 
 			popOverHTML += '</span>';
 
-			if (sourceModule === 'Calendar' || sourceModule == 'Events') {
+			if (sourceModule === 'Calendar' || sourceModule == 'Events'||sourceModule =="ProjectTask") {
 				popOverHTML += '' +
 						'<span class="pull-right cursorPointer" ' +
 						'onClick="Calendar_Calendar_Js.deleteCalendarEvent(\'' + eventObj.id +
@@ -1570,7 +1571,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				if (eventObj.status !== 'Held' && eventObj.status !== 'Completed') {
 					popOverHTML += '' +
 							'<span class="pull-right cursorPointer"' +
-							'onClick="Calendar_Calendar_Js.markAsHeld(\'' + eventObj.id + '\');" title="' + app.vtranslate('JS_MARK_AS_HELD') + '">' +
+							'onClick="Calendar_Calendar_Js.markAsHeld(\'' + eventObj.id + '\',\'' + eventObj.module + '\');" title="' + app.vtranslate('JS_MARK_AS_HELD') + '">' +
 							'<i class="fa fa-check"></i>' +
 							'</span>';
 				} else if (eventObj.status === 'Held') {

--- a/modules/Calendar/actions/DeleteAjax.php
+++ b/modules/Calendar/actions/DeleteAjax.php
@@ -28,7 +28,7 @@ class Calendar_DeleteAjax_Action extends Vtiger_DeleteAjax_Action {
 		parent::checkPermission($request);
 		
 		if ($record) {
-			$activityModulesList = array('Calendar', 'Events');
+			$activityModulesList = array('Calendar', 'Events','ProjectTask');
 			$recordEntityName = getSalesEntityType($record);
 
 		if (!in_array($recordEntityName, $activityModulesList)  || (!empty($sourceModule) && !in_array($sourceModule, $activityModulesList))) {

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -113,6 +113,10 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			$meta = $queryGenerator->getMeta($moduleModel->get('name'));
 
 			$queryGenerator->setFields(array_merge(array_merge($nameFields, array('id')), $fieldsList));
+			//カレンダー種別でタスク-開始日,終了日を選択している時の処理
+			if($type == 'ProjectTask'){
+				$queryGenerator->setFields(array_merge(array_merge($nameFields, array('id','projecttaskstatus')), $fieldsList));
+			}
 			$query = $queryGenerator->getQuery();
 			$startDateColumn = Vtiger_Util_Helper::validateStringForSql($fieldsList[0]);
 			$endDateColumn = Vtiger_Util_Helper::validateStringForSql($fieldsList[1]);
@@ -167,6 +171,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 
 				if($type == 'PriceBooks') {
 					$records = $this->queryForRecords($query, false);
+				//カレンダー種別でタスク-開始日またはタスク-終了日を選択している時の処理
 				}else if($type == 'ProjectTask'){
 					$query = "SELECT $selectFields, $fieldsList[0],projecttaskstatus FROM $type";
 					$query.= " WHERE $fieldsList[0] >= '$start' AND $fieldsList[0] <= '$end' ";

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -167,6 +167,10 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 
 				if($type == 'PriceBooks') {
 					$records = $this->queryForRecords($query, false);
+				}else if($type == 'ProjectTask'){
+					$query = "SELECT $selectFields, $fieldsList[0],projecttaskstatus FROM $type";
+					$query.= " WHERE $fieldsList[0] >= '$start' AND $fieldsList[0] <= '$end' ";
+					$records = $this->queryForRecords($query);
 				} else {
 					$records = $this->queryForRecords($query);
 				}
@@ -203,6 +207,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			if ($urlModule === 'Events') {
 				$urlModule = 'Calendar';
 			}
+			$item['status'] = $record['projecttaskstatus'];
 			$item['url']   = sprintf('index.php?module='.$urlModule.'&view=Detail&record=%s', $crmid);
 			$item['color'] = $color;
 			$item['textColor'] = $textColor;

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -202,6 +202,9 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 				$recordDateTime->setDate($calendarYear, $recordDateTime->format('m'), $recordDateTime->format('d'));
 				$item['start'] = $recordDateTime->format('Y-m-d');
 			}
+			if($type == 'ProjectTask'&& $record['projecttaskstatus']!=null){
+				$item['title'] = $item['title'].' - ('.decode_html(vtranslate($record['projecttaskstatus'],'ProjectTask')).')';
+			}
 
 			$urlModule = $type;
 			if ($urlModule === 'Events') {

--- a/modules/Calendar/actions/SaveAjax.php
+++ b/modules/Calendar/actions/SaveAjax.php
@@ -16,7 +16,7 @@ class Calendar_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 		
 		parent::checkPermission($request);
 		if ($record) {
-			$activityModulesList = array('Calendar', 'Events');
+			$activityModulesList = array('Calendar', 'Events','ProjectTask');
 			$recordEntityName = getSalesEntityType($record);
 
 			if (!in_array($recordEntityName, $activityModulesList) || !in_array($moduleName, $activityModulesList)) {

--- a/modules/Calendar/actions/SaveFollowupAjax.php
+++ b/modules/Calendar/actions/SaveFollowupAjax.php
@@ -89,7 +89,7 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
     public function markAsHeldCompleted(Vtiger_Request $request) {
         $moduleName = $request->getModule();
         $recordId = $request->get('record');
-		if($request->get('recordModel')=='ProjectTask'){
+		if($request->get('sourceModule')=='ProjectTask'){
 			$recordModel = Vtiger_Record_Model::getInstanceById($recordId,'ProjectTask');
 			$projecttaskstatus = $recordModel->get("projecttaskstatus");
 			$recordModel->set('mode','edit');

--- a/modules/Calendar/actions/SaveFollowupAjax.php
+++ b/modules/Calendar/actions/SaveFollowupAjax.php
@@ -17,7 +17,7 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
 		parent::checkPermission($request);
 
 		if ($record) {
-			$activityModulesList = array('Calendar', 'Events');
+			$activityModulesList = array('Calendar', 'Events','ProjectTask');
 			$recordEntityName = getSalesEntityType($record);
 			if (!in_array($recordEntityName, $activityModulesList) || !in_array($moduleName, $activityModulesList)) {
 				throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
@@ -89,43 +89,55 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
     public function markAsHeldCompleted(Vtiger_Request $request) {
         $moduleName = $request->getModule();
         $recordId = $request->get('record');
-        $recordModel = Vtiger_Record_Model::getInstanceById($recordId,$moduleName);
-        $recordModel->set('mode','edit');
-        $activityType = $recordModel->get('activitytype');
-        $response = new Vtiger_Response();
-        
-        if($activityType == 'Task'){
-            $status = 'Completed';
-            $recordModel->set('taskstatus',$status);
-            $result = array("valid"=>TRUE,"markedascompleted"=>TRUE,"activitytype"=>"Task");
-        }
-        else{
-            //checking if the event can be marked as Held (status validation)
-            $startDateTime = $this->getFormattedDateTime($recordModel->get('date_start'), $recordModel->get('time_start'));
-            $startDateTime = new DateTime($startDateTime);
-            $currentDateTime = date("Y-m-d H:i:s");
-            $currentDateTime = new DateTime($currentDateTime);
-            if($startDateTime > $currentDateTime){
-                $result = array("valid"=>FALSE,"markedascompleted"=>FALSE);
-                $response->setResult($result);
-                $response->emit();
-                return;
-            }
-            $status = 'Held';
-            $recordModel->set('eventstatus',$status);
-            $result = array("valid"=>TRUE,"markedascompleted"=>TRUE,"activitytype"=>"Event");
-        }
-		$_REQUEST['mode'] = 'edit';
-		$this->setRecurrenceInfo($recordModel);
-		try {
+		if($request->get('recordModel')=='ProjectTask'){
+			$recordModel = Vtiger_Record_Model::getInstanceById($recordId,'ProjectTask');
+			$projecttaskstatus = $recordModel->get("projecttaskstatus");
+			$recordModel->set('mode','edit');
+			$recordModel->set("projecttaskstatus", "Completed");
 			$recordModel->save();
+			$response = new Vtiger_Response();
+			$result = array("valid"=>TRUE,"markedascompleted"=>TRUE,"activitytype"=>"ProjectTask");
 			$response->setResult($result);
-		} catch (DuplicateException $e) {
-			$response->setError($e->getMessage(), $e->getDuplicationMessage(), $e->getMessage());
-		} catch (Exception $e) {
-			$response->setError($e->getMessage());
+			$response->emit();
+		}else{
+			$recordModel = Vtiger_Record_Model::getInstanceById($recordId,$moduleName);
+			$recordModel->set('mode','edit');
+			$activityType = $recordModel->get('activitytype');
+			$response = new Vtiger_Response();
+			
+			if($activityType == 'Task'){
+				$status = 'Completed';
+				$recordModel->set('taskstatus',$status);
+				$result = array("valid"=>TRUE,"markedascompleted"=>TRUE,"activitytype"=>"Task");
+			}
+			else{
+				//checking if the event can be marked as Held (status validation)
+				$startDateTime = $this->getFormattedDateTime($recordModel->get('date_start'), $recordModel->get('time_start'));
+				$startDateTime = new DateTime($startDateTime);
+				$currentDateTime = date("Y-m-d H:i:s");
+				$currentDateTime = new DateTime($currentDateTime);
+				if($startDateTime > $currentDateTime){
+					$result = array("valid"=>FALSE,"markedascompleted"=>FALSE);
+					$response->setResult($result);
+					$response->emit();
+					return;
+				}
+				$status = 'Held';
+				$recordModel->set('eventstatus',$status);
+				$result = array("valid"=>TRUE,"markedascompleted"=>TRUE,"activitytype"=>"Event");
+			}
+			$_REQUEST['mode'] = 'edit';
+			$this->setRecurrenceInfo($recordModel);
+			try {
+				$recordModel->save();
+				$response->setResult($result);
+			} catch (DuplicateException $e) {
+				$response->setError($e->getMessage(), $e->getDuplicationMessage(), $e->getMessage());
+			} catch (Exception $e) {
+				$response->setError($e->getMessage());
+			}
+			$response->emit();
 		}
-        $response->emit();
     }
 	
 	function setRecurrenceInfo($recordModel) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #354 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. プロジェクトタスクをカレンダー上のポップアップから完了にできるようにしたい。

##  原因 / Cause
<!-- バグの原因を記述 -->

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. feed.phpに予定があるかどうかのリクエストをする際に、プロジェクトタスクのstatus情報を返してもらえるように修正
2. プロジェクトタスクのstatusがCompletedでない時に完了ボタンが表示されるように修正
3. 完了ボタンが押されたときにプロジェクトタスクのstatusが完了になるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/179706407-0b4df501-365e-48be-90d1-9c86f679a90b.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
・完了にするボタンをクリックしたときの処理。
・カレンダーに表示する予定がプロジェクトタスクの場合の処理を追記したためその付近の範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->