### PR TITLE
#594 活動にてインポートした時にステータスを正しく取り込むように修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -1057,12 +1057,13 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							}
 						} else if (!in_array($fieldName, array('date_start', 'due_date'))) {
 							if ($fieldModel) {
-								$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
+								if(strpos($fieldName,'status')===false){
+									$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
+								}
 							}
 						}
 					}
 				}
-
 				foreach ($recordData as $fieldName => $fieldValue) {
 					if (in_array($fieldName, array('date_start', 'due_date'))) {
 						$timeField = 'time_start';


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #594 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インポートに成功してもステータスの情報を取得することができなかった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポートしたデータをデータベースに保存する際にステータスの情報を日本語に変換して保存してしまっていた。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インポートしたデータを保存するときに、statusの情報だけgetDisplayValueの関数を通らないように修正した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/182543499-b7bc28f0-d0b8-408f-a962-1154039a9900.png)
![image](https://user-images.githubusercontent.com/95267222/182543539-bc9c3641-3b1d-474f-b05d-cdb63883c49d.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
statusの名前がつくfieldNameのものをインポートする際にgetDisplayValueが通らなくなる。
現状問題はない。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->