### PR TITLE
#562 カスタム項目において関連を選択した時に「関連」として保存されるようにする修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -54,7 +54,7 @@
 								{foreach item=FIELD_TYPE from=$ADD_SUPPORTED_FIELD_TYPES}
 									{if !$IS_FIELD_EDIT_MODE and $FIELD_TYPE eq 'Relation'} {continue}{/if}
 									<option value="{$FIELD_TYPE}" 
-											{if ($FIELD_MODEL->getFieldDataTypeLabel() eq $FIELD_TYPE)}selected='selected'{/if}
+											{if ($FIELD_MODEL->getFieldDataTypeLabel() eq $FIELD_TYPE|| $FIELD_MODEL->getFieldDataTypeLabel() eq 'Relation')}selected='selected'{/if}
 											{foreach key=TYPE_INFO item=TYPE_INFO_VALUE from=$FIELD_TYPE_INFO[$FIELD_TYPE]}
 												data-{$TYPE_INFO}="{$TYPE_INFO_VALUE}"
 											{/foreach}>

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -394,6 +394,9 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 		}
 		// Usersの追加
 		$modulesList["Users"] = vtranslate("Users", "Users");	
+		//関連項目に、活動・カレンダーはあまり必要ではないため選択肢から除外する。
+		unset($modulesList['Events']);
+		unset($modulesList['Calendar']);
 		return $modulesList;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #562 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カスタム項目の「関連」がテキストとして保存される。
2. 活動をカスタム項目の関連として登録した時に、その項目を編集すると権限エラーが発生する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. テキストとして保存されていることに対して
　関連として保存はされていた。変数の比較の部分（下記参照）が左辺ではReration、右辺ではReferenceが入ってきていた。
　RerationもReferenceも変換すると「関連」になる。
![image](https://user-images.githubusercontent.com/95267222/190340820-241bce2c-aac1-4cec-a9a1-2ef02256b64f.png)

2.登録した項目を編集すると権限エラーが発生することに対して
　利用用途が少ないため関連項目から「活動」と「カレンダー」を選べないようにした。
　
##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. テキストとして保存されていることに対して
　ReferenceとRerationを比較した時は選択肢をselectedにするようにした。
　変数に代入する箇所をRerationかReferenceのどちらかに合わせる方法もあったが、ここ以外でも両方が混ざって使われていたため、このような修正にした。
2. 登録した項目を編集すると権限エラーが発生することに対して
　利用用途が少ないため関連項目から「活動」と「カレンダー」を選べないようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/190343461-6059cce4-0040-42e7-978b-56bedd5a37bc.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全てのモジュールのカスタム項目の範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
テキストとして保存されていることに対しての修正で、RerationかReferenceのどちらかに合わせて変数に代入するよう修正したほうがいい場合はコメントください。