### PR TITLE
#551 リスト（フィルタ）、レポートの条件で「担当」項目に対して「自分」が設定可能にする修正

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1157,7 +1157,14 @@ class QueryGenerator {
 			if(($this->isNumericType($field->getFieldDataType())) && empty($value)) {				
 				$value = '0';
 			}
-			$sql[] = "$sqlOperator $value";
+			
+			if ($operator === "own") {
+				$currentUser = Users_Record_Model::getCurrentUserModel();
+				$currentUserName = decode_html($currentUser->getName());
+				$sql[] = "= '$currentUserName'";
+			}else{
+				$sql[] = "$sqlOperator $value";
+			}
 		}
 		return $sql;
 	}

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -469,6 +469,7 @@ $languageStrings = array(
 	'LBL_BETWEEN' => 'between',
 	'LBL_IS_EMPTY'=> 'is empty',
 	'LBL_IS_NOT_EMPTY' => 'is not empty',
+	'LBL_IS_OWN' => 'own',
 	'LBL_APPROVE' => 'Approve',
 	'LBL_HAS_CHANGED' => 'has changed',
 	'LBL_HAS_CHANGED_TO' => 'has changed to',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -493,6 +493,7 @@ $languageStrings = array(
 	'LBL_BETWEEN' => '範囲',
 	'LBL_IS_EMPTY'=> '空である',
 	'LBL_IS_NOT_EMPTY' => '空ではない',
+	'LBL_IS_OWN' => '自分',
 	'LBL_APPROVE' => '承認',
 	'LBL_HAS_CHANGED' => '変更された',
 	'LBL_HAS_CHANGED_TO' => '～に変更された',

--- a/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
@@ -228,6 +228,11 @@ jQuery.Class("Vtiger_AdvanceFilter_Js",{
 			conditionList['none'] = 'None';
 		}
 
+		// owner以外の場合「自分」を非表示
+		if(fieldType != 'owner' && (fieldSpecificType == 'V' || fieldSpecificType == 'I')){
+			conditionList = conditionList.filter(key => key != 'own');
+		}
+
 		var options = '';
 		for(var key in conditionList) {
 			if (fieldType == 'multipicklist' && (conditionList[key] == "e" || conditionList[key] == "n" )) { continue; } 

--- a/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
@@ -367,7 +367,7 @@ jQuery.Class("Vtiger_AdvanceFilter_Js",{
 		
 		// Is Empty, today, tomorrow, yesterday conditions does not need any field input value - hide the UI
 		// re-enable if condition element is chosen.
-        var specialConditions = ["y","today","tomorrow","yesterday","ny"];
+        var specialConditions = ["y","today","tomorrow","yesterday","ny","own"];
 		if (specialConditions.indexOf(conditionSelectElement.val()) != -1) {
 			fieldUiHolder.hide();
 		} else {

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -980,6 +980,12 @@ class ReportRun extends CRMEntity {
 				continue;
 
 			while ($relcriteriarow = $adb->fetch_array($result)) {
+				if($relcriteriarow["comparator"] === "own"){
+					$currentUser = Users_Record_Model::getCurrentUserModel();
+					$currentUserName = decode_html($currentUser->getName());
+					$relcriteriarow['value'] = $currentUserName;
+					$relcriteriarow["comparator"] = 'e';
+				}
 				$columnIndex = $relcriteriarow["columnindex"];
 				$criteria = array();
 				$criteria['columnname'] = html_entity_decode($relcriteriarow["columnname"]);

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -998,6 +998,7 @@ class Vtiger_Field_Model extends Vtiger_Field {
 			'lessthanhourslater' => 'LBL_LESS_THAN_HOURS_LATER',
 			'morethanhoursbefore' => 'LBL_MORE_THAN_HOURS_BEFORE',
 			'morethanhourslater' => 'LBL_MORE_THAN_HOURS_LATER',
+			'own' => 'LBL_IS_OWN',
 		);
 	}
 
@@ -1008,10 +1009,10 @@ class Vtiger_Field_Model extends Vtiger_Field {
 	 */
 	public static function getAdvancedFilterOpsByFieldType() {
 		return array(
-			'V' => array('e','n','s','ew','c','k','y','ny'),
+			'V' => array('e','n','s','ew','c','k','y','ny','own'),
 			'N' => array('e','n','l','g','m','h', 'y','ny'),
 			'T' => array('e','n','l','g','m','h','bw','b','a','y','ny'),
-			'I' => array('e','n','l','g','m','h','y','ny'),
+			'I' => array('e','n','l','g','m','h','y','ny','own'),
 			'C' => array('e','n','y','ny'),
 			'D' => array('e','n','bw','b','a','y','ny'),
 			'DT' => array('e','n','bw','b','a','y','ny','lessthanhoursbefore','lessthanhourslater','morethanhoursbefore','morethanhourslater'),


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #551 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートおよびリストの条件にて、「担当」に対し「自分」が設定できなかった

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 項目が用意されていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. FilterOptionにown(自分)を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/187580382-161b7ae7-9ef9-4e7b-9ffc-1a8f3b5a8034.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- レポートおよびリストの条件

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
### テスト内容
- レポート
  - 「担当-自分」の条件が機能するか
  - 共有レポートとして機能するか
- リスト
  - 「担当-自分」の条件が機能するか
  - 共有リストとして機能するか