### PR TITLE
#539日報の概要画面から活動追加すると関連が空になる

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1685,7 +1685,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 				app.helper.showErrorMessage(app.vtranslate('JS_NO_CREATE_OR_NOT_QUICK_CREATE_ENABLED'));
 			}
 			var fieldName = thisInstance.referenceFieldNames[module];
-			if(typeof fieldName == 'undefined' && module != 'Contacts'){
+			if(typeof fieldName == 'undefined' && module != 'Contacts' && module != 'Dailyreports'){
 				fieldName = 'parent_id';
 			}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #539 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 日報データの概要画面にある「活動の追加」から活動データを作成する際、
「関連」項目で他モジュールのデータを選択し、保存すると「関連」が空になっている。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 日報の概要画面で「活動の追加」を選択し、「関連」項目で他モジュールを選択した際、選択した他モジュールのIDが追加先の「日報」のIDに上書きされていたため、関連項目が空になってしまった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 日報の概要画面で「活動の追加」を選択したときに、「関連」項目のIDが日報のIDに更新されないよう条件分岐した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
日報の「活動の追加」「TODOの追加」

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->