### PR TITLE
見積等のPDFを出力した際のファイル名に項目の値を指定したい

### DIFF
--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -292,10 +292,21 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 	public function getPDF($templateId, $isheader = true) {
 		$recordId = $this->getId();
 		$moduleName = $this->getModuleName();
+		
+		$ordernoarray = array(1=>"quote_no", 2=>"invoice_no", 3=>"salesorder_no", 4=>"purchaseorder_no");
+		$orderidarray = array(1=>"quoteid", 2=>"invoiceid", 3=>"salesorderid", 4=>"purchaseorderid");
+		$ordervtigerarray = array(1=>"vtiger_quotes", 2=>"vtiger_invoice", 3=>"vtiger_salesorder", 4=>"vtiger_purchaseorder");
+		$orderno = $ordernoarray[$templateId];
+		$orderid = $orderidarray[$templateId];
+		$ordervtiger = $ordervtigerarray[$templateId];
 
 		global $adb;
 		$template = null;
-
+		
+		$result2 = $adb->pquery("SELECT $orderno, subject FROM $ordervtiger WHERE $orderid = ?",array($recordId));
+		$orderno = $adb->query_result($result2, 0, $orderno);
+		$subject = $adb->query_result($result2, 0, 'subject');
+		
 		$result = $adb->pquery("SELECT templatename, body FROM vtiger_pdftemplates WHERE templateid = ?", array($templateId));
 		if($adb->num_rows($result) > 0) {
 			$templateName = $adb->query_result($result, 0, 'templatename');
@@ -319,7 +330,7 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Content-Transfer-Encoding: binary ");
 		header('Content-Type: application/octet-streams');
-		header("Content-Disposition: attachment; filename=\"{$templateName}.pdf\"");
+		header("Content-Disposition: attachment; filename=\"{$templateName}-{$subject}-{$orderno}.pdf\"");
 		echo $pdf;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #580 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFを出力すると全て同じ「テンプレート名」で出力されるため、ファイル名を変更する必要がある。
ファイル名を例えば「見積書-[案件名][見積番号]」のような形で出力できるようにしたい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 出力時に呼び出される関数getPDFにテンプレート名しか渡されていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 関数getPDFにテンプレート名だけでなく、固有の案件名と案件番号を見積、請求、注文、発注に対応するように渡し、PDF名に追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
PDF名のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
テストでは不具合は発生しなかったが、見積、請求等の案件名と案件番号をデータベースから取ってくる際、
$adb->pquery("SELECT $orderno, subject FROM $ordervtiger WHERE $orderid = ?",array($recordId));
のようにエスケープを使用せず、SELECT文に変数を使用して値を取得したため、不具合が発生する可能性がある（？）