### PR TITLE
#652 参照権限のみのユーザーでCSVエクスポートができない問題を修正

### DIFF
--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -12,7 +12,8 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 
 	var $moduleCall = false;
 	public function requiresPermission(\Vtiger_Request $request) {
-		$permissions = parent::requiresPermission($request);
+//		$permissions = parent::requiresPermission($request);
+		$permissions[] = array('module_parameter' => 'module', 'action' => 'DetailView');
 		$permissions[] = array('module_parameter' => 'module', 'action' => 'Export');
         if (!empty($request->get('source_module'))) {
             $permissions[] = array('module_parameter' => 'source_module', 'action' => 'Export');


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #652 

##  不具合の内容 / Bug
1. 参照権限のユーザーでログインしている場合、CSVをエクスポートできない。

##  原因 / Cause
1. 権限の処理時に一括編集の権限を記しているVtiger_Mass_Actionを継承しており、それにより権限の設定不具合が生じていたため。

##  変更内容 / Details of Change
1. ![2022-10-03 (12)](https://user-images.githubusercontent.com/112600172/193542837-1e7b7c22-e771-49ea-9e0a-293f89e55ddd.png)
$permissions = parent::requiresPermission($request);をコメントアウトし、$permissions[] = array('module_parameter' => 'module', 'action' => 'DetailView');を追加。

## 影響範囲  / Affected Area
CSVのエクスポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [X] 自らテストを行った
- [X] 不必要な変更が無い
- [X] 影響範囲の検討を行った