### PR TITLE
#578 vtiger_notesのfiletypeの桁数を増やす修正

### DIFF
--- a/modules/Migration/schema/736_to_737.php
+++ b/modules/Migration/schema/736_to_737.php
@@ -14,4 +14,5 @@ if (defined('VTIGER_UPGRADE')) {
 
     // PDFテンプレートに大きなサイズの画像を張り付ける場合、bodyが途切れるのでtextからlongtextへ変更する
     $db->query('ALTER TABLE vtiger_pdftemplates MODIFY body longtext;');
+    $db->query("ALTER TABLE vtiger_notes MODIFY filetype varchar(255);");
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #578 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  Excelファイルをアップロードした時に、vtiger_notesのfiletypeの桁数が足りていなかった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. vtiger_notesのfiletypeの型がvarchar(50)になっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. migrationを使ってvtiger_notesのfiletypeの型をvarchar(255)とした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/186111864-e00e94d9-c4f1-496e-ba14-6612cdfa2180.png)
![image](https://user-images.githubusercontent.com/95267222/186111894-619a89b2-42e6-4c78-8863-2ec2ee6a368a.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
fileをアップロードした際など、vtiger_notesを参照、書き込みする箇所。


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
MIMEタイプの桁数を明確に定めているところはありませんでした。
以下にMIMEタイプの一覧が載っていますが、その中だと一番長いもので84でした。現状で言うならばfiletypeの桁数は100でも足りるかもしれません。
https://www.iana.org/assignments/media-types/media-types.xhtml