### PR TITLE
#639 ダッシュボードのミニリストのレイアウトが崩れる箇所の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
+++ b/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
@@ -11,25 +11,24 @@
 	{* Comupte the nubmer of columns required *}
 	{assign var="SPANSIZE" value=12}
 	{assign var=HEADER_COUNT value=$MINILIST_WIDGET_MODEL->getHeaderCount()}
-	{if $HEADER_COUNT && $HEADER_COUNT eq '5'}{* 5分割レイアウトは表現できないため、6分割として処理する *}
-		{assign var="SPANSIZE" value=12/6}
-	{elseif $HEADER_COUNT}
+	{if $HEADER_COUNT}
 		{assign var="SPANSIZE" value=12/$HEADER_COUNT}
+		{assign var="SPANWIDTH" value=100/$HEADER_COUNT}
 	{/if}
 
-	<div class="row" style="padding:5px">
+	<div class="row minilist-container" style="padding:5px">
 		{assign var=HEADER_FIELDS value=$MINILIST_WIDGET_MODEL->getHeaders()}
 		{foreach item=FIELD from=$HEADER_FIELDS}
-		<div class="col-lg-{$SPANSIZE}"><strong>{vtranslate($FIELD->get('label'),$BASE_MODULE)}</strong></div>
+		<div class="" style="width:{$SPANWIDTH}%"><strong>{vtranslate($FIELD->get('label'),$BASE_MODULE)}</strong></div>
 		{/foreach}
 	</div>
 
 	{assign var="MINILIST_WIDGET_RECORDS" value=$MINILIST_WIDGET_MODEL->getRecords()}
 
 	{foreach item=RECORD from=$MINILIST_WIDGET_RECORDS}
-	<div class="row miniListContent" style="padding:5px">
+	<div class="row miniListContent minilist-container" style="padding:5px">
 		{foreach item=FIELD key=NAME from=$HEADER_FIELDS name="minilistWidgetModelRowHeaders"}
-			<div class="col-lg-{$SPANSIZE} textOverflowEllipsis" title="{strip_tags($RECORD->get($NAME))}" style="padding-right: 5px;">
+			<div class="textOverflowEllipsis" title="{strip_tags($RECORD->get($NAME))}" style="width:{$SPANWIDTH}%">
                {if $FIELD->get('uitype') eq '71' || ($FIELD->get('uitype') eq '72' && $FIELD->getName() eq 'unit_price')}
 					{assign var=CURRENCY_ID value=$USER_MODEL->get('currency_id')}
 					{if $FIELD->get('uitype') eq '72' && $NAME eq 'unit_price'}

--- a/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
+++ b/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
@@ -11,7 +11,7 @@
 	{* Comupte the nubmer of columns required *}
 	{assign var="SPANSIZE" value=12}
 	{assign var=HEADER_COUNT value=$MINILIST_WIDGET_MODEL->getHeaderCount()}
-	{if $HEADER_COUNT && $HEADER_COUNT neq '5'}{* 5分割レイアウトは表現できないため、6分割として処理する *}
+	{if $HEADER_COUNT && $HEADER_COUNT eq '5'}{* 5分割レイアウトは表現できないため、6分割として処理する *}
 		{assign var="SPANSIZE" value=12/6}
 	{elseif $HEADER_COUNT}
 		{assign var="SPANSIZE" value=12/$HEADER_COUNT}

--- a/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
+++ b/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
@@ -28,7 +28,7 @@
 	{foreach item=RECORD from=$MINILIST_WIDGET_RECORDS}
 	<div class="row miniListContent minilist-container" style="padding:5px">
 		{foreach item=FIELD key=NAME from=$HEADER_FIELDS name="minilistWidgetModelRowHeaders"}
-			<div class="textOverflowEllipsis" title="{strip_tags($RECORD->get($NAME))}" style="width:{$SPANWIDTH}%">
+			<div class="textOverflowEllipsis" title="{strip_tags($RECORD->get($NAME))}" style="padding-right: 5px; width:{$SPANWIDTH}%">
                {if $FIELD->get('uitype') eq '71' || ($FIELD->get('uitype') eq '72' && $FIELD->getName() eq 'unit_price')}
 					{assign var=CURRENCY_ID value=$USER_MODEL->get('currency_id')}
 					{if $FIELD->get('uitype') eq '72' && $NAME eq 'unit_price'}

--- a/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
+++ b/layouts/v7/modules/Vtiger/dashboards/MiniListContents.tpl
@@ -11,7 +11,9 @@
 	{* Comupte the nubmer of columns required *}
 	{assign var="SPANSIZE" value=12}
 	{assign var=HEADER_COUNT value=$MINILIST_WIDGET_MODEL->getHeaderCount()}
-	{if $HEADER_COUNT}
+	{if $HEADER_COUNT && $HEADER_COUNT neq '5'}{* 5分割レイアウトは表現できないため、6分割として処理する *}
+		{assign var="SPANSIZE" value=12/6}
+	{elseif $HEADER_COUNT}
 		{assign var="SPANSIZE" value=12/$HEADER_COUNT}
 	{/if}
 

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -605,3 +605,24 @@ ul#productsImageContainer > li a{
   color: #ff0000;
   font-weight: 900;
 }
+
+/* ダッシュボードのミニリスト */
+@media (max-width: 1200px) {
+  .row.minilist-container {
+    color: red;
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column;
+  }
+  .row.minilist-container > div {
+    width: 100% !important;
+  }
+}
+.row.minilist-container {
+  display: flex;
+  flex-wrap: nowrap;
+}
+.row.minilist-container > div {
+  padding-right: 15px; 
+  padding-left: 15px; 
+}

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -609,7 +609,6 @@ ul#productsImageContainer > li a{
 /* ダッシュボードのミニリスト */
 @media (max-width: 1200px) {
   .row.minilist-container {
-    color: red;
     display: flex;
     flex-wrap: nowrap;
     flex-direction: column;

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -607,7 +607,7 @@ ul#productsImageContainer > li a{
 }
 
 /* ダッシュボードのミニリスト */
-@media (max-width: 1200px) {
+@media (max-width: 991px) {
   .row.minilist-container {
     display: flex;
     flex-wrap: nowrap;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #639 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ダッシュボードのミニリストにて、5つの項目を選択するとレイアウトが崩れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Bootstrapのグリッドを使用しているため、5等分レイアウトが作成できない
※項目は6項目までしか選べないため、5項目選択した場合にのみレイアウトが崩れる

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Bootstrapのグリッドではなく、`display:flex`で分割する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* デスクトップPC
![image](https://user-images.githubusercontent.com/75693720/192115007-5b77d203-9bc6-470e-bd2d-ab612396abdf.png)
* スマホ/タブレット ※縦並びになる
![image](https://user-images.githubusercontent.com/75693720/192115024-084d7537-06a5-4cef-b4d3-19da167fbd1c.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- ダッシュボード>ミニリスト

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->