### PR TITLE
#628 カレンダー複製時に終了時間が変更されないようにする修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Edit.js
+++ b/layouts/v7/modules/Calendar/resources/Edit.js
@@ -561,9 +561,7 @@ Vtiger_Edit_Js("Calendar_Edit_Js",{
 	  if(container.find('[name="record"]').val()===''){
 		this.registerDateStartChangeEvent(container);
 		this.registerTimeStartChangeEvent(container);
-			container.find('[name="time_end"]').on('focus', function () {
-				thisInstance.registerTimeEndChangeEvent(container);
-			});
+		this.registerTimeEndChangeEvent(container);
 		this.registerDateEndChangeEvent(container);
 		this.registerUserChangedDateTimeDetection(container);
 		this.registerActivityTypeChangeEvent(container);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #628 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーを複製した時に、開始日を変更すると終了時間が変更されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 編集以外の複製、新規作成の時は終了時間を選択しない限り終了時間が保持されなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 複製を選択した時に終了時間を保持するように修正した。（実際には開始時間と終了時間の差を保持している。）

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
複製を選択した時の動作範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->