### PR TITLE
選択肢のバリデーションエラー時の配色がおかしい

### DIFF
--- a/layouts/v7/lib/jquery/select2/select2.css
+++ b/layouts/v7/lib/jquery/select2/select2.css
@@ -330,6 +330,7 @@ Version: 3.4.8 Timestamp: Thu May  1 09:50:32 EDT 2014
     list-style: none;
     display: list-item;
     background-image: none;
+    background-color: #ffffff;
 }
 
 .select2-results li.select2-result-with-children > .select2-result-label {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #587 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 必須項目の選択肢項目がバリデーションエラーになった際に、デフォルトで設定されている選択肢はピンク色になるが、システム設定から追加した選択肢の背景色が白になる。デフォルトの無色（=empty(color)）の場合はtplかmodelクラスの中で白（#ffffff）にしてほしい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. デフォルトの選択肢に背景色が登録されておらず、空だったため、選択肢がピンク色になっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  layouts/v7/lib/jquery/select2 の「select2.css」にて背景色を白（#ffffff）で追加した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前（案件）
[![スクリーンショット (4)](https://user-images.githubusercontent.com/107910164/182521788-9af877db-6692-4bf8-9361-ea2c63a84fac.png)](url)


変更後（案件）
[![選択肢のバリデーションエラー時の配色がおかしい1](https://user-images.githubusercontent.com/107910164/182521608-c66a0e4b-bc35-479b-8a63-7143a966305b.png)](url)

変更後（資産・レンタル管理）
[![選択肢のバリデーションエラー時の配色がおかしい2](https://user-images.githubusercontent.com/107910164/182521661-a2cc6ab5-7520-4476-a21f-6658feff98d3.png)](url)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
その他の「資産・レンタル管理」「見積」等の必須選択項目画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->