### PR TITLE
#614 項目設定で必須の付け外しをした際、*の付与位置がずれる

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -105,8 +105,8 @@
                             <div class="col-sm-9" style="word-wrap: break-word;">
                               <div class="fieldLabelContainer row">
                                 <span class="fieldLabel">
-                                  <b>{vtranslate($FIELD_MODEL->get('label'), $SELECTED_MODULE_NAME)}</b>
-                                  {if $IS_MANDATORY}&nbsp;<span class="redColor">*</span>{/if}
+                                  <b>{vtranslate($FIELD_MODEL->get('label'), $SELECTED_MODULE_NAME)}</b>&nbsp;
+                                  {if $IS_MANDATORY}<span class="redColor">*</span>{/if}
                                 </span><br>
                                 <span class="pull-right" style="opacity:0.6;">
                                   {vtranslate($FIELD_MODEL->getFieldDataTypeLabel(),$QUALIFIED_MODULE)}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #614 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目設定で必須の付け外しをした際、*の付与位置がずれる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 画面生成時に必須だと項目名の後ろに半角スペースが入っているが、非必須だと入っていないため、*の付与位置がずれた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 画面生成時に必須、非必須に関わらず、半角スペースを消す。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
画面生成時に必須、非必須に関わらず半角スペースをいれてしまったため、半角スペース無しに修正したものを再投稿します