### PR TITLE
#646 ワークフローの複数選択肢条件が機能していない箇所の修正

### DIFF
--- a/data/VTEntityDelta.php
+++ b/data/VTEntityDelta.php
@@ -116,10 +116,23 @@ class VTEntityDelta extends VTEventHandler {
 		if(is_array($fieldDelta)) {
 			$fieldDelta = array_map('decode_html', $fieldDelta);
 		}
-		$result = $fieldDelta['oldValue'] != $fieldDelta['currentValue'];
-		if ($fieldValue !== NULL) {
-			$result = $result && ($fieldDelta['currentValue'] === $fieldValue);
-		}
+		
+		$module = Vtiger_Module::getInstance($moduleName);
+        $fieldModel = Vtiger_Field_Model::getInstance($fieldName, $module);
+        if($fieldModel->getFieldDataType() == "multipicklist") {
+			$fieldDelta_oldValue = explode(' |##| ', $fieldDelta['oldValue']);
+			$fieldDelta_currentValue = explode(' |##| ', $fieldDelta['currentValue']);
+			$result = !empty(array_diff($fieldDelta_oldValue, $fieldDelta_currentValue)) || !empty(array_diff($fieldDelta_currentValue, $fieldDelta_oldValue));
+			if ($fieldValue !== NULL) { //$fieldValueは「～に変更された」条件のとき
+				$fieldValue = explode(',', $fieldValue);
+				$result = $result && (empty(array_diff($fieldValue, $fieldDelta_currentValue)) && empty(array_diff($fieldDelta_currentValue, $fieldValue)));
+			}
+        }else{
+            $result = $fieldDelta['oldValue'] != $fieldDelta['currentValue'];
+			if ($fieldValue !== NULL) {
+				$result = $result && ($fieldDelta['currentValue'] === $fieldValue);
+			}
+        }
 		return $result;
 	}
 

--- a/modules/com_vtiger_workflow/VTJsonCondition.inc
+++ b/modules/com_vtiger_workflow/VTJsonCondition.inc
@@ -143,6 +143,15 @@ class VTJsonCondition {
 		}
 	}
 
+	function getPicklistArray($value){
+		if ($value && strpos($value, ' |##| ') !== false){
+			$value = explode(' |##| ', $value);
+		} else {
+			$value = explode(',', $value);
+		}
+		return $value;
+	}
+
 	function checkCondition($entityData, $cond, $referredEntityData=null) {
 		$data = $entityData->getData();
 
@@ -256,6 +265,10 @@ class VTJsonCondition {
 					} else {
 						return $fieldValue === 'off' || $fieldValue === 0 || $fieldValue === '0' || $fieldValue === '';
 					}
+				} else if($fieldInstance && $fieldInstance->getFieldDataType() == 'multipicklist'){
+					$fieldValue = $this->getPicklistArray($fieldValue);
+					$value = $this->getPicklistArray($value);
+					return empty(array_diff($fieldValue, $value)) && empty(array_diff($value, $fieldValue));
 				} else {
 					if($fieldInstance && $fieldInstance->getFieldDataType() == 'datetime') {
 						$value = getValidDBInsertDateValue($value);
@@ -270,6 +283,10 @@ class VTJsonCondition {
 					} else {
 						return $fieldValue === 'on' || $fieldValue === 1 || $fieldValue === '1';
 					}
+				} else if($fieldInstance && $fieldInstance->getFieldDataType() == 'multipicklist'){
+					$fieldValue = $this->getPicklistArray($fieldValue);
+					$value = $this->getPicklistArray($value);
+					return !empty(array_diff($fieldValue, $value)) || !empty(array_diff($value, $fieldValue));
 				} else {
 					if($fieldInstance && $fieldInstance->getFieldDataType() == 'datetime') {
 						$value = getValidDBInsertDateValue($value);
@@ -281,22 +298,23 @@ class VTJsonCondition {
 					if(empty($fieldValue) && empty($value)) {
 						return true;
 					} else if(!empty($fieldValue)) {
-						$fieldValue = explode(' |##| ', $fieldValue);
+						$fieldValue = $this->getPicklistArray($fieldValue);
 						if(is_array($fieldValue)) {
-							$conditionMatched = false;
-							$valueExplodedArr = explode(',',$value);
-							foreach ($fieldValue as $arrayValue) {
-								foreach($valueExplodedArr as $val){
-									if(strpos($arrayValue,$val) !== false) {
-									$conditionMatched = true;
+							$valueExplodedArr = $this->getPicklistArray($value);
+							$matchcount = 0;
+							foreach($valueExplodedArr as $val){
+								foreach ($fieldValue as $arrayValue) {
+									if($val == $arrayValue){
+										$matchcount++;
 										break;
 									}
 								}
-								if($conditionMatched){
-									break;
-								}
 							}
-							return $conditionMatched;
+							if($matchcount == count($valueExplodedArr)){
+								return true;
+							}else{
+								return false;
+							}
 						}
 					}
 					return false;
@@ -313,22 +331,23 @@ class VTJsonCondition {
 					if(empty($fieldValue) && empty($value)) {
 						return false;
 					} else if(!empty($fieldValue)) {
-						$fieldValue = explode(' |##| ', $fieldValue);
+						$fieldValue = $this->getPicklistArray($fieldValue);
 						if(is_array($fieldValue)) {
-							$conditionMatched = true;
-							$valueExplodedArr = explode(',',$value);
-							foreach ($fieldValue as $arrayValue) {
-								foreach($valueExplodedArr as $val){
-									if(strpos($arrayValue,$val) !== false) {
-										$conditionMatched = false;
+							$valueExplodedArr = $this->getPicklistArray($value);
+							$matchcount = 0;
+							foreach($valueExplodedArr as $val){
+								foreach ($fieldValue as $arrayValue) {
+									if($val == $arrayValue){
+										$matchcount++;
 										break;
 									}
 								}
-								if(!$conditionMatched) {
-									break;
-								}
 							}
-							return $conditionMatched;
+							if($matchcount == count($valueExplodedArr)){
+								return false;
+							}else{
+								return true;
+							}
 						}
 					}
 					return true;
@@ -350,6 +369,8 @@ class VTJsonCondition {
 				$idParts = vtws_getIdComponents($entityData->getId());
 				$hasChanged = $entityDelta->hasChanged($entityData->getModuleName(), $idParts[1], $cond['fieldname']);
 				if (empty($value)) {
+					return $hasChanged;
+				} else if($fieldInstance && $fieldInstance->getFieldDataType() == 'multipicklist'){
 					return $hasChanged;
 				} else {
 					return $hasChanged && $fieldValue == $value;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #646 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローの複数選択肢条件が機能していない 

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 複数選択肢の一致は他項目の一致と異なる処理のはずだが区別されていなかった
例) 複数選択肢が「あ」「い」「う」の3つある場合で「等しい」条件

条件値 : あ,い,う
入力値 : あ,う,い
→ワークフロー結果 : falise

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 複数選択肢で使用するすべての条件に対して別処理を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- ワークフロー条件

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->