### PR TITLE
#635 モジュール名が長いとワークフローの件数が表示されない

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/resources/List.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/List.js
@@ -114,9 +114,11 @@ Settings_Vtiger_List_Js("Settings_Workflows_List_Js", {
                     count = 0;
                 }
 
-                return result.text
-                + "&nbsp;&nbsp;<span class='label-success badge' style='display: inline;'>"
+                return "<span style='margin-right:0px;'><span style='max-width: 85%; display:inline-block; margin-right:5px;'>"
+                + result.text
+                + "&nbsp;&nbsp;</span><span class='label-success badge' style='display: inline; vertical-align:super; margin-right:0px;'>"
                 + count
+                + "</span>"
                 + "</span>";
             }
         });


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #635 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフロー一覧表にて、モジュール名が長いワークフローを選択するとワークフロー件数が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ワークフロー名と件数バッジが一つのタグとして処理されていたため、名前が長くなり検索ボックスの枠を超えてしまうとバッジも省略されてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ワークフロー名とワークフロー件数バッジを別のタグに分け、ワークフロー名が一定の長さを超えると省略されるようにし、件数バッジを表示させる枠を確保した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
ワークフロー名が長いとき
![スクリーンショット (18)](https://user-images.githubusercontent.com/107910164/191462719-2d340310-678b-4d02-9c4f-024bd407a688.png)

ワークフロー名が短いとき
![スクリーンショット (19)](https://user-images.githubusercontent.com/107910164/191466072-2afb6e00-e002-46fe-b0cf-65f673f6bcd3.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフロー設定画面のワークフロー一覧表のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->