### PR TITLE
refs #631 カレンダー画面で非公開として登録した予定が表示される件を修正

### DIFF
--- a/include/utils/UserInfoUtil.php
+++ b/include/utils/UserInfoUtil.php
@@ -259,6 +259,11 @@ function getRoleName($roleid)
  */
 function isPermitted($module,$actionname,$record_id='')
 {
+
+	if($module == 'Events'){
+		$module = 'Calendar';
+	}
+
 	global $log;
 	$log->debug("Entering isPermitted(".$module.",".$actionname.",".$record_id.") method ...");
 
@@ -541,7 +546,17 @@ function isPermitted($module,$actionname,$record_id='')
 			{
 				if($module == 'Calendar')
 				{
-					$permission='no';
+					$permission='yes';
+					if($module == 'Calendar') {
+						$activityType = vtws_getCalendarEntityType($record_id);
+						if($activityType == 'Events') {
+							$permission = isCalendarPermittedBySharing($record_id);
+						} else {
+							$permission = isToDoPermittedBySharing($record_id);
+						}
+					}
+					$log->debug("Exiting isPermitted method ...");
+					return $permission;
 				}
 				else
 				{

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1599,7 +1599,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		if (calendarView.name === 'agendaDay') {
 			params.constrains = 'vertical';
 		}
-		element.webuiPopover(params);
+		if(app.getUserId() == event.userid || event.visibility != "Private"){
+			element.webuiPopover(params);
+		}
 	},
 	performPreEventRenderActions: function (event, element) {
 		var calendarView = this.getCalendarViewContainer().fullCalendar('getView');

--- a/layouts/v7/modules/Vtiger/RelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedList.tpl
@@ -84,11 +84,18 @@
 					</thead>
 					{foreach item=RELATED_RECORD from=$RELATED_RECORDS}
 						<tr class="listViewEntries" data-id='{$RELATED_RECORD->getId()}' 
+							{assign var=CURRENT_USER_MODEL value=Users_Record_Model::getCurrentUserModel()}
+							{assign var=CURRENT_USER_ID value=$CURRENT_USER_MODEL->getId()}
+							{assign var=RAWDATA value=$RELATED_RECORD->getData()}
+							{assign var=OWNER_ID value=$RAWDATA['assigned_user_id']}
 							{if $RELATED_MODULE_NAME eq 'Calendar'}
 								data-recurring-enabled='{$RELATED_RECORD->isRecurringEnabled()}'
-								{assign var=DETAILVIEWPERMITTED value=isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId())}
-								{if $DETAILVIEWPERMITTED eq 'yes'}
-									data-recordUrl='{$RELATED_RECORD->getDetailViewUrl()}'
+								{if $RELATED_RECORD->get('visibility') == vtranslate('Private', $MODULE ) && $OWNER_ID != $CURRENT_USER_ID && !$CURRENT_USER_MODEL->isAdminUser()}
+									{else}
+										{assign var=DETAILVIEWPERMITTED value=isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId())}
+										{if $DETAILVIEWPERMITTED eq 'yes'}
+											data-recordUrl='{$RELATED_RECORD->getDetailViewUrl()}'
+										{/if}
 								{/if}
 							{else}
 								data-recordUrl='{$RELATED_RECORD->getDetailViewUrl()}'
@@ -130,7 +137,11 @@
 											<center>{$RELATED_RECORD->get($RELATED_HEADERNAME)}</center>
 											{else}
 												{if $HEADER_FIELD->isNameField() eq true or $HEADER_FIELD->get('uitype') eq '4'}
-												<a href="{$RELATED_RECORD->getDetailViewUrl()}">{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}</a>
+													{if $RELATED_RECORD->get('visibility') == vtranslate('Private', $MODULE ) && $OWNER_ID != $CURRENT_USER_ID && !$CURRENT_USER_MODEL->isAdminUser()}
+														{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
+													{else}
+														<a href="{$RELATED_RECORD->getDetailViewUrl()}">{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}</a>
+													{/if}
 											{elseif $RELATED_HEADERNAME eq 'access_count'}
 												{$RELATED_RECORD->getAccessCountValue($PARENT_RECORD->getId())}
 											{elseif $RELATED_HEADERNAME eq 'time_start' or $RELATED_HEADERNAME eq 'time_end'}
@@ -174,19 +185,22 @@
 												{/if}
 												<span {if !empty($RELATED_LIST_VALUE)} class="picklist-color picklist-{$PICKLIST_FIELD_ID}-{Vtiger_Util_Helper::convertSpaceToHyphen($RELATED_LIST_VALUE)}" {/if}> {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)} </span>
 											{else}
-												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
-												{* Documents list view special actions "view file" and "download file" *}
-												{if $RELATED_MODULE_NAME eq 'Documents' && $RELATED_HEADERNAME eq 'filename' && isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId()) eq 'yes'}
-													<span class="actionImages">
-														{assign var=RECORD_ID value=$RELATED_RECORD->getId()}
-														{assign var="DOCUMENT_RECORD_MODEL" value=Vtiger_Record_Model::getInstanceById($RECORD_ID)}
-														{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus')}
-															<a name="viewfile" href="javascript:void(0)" data-filelocationtype="{$DOCUMENT_RECORD_MODEL->get('filelocationtype')}" data-filename="{$DOCUMENT_RECORD_MODEL->get('filename')}" onclick="Vtiger_Header_Js.previewFile(event)"><i title="{vtranslate('LBL_VIEW_FILE', $RELATED_MODULE_NAME)}" class="icon-picture alignMiddle"></i></a>&nbsp;
-															{/if}
-															{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus') && $DOCUMENT_RECORD_MODEL->get('filelocationtype') eq 'I'}
-															<a name="downloadfile" href="{$DOCUMENT_RECORD_MODEL->getDownloadFileURL()}"><i title="{vtranslate('LBL_DOWNLOAD_FILE', $RELATED_MODULE_NAME)}" class="icon-download-alt alignMiddle"></i></a>&nbsp;
-															{/if}
-													</span>
+												{if $RELATED_RECORD->get('visibility') == vtranslate('Private', $MODULE ) && $OWNER_ID != $CURRENT_USER_ID && !$CURRENT_USER_MODEL->isAdminUser()}
+													{else}
+														{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
+														{* Documents list view special actions "view file" and "download file" *}
+														{if $RELATED_MODULE_NAME eq 'Documents' && $RELATED_HEADERNAME eq 'filename' && isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId()) eq 'yes'}
+															<span class="actionImages">
+																{assign var=RECORD_ID value=$RELATED_RECORD->getId()}
+																{assign var="DOCUMENT_RECORD_MODEL" value=Vtiger_Record_Model::getInstanceById($RECORD_ID)}
+																{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus')}
+																	<a name="viewfile" href="javascript:void(0)" data-filelocationtype="{$DOCUMENT_RECORD_MODEL->get('filelocationtype')}" data-filename="{$DOCUMENT_RECORD_MODEL->get('filename')}" onclick="Vtiger_Header_Js.previewFile(event)"><i title="{vtranslate('LBL_VIEW_FILE', $RELATED_MODULE_NAME)}" class="icon-picture alignMiddle"></i></a>&nbsp;
+																	{/if}
+																	{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus') && $DOCUMENT_RECORD_MODEL->get('filelocationtype') eq 'I'}
+																	<a name="downloadfile" href="{$DOCUMENT_RECORD_MODEL->getDownloadFileURL()}"><i title="{vtranslate('LBL_DOWNLOAD_FILE', $RELATED_MODULE_NAME)}" class="icon-download-alt alignMiddle"></i></a>&nbsp;
+																	{/if}
+															</span>
+														{/if}
 												{/if}
 											{/if}
 										{/if}

--- a/modules/Accounts/Accounts.php
+++ b/modules/Accounts/Accounts.php
@@ -477,7 +477,7 @@ class Accounts extends CRMEntity {
 		$userNameSql = getSqlForNameInDisplayFormat(array('last_name' => 'vtiger_users.last_name', 'first_name'=>'vtiger_users.first_name',), 'Users');
 
 		$query = "SELECT DISTINCT(vtiger_activity.activityid), vtiger_activity.subject, vtiger_activity.status, vtiger_activity.eventstatus,
-				vtiger_activity.activitytype, vtiger_activity.date_start, vtiger_activity.due_date, vtiger_activity.time_start, vtiger_activity.time_end,
+				vtiger_activity.activitytype, vtiger_activity.date_start, vtiger_activity.due_date, vtiger_activity.time_start, vtiger_activity.time_end, vtiger_activity.visibility,
 				vtiger_crmentity.modifiedtime, vtiger_crmentity.createdtime, vtiger_crmentity.description,
 				case when (vtiger_users.user_name not like '') then $userNameSql else vtiger_groups.groupname end as user_name
 				FROM vtiger_activity

--- a/modules/Accounts/models/Module.php
+++ b/modules/Accounts/models/Module.php
@@ -380,16 +380,13 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 			} else if($ownerId == $currentUser->getId()){
 				$visibility = false;
 			}
-			if($newRow['activitytype'] != 'Task' && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
+			if(!$currentUser->isAdminUser() && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
 				foreach($newRow as $data => $value) {
 					if(in_array($data, $visibleFields) != -1) {
 						unset($newRow[$data]);
 					}
 				}
 				$newRow['subject'] = vtranslate('Busy','Events').'*';
-			}
-			if($newRow['activitytype'] == 'Task') {
-				unset($newRow['visibility']);
 			}
 
 			$model->setData($newRow);

--- a/modules/Calendar/models/ListView.php
+++ b/modules/Calendar/models/ListView.php
@@ -291,7 +291,7 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 				$visibility = false;
 			}
 
-			if(!$currentUser->isAdminUser() && $rawData['activitytype'] != 'Task' && $rawData['visibility'] == 'Private' && $ownerId && $visibility) {
+			if(!$currentUser->isAdminUser() && $rawData['visibility'] == 'Private' && $ownerId && $visibility) {
 				foreach($record as $data => $value) {
 					if(in_array($data, $visibleFields) != -1) {
 						unset($rawData[$data]);

--- a/modules/Contacts/Contacts.php
+++ b/modules/Contacts/Contacts.php
@@ -424,7 +424,7 @@ class Contacts extends CRMEntity {
 		$query = "SELECT case when (vtiger_users.user_name not like '') then $userNameSql else vtiger_groups.groupname end as user_name," .
 				" vtiger_contactdetails.lastname, vtiger_contactdetails.firstname,  vtiger_activity.activityid ," .
 				" vtiger_activity.subject, vtiger_activity.activitytype, vtiger_activity.date_start, vtiger_activity.due_date," .
-				" vtiger_activity.time_start,vtiger_activity.time_end, vtiger_cntactivityrel.contactid, vtiger_crmentity.crmid," .
+				" vtiger_activity.time_start,vtiger_activity.time_end, vtiger_activity.visibility, vtiger_cntactivityrel.contactid, vtiger_crmentity.crmid," .
 				" vtiger_crmentity.smownerid, vtiger_crmentity.modifiedtime, vtiger_recurringevents.recurringtype," .
 				" case when (vtiger_activity.activitytype = 'Task') then vtiger_activity.status else vtiger_activity.eventstatus end as status, " .
 				" vtiger_seactivityrel.crmid as parent_id " .
@@ -460,7 +460,7 @@ class Contacts extends CRMEntity {
 		$userNameSql = getSqlForNameInDisplayFormat(array('last_name' => 'vtiger_users.last_name', 'first_name' => 'vtiger_users.first_name',), 'Users');
 		$query = "SELECT vtiger_activity.activityid, vtiger_activity.subject, vtiger_activity.status
 			, vtiger_activity.eventstatus,vtiger_activity.activitytype, vtiger_activity.date_start,
-			vtiger_activity.due_date,vtiger_activity.time_start,vtiger_activity.time_end,
+			vtiger_activity.due_date,vtiger_activity.time_start,vtiger_activity.time_end,vtiger_activity.visibility,
 			vtiger_contactdetails.contactid, vtiger_contactdetails.firstname,
 			vtiger_contactdetails.lastname, vtiger_crmentity.modifiedtime,
 			vtiger_crmentity.createdtime, vtiger_crmentity.description,vtiger_crmentity.crmid,

--- a/modules/Contacts/models/Module.php
+++ b/modules/Contacts/models/Module.php
@@ -109,7 +109,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
 			} else if($ownerId == $currentUser->getId()){
 				$visibility = false;
 			}
-			if(!$currentUser->isAdminUser() && $newRow['activitytype'] != 'Task' && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
+			if(!$currentUser->isAdminUser() && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
 				foreach($newRow as $data => $value) {
 					if(in_array($data, $visibleFields) != -1) {
 						unset($newRow[$data]);
@@ -118,7 +118,6 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
 				$newRow['subject'] = vtranslate('Busy','Events').'*';
 			}
 			if($newRow['activitytype'] == 'Task') {
-				unset($newRow['visibility']);
 
 				$due_date = $newRow["due_date"];
 				$dayEndTime = "23:59:59";

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -2531,7 +2531,8 @@ class ReportRun extends CRMEntity {
 
 			$query .= " ".$this->getRelatedModulesQuery($module,$this->secondarymodule).
 					getNonAdminAccessControlQuery($this->primarymodule,$current_user).
-					" WHERE vtiger_crmentity.deleted=0 and (vtiger_activity.activitytype != 'Emails')";
+					" WHERE vtiger_crmentity.deleted=0 and (vtiger_activity.activitytype != 'Emails')".
+					" and vtiger_activity.visibility != 'Private'";// カレンダー用 非公開のスケジュールは出力しない
 		} else if ($module == "Quotes") {
 			$matrix = $this->queryPlanner->newDependencyMatrix();
 
@@ -2981,6 +2982,16 @@ class ReportRun extends CRMEntity {
 		}
 		if ($advfiltersql != "") {
 			$wheresql .= " and " . $advfiltersql;
+		}
+
+		// カレンダー用 非公開のスケジュールは出力しない
+		if ($this->secondarymodule != '') {
+			$secondarymodule = explode(":", $this->secondarymodule);
+			foreach ($secondarymodule as $value) {
+				if ($value == 'Calendar') {
+					$wheresql .= " AND vtiger_activity.visibility != 'Private' ";
+				}
+			}
 		}
 
         if($this->_reportquery == false){

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -1144,7 +1144,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 			} else if($ownerId == $currentUser->getId()){
 				$visibility = false;
 			}
-			if(!$currentUser->isAdminUser() && $newRow['activitytype'] != 'Task' && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
+			if(!$currentUser->isAdminUser() && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
 				foreach($newRow as $data => $value) {
 					if(in_array($data, $visibleFields) != -1) {
 						unset($newRow[$data]);
@@ -1153,8 +1153,6 @@ class Vtiger_Module_Model extends Vtiger_Module {
 				$newRow['subject'] = vtranslate('Busy','Events').'*';
 			}
 			if($newRow['activitytype'] == 'Task') {
-				unset($newRow['visibility']);
-
 				$due_date = $newRow["due_date"];
 				$dayEndTime = "23:59:59";
 				$EndDateTime = Vtiger_Datetime_UIType::getDBDateTimeValue($due_date." ".$dayEndTime);

--- a/modules/Vtiger/models/RelationListView.php
+++ b/modules/Vtiger/models/RelationListView.php
@@ -367,7 +367,7 @@ class Vtiger_RelationListView_Model extends Vtiger_Base_Model {
 				} else if($ownerId == $currentUser->getId()){
 					$visibility = false;
 				}
-				if(!$currentUser->isAdminUser() && $newRow['activitytype'] != 'Task' && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
+				if(!$currentUser->isAdminUser() && $newRow['visibility'] == 'Private' && $ownerId && $visibility) {
 					foreach($newRow as $data => $value) {
 						if(in_array($data, $visibleFields) != -1) {
 							unset($newRow[$data]);
@@ -375,10 +375,6 @@ class Vtiger_RelationListView_Model extends Vtiger_Base_Model {
 					}
 					$newRow['subject'] = vtranslate('Busy','Events').'*';
 				}
-				if($newRow['activitytype'] == 'Task') {
-					unset($newRow['visibility']);
-				}
-
 			}
 
 			$record = Vtiger_Record_Model::getCleanInstance($relationModule->get('name'));


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #631 

##  不具合の内容 / Bug
1. カレンダー画面にて活動のポップアップを表示した際、非公開として登録した予定の内容が表示されている。

##  原因 / Cause
1. そもそもカレンダー画面にて活動のポップアップを表示した際に、非公開として登録した場合に予定の内容を非表示にする条件が書かれていなかった。

##  変更内容 / Details of Change
1. 非公開として登録した予定については内容を非表示にするよう条件を追加。

## 影響範囲  / Affected Area
カレンダー
（管理者権限であっても非表示になっている）


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った