### PR TITLE
#146 必須項目に「x」が表示される問題を修正

### DIFF
--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,7 +222,7 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		fieldsListSelect2Element.find('.select2-search-choice div:match("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
+		fieldsListSelect2Element.find('.select2-search-choice div:contains("'+mandatoryFieldLabel+'*")').closest('li').find('a').remove();
 	},
 	
 	/**

--- a/layouts/v7/modules/Settings/Webforms/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Webforms/resources/Edit.js
@@ -222,7 +222,7 @@ Settings_Vtiger_Edit_Js('Settings_Webforms_Edit_Js', {}, {
 	lockMandatoryOptionInSelect2 : function(mandatoryFieldLabel){
 		var sourceModuleContainer = this.getSourceModuleFieldTable();
 		var fieldsListSelect2Element = sourceModuleContainer.find('#s2id_fieldsList');
-		fieldsListSelect2Element.find('.select2-search-choice div:contains("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
+		fieldsListSelect2Element.find('.select2-search-choice div:match("'+mandatoryFieldLabel+'")').closest('li').find('a').remove();
 	},
 	
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #146 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 必須項目にも「*」が表示されてしまっていたためその修正。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 必須項目には「*」がつくためmatchの完全一致だと引っかからなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「*」を含めた文字列で検索を掛けるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/191671863-53286b8e-4bd9-4dab-bcb2-907cc958c6d1.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
Webフォームのselect2の範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
**タグに含まれる文字列で判定を行っているため「(必須項目名)*」を含む項目名に対しては「x」をつけることができない。**
![image](https://user-images.githubusercontent.com/95267222/191672433-4b4d3f97-4ae0-4184-94d3-cbc0e90f8550.png)

