### PR TITLE
#552 インポートでマージを選択した際に必須項目を選択しなくてもインポートできるようにする修正

### DIFF
--- a/layouts/v7/modules/Import/resources/Import.js
+++ b/layouts/v7/modules/Import/resources/Import.js
@@ -151,7 +151,7 @@ if (typeof (Vtiger_Import_Js) == 'undefined') {
                     missingMandatoryFields.push('"' + mandatoryFields[mandatoryFieldName] + '"');
                 }
             }
-            if (missingMandatoryFields.length > 0) {
+            if (missingMandatoryFields.length > 0 && jQuery('[name="merge_type"]').val() != 3) {
                 errorMessage = app.vtranslate('JS_MAP_MANDATORY_FIELDS') + missingMandatoryFields.join(',');
                 app.helper.showErrorNotification({'message': errorMessage});
                 return false;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #552 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インポートでマージを選択した際に必須項目を選択しないとインポートすることができなかった。
    任意項目をマッチング項目に選択しマージしたい時などに不便だった。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 重複レコードの処理にマージを選択した時だけ、必須項目を選択していなくてもエラーにならないように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/179922536-09f48136-34bb-4e90-a8bc-6769108074a2.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
インポートのマージの範囲
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
マッチング項目に任意項目を選択し、マッピング項目に必須項目を選択しなかったときにデータが新規作成されるときは必須項目は????でデータが作成される。このときマッチング項目に選択した任意項目はインポート元のcsvファイルの値ではなく新規作成した時に割り振られる値が設定される。
またカレンダーのインポートに関しては修正にかかわらず正しく動作していなかった。今回のissueとは関係ないため修正していません。
![image](https://user-images.githubusercontent.com/95267222/179923409-c9724fcb-b02d-4347-8470-85bd91e4ef38.png)
