### PR TITLE
#632 不必要なコメントが非表示になるように修正

### DIFF
--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -293,7 +293,13 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		}
 
 		if($module != 'PurchaseOrder' && $focus->object_name != 'Order') {
-			$product_Detail[$i]['qtyInStock'.$i]=decimalFormat($qtyinstock);
+			$checkpresenceresult = $adb->pquery("SELECT * FROM vtiger_field WHERE fieldname=? AND tabid=?",array("qtyinstock", Vtiger_Functions::getModuleId('Products')));
+			$presence = $adb->query_result($checkpresenceresult,0,'presence');
+			if(in_array($presence, array(0, 2))){
+				$product_Detail[$i]['qtyInStock'.$i]=decimalFormat($qtyinstock);
+			}else{
+				$product_Detail[$i]['qtyInStock'.$i]=false;
+			}
 		}
 		$listprice = number_format($listprice, $no_of_decimal_places,'.','');
 		$product_Detail[$i]['qty'.$i]=decimalFormat($qty);

--- a/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
@@ -151,7 +151,7 @@
 
 		{if $MODULE neq 'PurchaseOrder'}
 			<br>
-			<span class="stockAlert redColor {if $data.$qty <= $data.$qtyInStock|| not $data.$qtyInStock}hide{/if}" >
+			<span class="stockAlert redColor {if $data.$qty <= $data.$qtyInStock|| $data.$qtyInStock === false}hide{/if}" >
 				{vtranslate('LBL_STOCK_NOT_ENOUGH',$MODULE)}
 				<br>
 				{vtranslate('LBL_MAX_QTY_SELECT',$MODULE)}&nbsp;<span class="maxQuantity">{$data.$qtyInStock}</span>

--- a/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
@@ -151,7 +151,7 @@
 
 		{if $MODULE neq 'PurchaseOrder'}
 			<br>
-			<span class="stockAlert redColor {if $data.$qty <= $data.$qtyInStock}hide{/if}" >
+			<span class="stockAlert redColor {if $data.$qty <= $data.$qtyInStock|| not $data.$qtyInStock}hide{/if}" >
 				{vtranslate('LBL_STOCK_NOT_ENOUGH',$MODULE)}
 				<br>
 				{vtranslate('LBL_MAX_QTY_SELECT',$MODULE)}&nbsp;<span class="maxQuantity">{$data.$qtyInStock}</span>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #632 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 製品モジュールの「在庫数」項目を非表示にした時に、見積の編集画面に行くと「在庫が不足しています 最大値：0」の警告文が表示されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「在庫数」を非表示にしたとき$data.$qtyInStocknが空になるため、在庫数が数量を上回っていても$data.$qty <= $data.$qtyInStockがfalseになってしまう。
2. 1の条件を満たす場合、本来不必要であっても警告文が表示されてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.「 $data.$qtyInStocknが空の場合、警告文を出さない。」という条件を加えた。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
見積編集画面
![スクリーンショット (33)](https://user-images.githubusercontent.com/86254425/198975883-3dc99b1b-dd14-4cb5-981c-4ad21ab85d37.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
製品の数量、在庫に関係する範囲。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->