### PR TITLE
#573 ログイントップ画面でのFatalエラーに対応する修正

### DIFF
--- a/modules/Users/views/Login.php
+++ b/modules/Users/views/Login.php
@@ -40,8 +40,10 @@ class Users_Login_View extends Vtiger_View_Controller {
 			$xml = new SimpleXMLElement($rssPath, LIBXML_NOCDATA, true);
 			$jsonData = json_decode(json_encode($xml));
 			$dataCount = count($jsonData->channel->item);
-		}catch(Exception $e){
+		}catch(Throwable $e){
 			$dataCount = 0;
+			global $log;
+			$log->error($e->getMessage());
 		}
 
 		$oldTextLength = vglobal('listview_max_textlength');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #573 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ログイントップ画面でのRSS取得処理においてFatalエラーが起きたときに、ログインできない可能性があった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Exceptionによって例外をキャッチしていたが、これだとerrorが投げられた場合にキャッチすることができなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Exceptionではなくthrowableでキャッチすることにより、すべてをキャッチするようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
下記のFatalエラーはExceptionだとキャッチできなかった。Throwableだとキャッチできた。
![image](https://user-images.githubusercontent.com/95267222/186346313-56d96179-ffab-4673-bc62-c992f87b8770.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ログイン時のRSS取得処理の例外処理部分。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->