### PR TITLE
#622 レコード番号設定画面の文言を統一してほしい

### DIFF
--- a/languages/ja_jp/Settings/Vtiger.php
+++ b/languages/ja_jp/Settings/Vtiger.php
@@ -260,6 +260,7 @@ $languageStrings = array(
 	//CustomRecordNumbering
 	'LBL_SUCCESSFULLY_UPDATED' => '更新しました。',
 	'LBL_CUSTOMIZE_RECORD_NUMBERING' => 'モジュール番号',
+	'LBL_RECORD_NUMBERING' => 'レコード番号',
 	'LBL_MODULE_ENTITY_NUMBER_CUSTOMIZATION' => 'モジュールエンティティ番号の設定',
 	'LBL_UPDATE_MISSING_RECORD_SEQUENCE' => '未割当のレコード番号の更新',
 	'LBL_USE_PREFIX' => '接頭子',

--- a/layouts/v7/modules/Settings/Vtiger/CustomRecordNumbering.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/CustomRecordNumbering.tpl
@@ -16,7 +16,7 @@
 						<button type="button" class="btn addButton btn-default" name="updateRecordWithSequenceNumber">{vtranslate('LBL_UPDATE_MISSING_RECORD_SEQUENCE', $QUALIFIED_MODULE)}</button>
 					</div>
 					<div>
-						<h4>{vtranslate('LBL_CUSTOMIZE_RECORD_NUMBERING', $QUALIFIED_MODULE)}</h4>
+						<h4>{vtranslate('LBL_RECORD_NUMBERING', $QUALIFIED_MODULE)}</h4>
 					</div>
 				</div>
 				<hr>

--- a/modules/Settings/Vtiger/views/CustomRecordNumbering.php
+++ b/modules/Settings/Vtiger/views/CustomRecordNumbering.php
@@ -32,7 +32,7 @@ class Settings_Vtiger_CustomRecordNumbering_View extends Settings_Vtiger_Index_V
 	
 	function getPageTitle(Vtiger_Request $request) {
 		$qualifiedModuleName = $request->getModule(false);
-		return vtranslate('LBL_CUSTOMIZE_RECORD_NUMBERING',$qualifiedModuleName);
+		return vtranslate('LBL_RECORD_NUMBERING',$qualifiedModuleName);
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #622 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レコード番号設定画面に「レコード番号」と「モジュール番号」が混在している。
ややこしい為、文言を統一してほしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. レコード番号設定画面のページタイトルと見出しに「モジュール番号」という文言を呼び出している。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 辞書に「レコード番号」を追加し、レコード番号設定画面のページタイトルと見出しで呼び出すように変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
![#622before](https://user-images.githubusercontent.com/107910164/187330579-d1d93b8e-81bd-4173-b22e-00a0b3b3bef8.png)

変更後
![スクリーンショット (10)](https://user-images.githubusercontent.com/107910164/187330603-a5c326d8-9b48-4267-8b70-2a4a7bf2cbeb.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
「モジュール番号」を呼び出している画面はレコード番号設定画面のタイトルと見出しのみであったため、影響範囲はレコード番号設定画面のみだと考えられる。


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->