### PR TITLE
#597 ユーザー一覧画面から「ユーザー名の変更」ができない。

### DIFF
--- a/layouts/v7/modules/Users/resources/List.js
+++ b/layouts/v7/modules/Users/resources/List.js
@@ -249,27 +249,6 @@ Settings_Vtiger_List_Js("Settings_Users_List_Js",{
 					var params = {
 						submitHandler : function(form) {
 							var form = jQuery(form);
-							var new_password = form.find('[name="new_password"]');
-							var confirm_password = form.find('[name="confirm_password"]');
-							var params = {
-								position: {
-									my: 'bottom left',
-									at: 'top left',
-									container : form
-								},
-							};
-							if (new_password.val() !== confirm_password.val()) {
-								vtUtils.showValidationMessage(new_password, app.vtranslate('JS_REENTER_PASSWORDS'), params);
-								vtUtils.showValidationMessage(confirm_password, app.vtranslate('JS_REENTER_PASSWORDS'), params);
-								return false;
-							}else if(!app.helper.checkStrengthPassword(new_password)) {
-								vtUtils.showValidationMessage(new_password, app.vtranslate('JS_INVALID_STRENGTH_PASSWORDS'), params);
-								return false;
-							}else {
-								vtUtils.hideValidationMessage(new_password);
-								vtUtils.hideValidationMessage(confirm_password);
-							}
-
 							Settings_Users_List_Js.changeUserName(form);
 						}
 					};
@@ -286,8 +265,6 @@ Settings_Vtiger_List_Js("Settings_Users_List_Js",{
 
 	changeUserName: function (form) {
 		var newUsername = form.find('[name="new_username"]');
-		var new_password = form.find('[name="new_password"]');
-		var confirm_password = form.find('[name="confirm_password"]');
 		var userid = form.find('[name="userid"]');
 
 		app.helper.showProgress(app.vtranslate('JS_PLEASE_WAIT'));
@@ -297,8 +274,6 @@ Settings_Vtiger_List_Js("Settings_Users_List_Js",{
 			action: 'SaveAjax',
 			mode: 'changeUsername',
 			newUsername: newUsername.val(),
-			newPassword: new_password.val(),
-			confirmPassword: confirm_password.val(),
 			userid: userid.val()
 		};
 		vtUtils.hideValidationMessage(newUsername);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #597 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー一覧画面から「ユーザー名の変更」をすることができない。
「ユーザー名の変更」を選択するとポップアップは表示されるが、保存を押しても保存されない（保存を押せない）。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「ユーザー名の変更」を押したときに呼び出される関数Settings_Users_List_Js.triggerChangeUsernameによって動かされる関数triggerChangeUsernameと関数ChangeUsernameの中に不要な文が混ざっており、正しく動作しなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 関数triggerChangeUsernameと関数ChangeUsernameの不要な文を削除した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー一覧画面からユーザー名を変更するときのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->