### PR TITLE
#70 カスタム項目において日付項目にTODAYを使えるように改善

### DIFF
--- a/include/fields/DateTimeField.php
+++ b/include/fields/DateTimeField.php
@@ -188,36 +188,37 @@ class DateTimeField {
     {
         $date = self::convertToInternalFormat($date);
         list($y, $m, $d) = explode('-', $date[0]);
-
-        switch ($format) {
-            case 'dd.mm.yyyy':
-                $date[0] = $d . '.' . $m . '.' . $y;
-				break;
-			case 'mm.dd.yyyy':
-                $date[0] = $m . '.' . $d . '.' . $y;
-				break;
-			case 'yyyy.mm.dd':
-                $date[0] = $y . '.' . $m . '.' . $d;
-				break;
-			case 'dd/mm/yyyy':
-                $date[0] = $d . '/' . $m . '/' . $y;
-				break;
-			case 'mm/dd/yyyy':
-                $date[0] = $m . '/' . $d . '/' . $y;
-				break;
-			case 'yyyy/mm/dd':
-                $date[0] = $y . '/' . $m . '/' . $d;
-                break;
-            case 'dd-mm-yyyy':
-                $date[0] = $d . '-' . $m . '-' . $y;
-                break;
-            case 'mm-dd-yyyy':
-                $date[0] = $m . '-' . $d . '-' . $y;
-                break;
-            case 'yyyy-mm-dd':
-                $date[0] = $y . '-' . $m . '-' . $d;
-                break;
-        }
+		if($date[0]!='TODAY'){
+			switch ($format) {
+				case 'dd.mm.yyyy':
+					$date[0] = $d . '.' . $m . '.' . $y;
+					break;
+				case 'mm.dd.yyyy':
+					$date[0] = $m . '.' . $d . '.' . $y;
+					break;
+				case 'yyyy.mm.dd':
+					$date[0] = $y . '.' . $m . '.' . $d;
+					break;
+				case 'dd/mm/yyyy':
+					$date[0] = $d . '/' . $m . '/' . $y;
+					break;
+				case 'mm/dd/yyyy':
+					$date[0] = $m . '/' . $d . '/' . $y;
+					break;
+				case 'yyyy/mm/dd':
+					$date[0] = $y . '/' . $m . '/' . $d;
+					break;
+				case 'dd-mm-yyyy':
+					$date[0] = $d . '-' . $m . '-' . $y;
+					break;
+				case 'mm-dd-yyyy':
+					$date[0] = $m . '-' . $d . '-' . $y;
+					break;
+				case 'yyyy-mm-dd':
+					$date[0] = $y . '-' . $m . '-' . $d;
+					break;
+			}
+		}
 
         if ($date[1] != '') {
             $userDate = $date[0] . ' ' . $date[1];

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1031,6 +1031,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 						}
 						else{
 							datedefaultvaluebox.classList.remove('ignore-validation');
+							datedefaultvaluebox.classList.remove('input-error');
 						}
 					});	
 				}

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1016,6 +1016,23 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 				var dateField = defaultValueUiContainer.find('.dateField')
 				if (dateField.length > 0) {
 					vtUtils.registerEventForDateFields(dateField);
+					var datedefaultvaluebox = document.getElementsByClassName("inputElement dateField form-control")[0];
+					if(datedefaultvaluebox.value == 'TODAY'){
+						datedefaultvaluebox.classList.add('ignore-validation');
+						datedefaultvaluebox.classList.remove('input-error');
+					}
+					else{
+						datedefaultvaluebox.classList.remove('ignore-validation');
+					}
+					dateField.on("change",function (e) {
+						if(datedefaultvaluebox.value == 'TODAY'){
+							datedefaultvaluebox.classList.add('ignore-validation');
+							datedefaultvaluebox.classList.remove('input-error');
+						}
+						else{
+							datedefaultvaluebox.classList.remove('ignore-validation');
+						}
+					});	
 				}
 
 				defaultValueUiContainer.find('[data-rule-required]').removeAttr('data-rule-required');

--- a/modules/Calendar/models/EditRecordStructure.php
+++ b/modules/Calendar/models/EditRecordStructure.php
@@ -67,7 +67,13 @@ class Calendar_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mode
 							if ($fieldValue == '') {
 								$defaultValue = $fieldModel->getDefaultFieldValue();
 								if ($defaultValue && !$recordId) {
-									$fieldValue = $defaultValue;
+									$defaultValue = $fieldModel->getDefaultFieldValue();
+									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
+										$fieldValue = date('Y-m-d');
+									}
+									else{
+										$fieldValue = $defaultValue;
+									}
 								}
 							}
 							$fieldModel->set('fieldvalue', $fieldValue);

--- a/modules/Calendar/models/QuickCreateRecordStructure.php
+++ b/modules/Calendar/models/QuickCreateRecordStructure.php
@@ -57,7 +57,10 @@ class Calendar_QuickCreateRecordStructure_Model extends Vtiger_QuickCreateRecord
 				$fieldModel->set('fieldvalue', $fieldValue);
 			} else {
 				$defaultValue = $fieldModel->getDefaultFieldValue();
-				if ($defaultValue) {
+				if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
+					$fieldModel->set('fieldvalue', date('Y-m-d'));
+				}
+				else{
 					$fieldModel->set('fieldvalue', $defaultValue);
 				}
 			}

--- a/modules/Inventory/models/EditRecordStructure.php
+++ b/modules/Inventory/models/EditRecordStructure.php
@@ -40,8 +40,14 @@ class Inventory_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mod
 								$fieldValue = $recordModel->getInventoryTermsAndConditions();
 							} else if($fieldValue == '') {
                                 $defaultValue = $fieldModel->getDefaultFieldValue();
-                                if(!empty($defaultValue) && !$recordId)
-									$fieldValue = $defaultValue;
+                                if(!empty($defaultValue) && !$recordId){
+									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
+										$fieldValue = date('Y-m-d');
+									}
+									else{
+										$fieldValue = $defaultValue;
+									}
+								}
 							}
 							$fieldModel->set('fieldvalue', $fieldValue);
 						}

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -188,8 +188,10 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 
 		$defaultValue = $params['fieldDefaultValue'];
 		if(strtolower($fieldType) == 'date') {
-			$dateInstance = new Vtiger_Date_UIType();
-			$defaultValue = $dateInstance->getDBInsertedValue($defaultValue);
+			if($defaultValue != 'TODAY'){
+				$dateInstance = new Vtiger_Date_UIType();
+				$defaultValue = $dateInstance->getDBInsertedValue($defaultValue);
+			}
 		} else if (strtolower($fieldType) == 'time') {
 			$defaultValue = Vtiger_Time_UIType::getTimeValueWithSeconds($defaultValue);
 		} else if (strtolower($fieldType) == 'currency') {

--- a/modules/Vtiger/models/EditRecordStructure.php
+++ b/modules/Vtiger/models/EditRecordStructure.php
@@ -38,7 +38,13 @@ class Vtiger_EditRecordStructure_Model extends Vtiger_RecordStructure_Model {
 						}else{
 							$defaultValue = $fieldModel->getDefaultFieldValue();
 							if(!empty($defaultValue) && !$recordId)
-								$fieldModel->set('fieldvalue', $defaultValue);
+								if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
+									$fieldModel->set('fieldvalue', date('Y-m-d'));
+								}
+								else{
+									$fieldModel->set('fieldvalue', $defaultValue);
+								}
+								
 						}
 						$values[$blockLabel][$fieldName] = $fieldModel;
                         if ($fieldName == 'taxclass' && count($recordModel->getTaxClassDetails()) < 1) {

--- a/modules/Vtiger/models/QuickCreateRecordStructure.php
+++ b/modules/Vtiger/models/QuickCreateRecordStructure.php
@@ -50,7 +50,12 @@ class Vtiger_QuickCreateRecordStructure_Model extends Vtiger_RecordStructure_Mod
             } else{
                 $defaultValue = $fieldModel->getDefaultFieldValue();
                 if($defaultValue) {
-                    $fieldModel->set('fieldvalue', $defaultValue);
+                    if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
+                        $fieldModel->set('fieldvalue', date('Y-m-d'));
+                    }
+                    else{
+                        $fieldModel->set('fieldvalue', $defaultValue);
+                    }
                 }
             }
 			$values[$fieldName] = $fieldModel;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #70 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カスタム項目において日付形式を選択した時に、デフォルト値にTODAYを設定できるようにした。
2. TODAYを設定された項目は項目値にその日の日付が入力されるようにした。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger、カレンダー、インベントリモジュールにおいて以下の修正を行った
　・fieldmodelのdatatyeがdate型かつデフォルト値がTODAYの時に値をその日の日付に設定する。
2. settingsのLayoutEditorにてdate型かつデフォルト値がTODAYの時に型をuitypeのdate型に合わせる処理をスキップした。
3. カスタム項目の日付項目のデフォルト値がTODAYの時は入力欄のバリデーションを外す処理を行った。
4. カレンダーの日付形式においてTODAYの時は表示形式をユーザーの設定に合わせずにそのままTODAYと表示するように変更。
　例)
　・ユーザー設定で日付形式をmm/dd/yyyyにしていた時もカスタム項目のデフォルト値にはTODAYと表示される。これを行わないとカスタム項目のデフォルト値にはTODAY//と表示されてしまう。
　・include/fieldsにてこの処理を行っているが、この処理はdate型を表示する最後のほうの処理である。そのためユーザーの設定に合わせない処理が行われるのはカスタム項目のデフォルト値を表示するとき、かつその値がTODAYの時だけである。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/197488738-0883e82e-16d9-493a-a8f4-5dae101a3384.png)
上の画像のようにすると下の画像のようにその日の日付が入力される。
![image](https://user-images.githubusercontent.com/95267222/197488926-c779611b-be7d-4dc7-881b-d2fa62f699ec.png)

クイック作成時もその日の日付が入力される。
![image](https://user-images.githubusercontent.com/95267222/197489008-28e2b69e-385c-46ad-9ed2-4b1d310e3431.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
・カスタム項目の日付項目におけるバリデーションの範囲。
・fieldmodelのdatatyeがdate型の時のデフォルト値に関する範囲。
・date型をユーザー設定に合わせる形に変更する箇所。（date型に'TODAY'を許容する時は要注意。ユーザーの設定が反映されない）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
バリデーションに関して
日付形式に関するバリデーション自体を変更すると影響範囲が広くなりすぎるため今回は、カスタム項目のデフォルト値の日付項目に関してのみ条件を付けてバリデーションを外す方針をとった。
その影響でデフォルト値にTODAYを設定した日付項目の編集画面を開くと３秒ほどエラーメッセージが表示されてしまう。
![image](https://user-images.githubusercontent.com/95267222/197492983-8674739d-5b52-4136-9d4f-afc6684147f6.png)
