### PR TITLE
#625 消費税が「個別」の請求書を出力すると、値がおかしくなる 

### DIFF
--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -411,7 +411,11 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	$finalDiscount = 0;
 	$product_Detail[1]['final_details']['discount_type_final'] = 'zero';
 
-	$subTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
+	//subTotalに消費税のグループに関係なく小計が入っているpre_tax_totalを代入
+	//[消費税個別用]individualTotalに税込み金額が入っているhdnSubTotalを代入
+	$individualTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
+	$individualTotal = number_format($individualTotal, $no_of_decimal_places,'.','');
+	$subTotal = ($focus->column_fields['pre_tax_total'] != '')?$focus->column_fields['pre_tax_total']:0;
 	$subTotal = number_format($subTotal, $no_of_decimal_places,'.','');
 
 	$product_Detail[1]['final_details']['hdnSubTotal'] = $subTotal;
@@ -514,6 +518,10 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$taxTotal = $taxTotal + $taxDetails[$taxId]['amount'];
 	}
 	$product_Detail[1]['final_details']['taxes'] = $taxDetails;
+	//消費税が「個別」の時に、消費税を正しい数字に上書きする
+	if($taxtype == 'individual'){
+		$taxTotal = $individualTotal - $subTotal;
+	}
 	$product_Detail[1]['final_details']['tax_totalamount'] = number_format($taxTotal, $no_of_decimal_places, '.', '');
 	// 消費税がマイナスとなっている場合、引き算した時に料金が減ってしまうため、0にする
 	if($product_Detail[1]['final_details']['tax_totalamount'] <= 0){

--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -411,7 +411,11 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	$finalDiscount = 0;
 	$product_Detail[1]['final_details']['discount_type_final'] = 'zero';
 
-	$subTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
+	//subTotalに消費税のグループに関係なく小計が入っているpre_tax_totalを代入
+	//[消費税個別用]individualTotalに税込み金額が入っているhdnSubTotalを代入
+	$individualTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
+	$individualTotal = number_format($individualTotal, $no_of_decimal_places,'.','');
+	$subTotal = ($focus->column_fields['pre_tax_total'] != '')?$focus->column_fields['pre_tax_total']:0;
 	$subTotal = number_format($subTotal, $no_of_decimal_places,'.','');
 
 	$product_Detail[1]['final_details']['hdnSubTotal'] = $subTotal;
@@ -514,6 +518,12 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$taxTotal = $taxTotal + $taxDetails[$taxId]['amount'];
 	}
 	$product_Detail[1]['final_details']['taxes'] = $taxDetails;
+	//消費税が「個別」の時に、消費税を正しい数字に上書きする
+	if($taxtype == 'individual'){
+		$taxTotal = $individualTotal - $subTotal;
+		file_put_contents("individualtotal.txt",json_encode($individualTotal, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE),FILE_APPEND );
+		file_put_contents("subtotal.txt",json_encode($subTotal, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE),FILE_APPEND );
+	}
 	$product_Detail[1]['final_details']['tax_totalamount'] = number_format($taxTotal, $no_of_decimal_places, '.', '');
 	// 消費税がマイナスとなっている場合、引き算した時に料金が減ってしまうため、0にする
 	if($product_Detail[1]['final_details']['tax_totalamount'] <= 0){

--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -411,11 +411,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 	$finalDiscount = 0;
 	$product_Detail[1]['final_details']['discount_type_final'] = 'zero';
 
-	//subTotalに消費税のグループに関係なく小計が入っているpre_tax_totalを代入
-	//[消費税個別用]individualTotalに税込み金額が入っているhdnSubTotalを代入
-	$individualTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
-	$individualTotal = number_format($individualTotal, $no_of_decimal_places,'.','');
-	$subTotal = ($focus->column_fields['pre_tax_total'] != '')?$focus->column_fields['pre_tax_total']:0;
+	$subTotal = ($focus->column_fields['hdnSubTotal'] != '')?$focus->column_fields['hdnSubTotal']:0;
 	$subTotal = number_format($subTotal, $no_of_decimal_places,'.','');
 
 	$product_Detail[1]['final_details']['hdnSubTotal'] = $subTotal;
@@ -518,12 +514,6 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$taxTotal = $taxTotal + $taxDetails[$taxId]['amount'];
 	}
 	$product_Detail[1]['final_details']['taxes'] = $taxDetails;
-	//消費税が「個別」の時に、消費税を正しい数字に上書きする
-	if($taxtype == 'individual'){
-		$taxTotal = $individualTotal - $subTotal;
-		file_put_contents("individualtotal.txt",json_encode($individualTotal, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE),FILE_APPEND );
-		file_put_contents("subtotal.txt",json_encode($subTotal, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE),FILE_APPEND );
-	}
 	$product_Detail[1]['final_details']['tax_totalamount'] = number_format($taxTotal, $no_of_decimal_places, '.', '');
 	// 消費税がマイナスとなっている場合、引き算した時に料金が減ってしまうため、0にする
 	if($product_Detail[1]['final_details']['tax_totalamount'] <= 0){

--- a/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
@@ -237,7 +237,7 @@
 					</td>
 				</tr>
 				{if $DISCOUNT_AMOUNT_EDITABLE || $DISCOUNT_PERCENT_EDITABLE}
-					<tr>
+					<tr id="overall_discount" valign="top" class="{if $IS_INDIVIDUAL_TAX_TYPE}hide{/if}">
 						<td width="83%">
 							<span class="pull-right">(-)&nbsp;
 								<strong><a href="javascript:void(0)" id="finalDiscount">{vtranslate('LBL_OVERALL_DISCOUNT',$MODULE)}&nbsp;

--- a/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
@@ -237,7 +237,7 @@
 					</td>
 				</tr>
 				{if $DISCOUNT_AMOUNT_EDITABLE || $DISCOUNT_PERCENT_EDITABLE}
-					<tr id="overall_discount" valign="top" class="{if $IS_INDIVIDUAL_TAX_TYPE}hide{/if}">
+					<tr>
 						<td width="83%">
 							<span class="pull-right">(-)&nbsp;
 								<strong><a href="javascript:void(0)" id="finalDiscount">{vtranslate('LBL_OVERALL_DISCOUNT',$MODULE)}&nbsp;

--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -1852,7 +1852,6 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		this.taxTypeElement.on('change', function(e){
 			if(self.isIndividualTaxMode()) {
 				jQuery('#group_tax_row').addClass('hide');
-				jQuery('#overall_discount').addClass('hide');
 				self.lineItemsHolder.find('tr.'+self.lineItemDetectingClass).each(function(index,domElement){
 					var lineItemRow = jQuery(domElement);
 					lineItemRow.find('.individualTaxContainer,.productTaxTotal').removeClass('hide');
@@ -1860,7 +1859,6 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 				});
 			}else{
 				jQuery('#group_tax_row').removeClass('hide');
-				jQuery('#overall_discount').removeClass('hide');
 				self.lineItemsHolder.find('tr.'+ self.lineItemDetectingClass).each(function(index,domElement){
 					var lineItemRow = jQuery(domElement);
 					lineItemRow.find('.individualTaxContainer,.productTaxTotal').addClass('hide');

--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -1076,7 +1076,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 	calculateNetTotal : function() {
 		var self = this
 		var netTotalValue = 0;
-		this.lineItemsHolder.find('tr.'+this.lineItemDetectingClass+' .netPrice').each(function(index,domElement){
+		this.lineItemsHolder.find('tr.'+this.lineItemDetectingClass+' .totalAfterDiscount').each(function(index,domElement){
 			var lineItemNetPriceEle = jQuery(domElement);
 			netTotalValue += self.formatLineItemNetPrice(lineItemNetPriceEle);
 		});
@@ -1243,7 +1243,13 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 	},
     
     calculateGrandTotal : function(){
-        var netTotal = this.getNetTotal();
+		var self = this;
+		var netTotal = 0;
+		this.lineItemsHolder.find('tr.'+this.lineItemDetectingClass+' .netPrice').each(function(index,domElement){
+			var lineItemNetPriceEle = jQuery(domElement);
+			netTotal += self.formatLineItemNetPrice(lineItemNetPriceEle);
+		});
+        // var netTotal = this.getNetTotal();
 		var discountTotal = this.getFinalDiscountTotal();
 		var shippingHandlingCharge = this.getChargesTotal();
 		var shippingHandlingTax = this.getChargeTaxesTotal();
@@ -2830,4 +2836,6 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
     },
 });
     
+
+
 

--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -1852,6 +1852,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 		this.taxTypeElement.on('change', function(e){
 			if(self.isIndividualTaxMode()) {
 				jQuery('#group_tax_row').addClass('hide');
+				jQuery('#overall_discount').addClass('hide');
 				self.lineItemsHolder.find('tr.'+self.lineItemDetectingClass).each(function(index,domElement){
 					var lineItemRow = jQuery(domElement);
 					lineItemRow.find('.individualTaxContainer,.productTaxTotal').removeClass('hide');
@@ -1859,6 +1860,7 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 				});
 			}else{
 				jQuery('#group_tax_row').removeClass('hide');
+				jQuery('#overall_discount').removeClass('hide');
 				self.lineItemsHolder.find('tr.'+ self.lineItemDetectingClass).each(function(index,domElement){
 					var lineItemRow = jQuery(domElement);
 					lineItemRow.find('.individualTaxContainer,.productTaxTotal').addClass('hide');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #625 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 請求書を作成するときに「項目の詳細」で消費税を「個別」に変更してPDF出力すると、「小計」に合計が入り、「消費税」に合計に消費税率をかけた金額が入ってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 請求書作成・編集画面で保存した段階で、消費税が「個別」のときに合計が入っている変数(hdnSubTotal)（「グループ」の時には小計が入っている）を、小計(subTotal)に反映していた。
2. 請求書に反映される消費税の値が、消費税の種類（個別・グループ）に関係なく一律で計算された値になっていたため、値がおかしくなっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 請求書作成・編集画面で保存した段階で、消費税の種類に関係なく小計(subTotal)に小計(pre_tax_total)を代入するように変更した。
2. 消費税が「個別」の請求書を作成するときには、「消費税」に入る値を計算しなおすように変更した。
3. 消費税を「個別」に変更した時点で、値引きは各製品項目にて行うようにし、合計金額から値引きは行えないように変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更後の請求書編集画面（個別・グループ）
![individual_edit](https://user-images.githubusercontent.com/107910164/191173857-c664b282-da1f-4d7c-9bad-8d4e6b94869f.png)

![group_edit](https://user-images.githubusercontent.com/107910164/191173864-8dff34ce-42b9-4e14-9e58-ac719225a6ff.png)


変更後の請求書（個別・グループ）
![invoice_individual](https://user-images.githubusercontent.com/107910164/191173946-b8ab58eb-33db-4c8d-a3d5-2a027040c7fc.png)

![invoice_group](https://user-images.githubusercontent.com/107910164/191173957-18cb3715-e025-4256-9abd-3b8a429ed7b4.png)



## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
請求書作成・編集画面
PDF出力した請求書

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->