### PR TITLE
Translate calendardaterange englishto japanese

### DIFF
--- a/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
+++ b/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
@@ -20,7 +20,9 @@
 				<span>
 					{$MODULE_LABEL} 
 					{if $VIEWINFO['conditions']['name'] neq ''} ({vtranslate($VIEWINFO['conditions']['name'],$MODULE)}) {/if}-
-					{vtranslate($VIEWINFO['fieldlabel'], $VIEWINFO['module'])}
+					{assign var=splitted_fieldlabel value=","|explode:$VIEWINFO['fieldlabel']}
+					{vtranslate($splitted_fieldlabel[0], $VIEWINFO['module'])}
+					{if $splitted_fieldlabel[1] neq ''},{vtranslate($splitted_fieldlabel[1], $VIEWINFO['module'])} {/if}			
 				</span>
 				<span class="activitytype-actions pull-right">
 					<input class="toggleCalendarFeed cursorPointer" type="checkbox" data-calendar-sourcekey="{$VIEWINFO['module']}_{$VIEWINFO['fieldname']}{if $VIEWINFO['conditions']['name'] neq ''}_{$VIEWINFO['conditions']['name']}{/if}" data-calendar-feed="{$VIEWINFO['module']}" 

--- a/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
+++ b/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
@@ -20,9 +20,7 @@
 				<span>
 					{$MODULE_LABEL} 
 					{if $VIEWINFO['conditions']['name'] neq ''} ({vtranslate($VIEWINFO['conditions']['name'],$MODULE)}) {/if}-
-					{assign var=splitted_fieldlabel value=","|explode:$VIEWINFO['fieldlabel']}
-					{vtranslate($splitted_fieldlabel[0], $VIEWINFO['module'])}
-					{if $splitted_fieldlabel[1] neq ''},{vtranslate($splitted_fieldlabel[1], $VIEWINFO['module'])} {/if}			
+					{vtranslate($VIEWINFO['fieldlabel'], $VIEWINFO['module'])}
 				</span>
 				<span class="activitytype-actions pull-right">
 					<input class="toggleCalendarFeed cursorPointer" type="checkbox" data-calendar-sourcekey="{$VIEWINFO['module']}_{$VIEWINFO['fieldname']}{if $VIEWINFO['conditions']['name'] neq ''}_{$VIEWINFO['conditions']['name']}{/if}" data-calendar-feed="{$VIEWINFO['module']}" 

--- a/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
+++ b/layouts/v7/modules/Calendar/CalendarViewTypes.tpl
@@ -20,7 +20,9 @@
 				<span>
 					{$MODULE_LABEL} 
 					{if $VIEWINFO['conditions']['name'] neq ''} ({vtranslate($VIEWINFO['conditions']['name'],$MODULE)}) {/if}-
-					{vtranslate($VIEWINFO['fieldlabel'], $VIEWINFO['module'])}
+					{assign var=splitted_fieldlabel value=","|explode:$VIEWINFO['fieldlabel']}
+					{vtranslate($splitted_fieldlabel[0], $VIEWINFO['module'])}
+					{if $splitted_fieldlabel[1] neq ''},{vtranslate($splitted_fieldlabel[1], $VIEWINFO['module'])} {/if}
 				</span>
 				<span class="activitytype-actions pull-right">
 					<input class="toggleCalendarFeed cursorPointer" type="checkbox" data-calendar-sourcekey="{$VIEWINFO['module']}_{$VIEWINFO['fieldname']}{if $VIEWINFO['conditions']['name'] neq ''}_{$VIEWINFO['conditions']['name']}{/if}" data-calendar-feed="{$VIEWINFO['module']}" 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #607

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー機能の種別追加からプロジェクトの開始日と完了日の表示追加後、読み込みすると
「開始日，完了日」と表記されていたものが「Start Date,Actual End Date」と表記される。

    再現手順
    1.カレンダー画面の左側、カレンダー種別を「+」で追加をする
    2. モジュールを「プロジェクト」で選択する
    3. 項目の選択を「開始日」に設定する
    4. 日付の範囲を選択する項目を「開始日」「完了日」にして保存する
    5.カレンダーで画面を読み込むと左側の画面表記がプロジェクトのみ「開始日，完了日」から「Start Date,Actual End Date」と表記される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 再現手順３,4で設定した日付の範囲が一つの文字列として認識されてしまうため、対応する日本語が見つからず、英語表記になってしまった。
 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 設定した日付の範囲を、','で区切り、それぞれを日本語に直してから表示するようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
![スクリーンショット #607(1)](https://user-images.githubusercontent.com/107910164/184300442-c7c9265c-9616-4087-acc9-285200fb599e.png)

変更後
![スクリーンショット#607(2)](https://user-images.githubusercontent.com/107910164/184300528-9e1e545e-9a3c-482b-aaaa-002c89c16df9.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーページのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->