### PR TITLE
#609 管理者以外のユーザーでログインするとインポートする際に「2 重複レコードの処理方法」で「選択可能な項目」に一覧が表示されない問題の修正

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -739,9 +739,9 @@ class QueryGenerator {
 					}else{
 						$moduleList = $this->referenceFieldInfoList[$fieldName];
 						foreach($moduleList as $module) {
+							$meta = $this->getMeta($module);
 							$nameFields = $this->moduleNameFields[$module];
 							$nameFieldList = explode(',',$nameFields);
-							$meta = $this->getMeta($module);
 							$columnList = array();
 							foreach ($nameFieldList as $column) {
 								if($module == 'Users') {
@@ -836,7 +836,7 @@ class QueryGenerator {
 							$fieldSql .= "$fieldGlue ".$field->getTableName().'.'.$field->getColumnName().' '.$valueSql;
 						}
 					}
-				} else if (($baseModule == 'Events' || $baseModule == 'Calendar') 
+				} else if (($baseModule == 'Events' || $baseModule == 'Calendar')
 						&& ($field->getColumnName() == 'status' || $field->getColumnName() == 'eventstatus')) {
 					$otherFieldName = 'eventstatus';
 					if($field->getColumnName() == 'eventstatus'){
@@ -848,7 +848,7 @@ class QueryGenerator {
 					$specialConditionForOtherField='';
 					$conditionGlue = ' OR ';
 					if($conditionInfo['operator'] == 'n' || $conditionInfo['operator'] == 'k' || $conditionInfo['operator'] == 'y') {
-					   $conditionGlue = ' AND '; 
+					   $conditionGlue = ' AND ';
 					   if($conditionInfo['operator'] == 'n') {
 						   $specialCondition = ' OR '.$field->getTableName().'.'.$field->getColumnName().' IS NULL ';
 						   if(!empty($otherField))
@@ -932,7 +932,7 @@ class QueryGenerator {
 				}
 			}
 		}
-		
+
 		// This is needed as there can be condition in different order and there is an assumption in makeGroupSqlReplacements API
 		// that it expects the array in an order and then replaces the sql with its the corresponding place
 		ksort($fieldSqlList);
@@ -1154,7 +1154,7 @@ class QueryGenerator {
 				$value = "'$value'";
 			}
 
-			if(($this->isNumericType($field->getFieldDataType())) && empty($value)) {				
+			if(($this->isNumericType($field->getFieldDataType())) && empty($value)) {
 				$value = '0';
 			}
 			$sql[] = "$sqlOperator $value";

--- a/include/Webservices/VtigerCRMObjectMeta.php
+++ b/include/Webservices/VtigerCRMObjectMeta.php
@@ -405,7 +405,7 @@ class VtigerCRMObjectMeta extends EntityMeta {
 				left join vtiger_blocks on vtiger_blocks.blockid = vtiger_field.block
 				where vtiger_field.tabid =? and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6)
 				order by vtiger_blocks.sequence, vtiger_field.sequence";
-			$params = array($tabid, $block);	
+			$params = array($tabid, $block); 
 		}else{
 			$profileList = getCurrentUserProfileList();
 
@@ -420,7 +420,7 @@ class VtigerCRMObjectMeta extends EntityMeta {
 						WHERE vtiger_field.tabid =? AND vtiger_profile2field.visible = 0 
 						AND vtiger_profile2field.profileid IN (". generateQuestionMarks($profileList) .")
 						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2)
-						group by vtiger_field.columnname
+						group by vtiger_field.columnname 
 						ORDER BY vtiger_blocks.sequence, vtiger_field.sequence";
 				$params = array($tabid, $profileList, $block);
 			} else {
@@ -434,7 +434,7 @@ class VtigerCRMObjectMeta extends EntityMeta {
 						WHERE vtiger_field.tabid=? 
 						AND vtiger_profile2field.visible = 0 
 						AND vtiger_def_org_field.visible = 0 and vtiger_field.block in (".generateQuestionMarks($block).") and vtiger_field.displaytype in (1,2,3,4,5,6) and vtiger_field.presence in (0,2)
-						group by columnname
+						group by columnname 
 						ORDER BY vtiger_blocks.sequence, vtiger_field.sequence";
 				$params = array($tabid, $block);
 			}

--- a/modules/Vtiger/views/Popup.php
+++ b/modules/Vtiger/views/Popup.php
@@ -14,7 +14,7 @@ class Vtiger_Popup_View extends Vtiger_Footer_View {
 
 	public function requiresPermission(Vtiger_Request $request){
 		$permissions = parent::requiresPermission($request);
-		
+
 		$permissions[] = array('module_parameter' => 'module', 'action' => 'DetailView');
 		return $permissions;
 	}
@@ -97,7 +97,7 @@ class Vtiger_Popup_View extends Vtiger_Footer_View {
 				$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
 				$searchParams=$request->get('search_params');
 
-		$relationId = $request->get('relationId'); 
+		$relationId = $request->get('relationId');
 
 		//To handle special operation when selecting record from Popup
 		$getUrl = $request->get('get_url');
@@ -167,6 +167,27 @@ class Vtiger_Popup_View extends Vtiger_Footer_View {
 					$listViewModel->set('search_params',$transformedSearchParams);
 				}
 		if(!empty($relatedParentModule) && !empty($relatedParentId)) {
+			$moduleFields = $moduleModel->getFields();
+			$whereCondition = [];
+
+			foreach ($searchParams as $fieldListGroup) {
+				foreach ($fieldListGroup as $fieldSearchInfo) {
+					$fieldModel = $moduleFields[$fieldSearchInfo[0]];
+					$tableName = $fieldModel->get('table');
+					$column = $fieldModel->get('column');
+					$whereCondition[$fieldSearchInfo[0]] = [
+						$tableName . '.' . $column,
+						$fieldSearchInfo[1],
+						$fieldSearchInfo[2],
+						$fieldSearchInfo[3]
+					];
+				}
+			}
+
+			if (!empty($whereCondition)) {
+				$listViewModel->set('whereCondition', $whereCondition);
+			}
+
 			$this->listViewHeaders = $listViewModel->getHeaders();
 
 			$models = $listViewModel->getEntries($pagingModel);
@@ -213,7 +234,7 @@ class Vtiger_Popup_View extends Vtiger_Footer_View {
 			$this->listViewHeaders = $listViewModel->getListViewHeaders();
 			$this->listViewEntries = $listViewModel->getListViewEntries($pagingModel);
 		}
-		// End  
+		// End
 				if(empty($searchParams)) {
 					$searchParams = array();
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #609 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 管理者ユーザー権限を持たないユーザーが、csvインポートをする際に「重複レコードの処理方法」の「選択可能な項目」に項目が何も表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. /include/Webservices/VtigerCRMObjectMeta.phpのretrieveMetaForBlock()において、SQL文が適切ではなかったため、ユーザーが選択できる項目の取得に失敗していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. /include/Webservices/VtigerCRMObjectMeta.phpのretrieveMetaForBlock()内部のSQL文を修正し、期待した結果が取得できるSQL文に変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
retrieveMeta()を利用してフィールド名を取得している範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->