### PR TITLE
#679 活動に招待者がいる値の更新ワークフローが無限ループする不具合の修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -147,14 +147,22 @@ class Activity extends CRMEntity {
 			$selected_users_string =  $_REQUEST['inviteesid'];
 			$this->invitee_array = explode(';',$selected_users_string);
 			$smownerid = $this->column_fields['assigned_user_id'];
+			$request_assigned_user_id = $_REQUEST['assigned_user_id'];
 			if(!in_array($smownerid, $this->invitee_array)) {
 				$this->invitee_array[] = $smownerid;
+			}
+			if(!in_array($request_assigned_user_id, $this->invitee_array)){
+				$this->invitee_array[] = $request_assigned_user_id;
 			}
 		} else if(empty($this->invitee_array) && count($_REQUEST['selectedusers']) > 0){// 概要欄や関連からの遷移の場合
 			$this->invitee_array = $_REQUEST['selectedusers'];
 			$smownerid = $this->column_fields['assigned_user_id'];
+			$request_assigned_user_id = $_REQUEST['assigned_user_id'];
 			if(!in_array($smownerid, $this->invitee_array)) {
 				$this->invitee_array[] = $smownerid;
+			}
+			if(!in_array($request_assigned_user_id, $this->invitee_array)){
+				$this->invitee_array[] = $request_assigned_user_id;
 			}
 		} else {// リクエストに入っていない場合はDBから取得を試みる
 			$this->loadInvitees();
@@ -439,12 +447,20 @@ function insertIntoRecurringTable(& $recurObj)
 	function insertIntoInviteeTable($module,$invitees_array)
 	{
 		global $log,$adb;
+		global $activityarray, $global_workflow_skip_field_array;// $activityarray：ワークフロー実行済みの活動IDを格納。$global_workflow_skip_field_array：ワークフローで更新済みのフィールド名を格納。
 		$log->debug("Entering insertIntoInviteeTable(".$module.",".$invitees_array.") method ...");
 
+		// 一度更新された招待活動の場合は、処理を行わない。
 		if($this->is_not_invitees_update) {
 			return ;
 		}
 
+		// 招待活動でない場合は、処理を行わない。
+		if(empty($this->invitee_parentid)) {
+			return ;
+		}
+
+		// 編集の場合
 		if($this->mode == 'edit'){
 			// 参加者のActivityを更新または削除
 			$result = $adb->pquery("SELECT
@@ -462,37 +478,67 @@ function insertIntoRecurringTable(& $recurObj)
 				$activityid = $adb->query_result($result, $i, "activityid");
 				$smownerid = $adb->query_result($result, $i, "smownerid");
 
+				// ワークフローで更新した項目を取得しておく。
+				if(is_array($global_workflow_skip_field_array[$activityid])){
+					$global_workflow_skip_field_array[$activityid] = array_unique(array_merge($global_workflow_skip_field_array[$activityid], $this->workflow_skip_field_array));
+				}else{
+					$global_workflow_skip_field_array[$activityid] = $this->workflow_skip_field_array;
+				}
+
+				// 自身の活動既に保存済みのため、処理は行わない。
 				if($activityid == $this->id) {
 					continue;
 				}
 
 				$inviteRecord = Vtiger_Record_Model::getInstanceById($activityid);
 				if(in_array($smownerid, $invitees_array)) {
-					foreach($this->column_fields as $field => $value) {
-						if(in_array($field, $this->notCopyFields)) {
-							continue;
-						}
-						$inviteRecord->set($field, $value);
-					}
 					$inviteRecord->set('invitee_parentid', $this->invitee_parentid);
 					$inviteRecord->set('invitees_array', $invitees_array);
 					$inviteRecord->set('is_not_invitees_update', true);
 					$inviteRecord->set('mode', 'edit');
 					$inviteRecord->set('is_allday', $this->is_allday);
-					$inviteRecord->save();
+					$inviteRecord->set('workflow_task_id', $this->workflow_task_id);
+					$inviteRecord->set('workflow_skip_field_array', $this->workflow_skip_field_array);
+					if($this->workflow_task_id && in_array($inviteRecord->getId(), $activityarray[$this->workflow_task_id])){
+						// 実行済みのワークフローによる更新の場合、イベントを発火させない為にsaveentity関数を使用する。
+						$inviteRecord->getEntity()->invitee_parentid = $this->invitee_parentid;
+						$inviteRecord->getEntity()->invitees_array = $invitees_array;
+						$inviteRecord->getEntity()->is_not_invitees_update = true;
+						$inviteRecord->getEntity()->is_allday = $this->is_allday;
+						$inviteRecord->getEntity()->mode = "edit";
+						$inviteRecord->getEntity()->workflow_task_id = $this->workflow_task_id;
+						$inviteRecord->getEntity()->workflow_skip_field_array = $this->workflow_skip_field_array;
+						$inviteRecord->getEntity()->saveentity($module, $inviteRecord->getId());
+					}else{
+						foreach($this->column_fields as $field => $value) {
+							// フィールドの更新ワークフローで既に更新している項目は、招待元からコピーしないようにする。
+							if(in_array($field, $this->notCopyFields) || in_array($field, $global_workflow_skip_field_array[$activityid])) {
+								continue;
+							}
+							$inviteRecord->set($field, $value);
+						}
+						// ワークフロー毎に、実行済みのcrmidを取得しておく。
+						if($this->workflow_task_id) {
+							$activityarray[$this->workflow_task_id][] = $inviteRecord->getId();
+						}
+						$log->debug("activityarray this->workflow_task_id ->>".$this->workflow_task_id);
+						$log->debug("[".__FUNCTION__."]line:".__LINE__.":activityarray:".str_replace(array("\n", "  "), array('',''), print_r($activityarray, true)));
+						$inviteRecord->save();
+					}
 				} else {
 					$inviteRecord->getModule()->deleteRecord($inviteRecord);
 					$adb->pquery("DELETE FROM vtiger_invitees WHERE activityid = ? AND inviteeid = ?", array($this->invitee_parentid, $inviteRecord->get('assigned_user_id')));
 				}
 			}
 		}
+		// 新規作成の場合
 		foreach($invitees_array as $inviteeid)
 		{
 			if(empty($inviteeid)) {
 				continue;
 			}
-
 			$result = $adb->pquery("SELECT 1 FROM vtiger_invitees WHERE activityid = ? AND inviteeid = ?", array($this->invitee_parentid, $inviteeid));
+			// 招待活動が存在しない場合は、作成する。
 			if($adb->num_rows($result) == 0) {
 				$query="INSERT INTO vtiger_invitees VALUES (?,?,?)";
 				$adb->pquery($query, array($this->invitee_parentid, $inviteeid, 'sent'));
@@ -506,7 +552,20 @@ function insertIntoRecurringTable(& $recurObj)
 				$inviteRecord->set('assigned_user_id', $inviteeid);
 				$inviteRecord->set('is_not_invitees_update', true);
 				$inviteRecord->set('is_allday', $this->is_allday);
+				$inviteRecord->set('workflow_task_id', $this->workflow_task_id);
+				$inviteRecord->set('workflow_skip_field_array', $this->workflow_skip_field_array);
 				$inviteRecord->save();
+				// ワークフロー毎に、実行済みのcrmidを取得しておく。
+				if($this->workflow_task_id) {
+					$activityarray[$this->workflow_task_id][] = $inviteRecord->getId();
+				}
+				// ワークフローで更新した項目を取得しておく。
+				if(is_array($global_workflow_skip_field_array[$inviteRecord->getId()])){
+					$global_workflow_skip_field_array[$inviteRecord->getId()] = array_unique(array_merge($global_workflow_skip_field_array[$inviteRecord->getId()], $this->workflow_skip_field_array));
+				}else{
+					$global_workflow_skip_field_array[$inviteRecord->getId()] = $this->workflow_skip_field_array;
+				}
+				$log->debug("[".__FUNCTION__."]line:".__LINE__.":activityarray:".str_replace(array("\n", "  "), array('',''), print_r($activityarray, true)));
 			}
 		}
 		$log->debug("Exiting insertIntoInviteeTable method ...");
@@ -522,10 +581,10 @@ function insertIntoRecurringTable(& $recurObj)
 	{
 			global $adb;
 			global $current_user;
-			if($this->mode == 'edit'){
+			// if($this->mode == 'edit'){
 				$sql = "delete from vtiger_salesmanactivityrel where activityid=?";
 				$adb->pquery($sql, array($this->id));
-			}
+			// }
 
 		$user_sql = $adb->pquery("select count(*) as count from vtiger_users where id=?", array($this->column_fields['assigned_user_id']));
 		if($adb->query_result($user_sql, 0, 'count') != 0) {

--- a/modules/com_vtiger_workflow/VTWorkflowManager.inc
+++ b/modules/com_vtiger_workflow/VTWorkflowManager.inc
@@ -423,6 +423,7 @@ class Workflow{
 				}
 				if($task->executeImmediately==true){
 					try {
+						global $log;$log->debug("[".__FUNCTION__."]line:".__LINE__."workflow_id:".$this->id."/workflow_taskid:".$task->id);
 						$task->doTask($entityData);
 					}
 					catch(Exception $e) {

--- a/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
+++ b/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
@@ -60,8 +60,14 @@ class VTUpdateFieldsTask extends VTTask {
 			$entityFields = $referenceEntityFields = false;
 			$focus->column_fields->resumeTracking();
 
-			foreach ($fieldValueMapping as $fieldInfo) {
+			$workflow_skip_field_array = array();
+
+			foreach ($fieldValueMapping as $fieldInfoKey => $fieldInfo) {
 				$fieldName = $fieldInfo['fieldname'];
+
+				// ワークフローで更新する項目名を取得しておく。
+				$workflow_skip_field_array[] = $fieldName;
+
 				$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
 				if ($moduleModel && in_array($fieldName, $moduleModel->getNameFields())) {
 					$entityFields = true;
@@ -321,7 +327,32 @@ class VTUpdateFieldsTask extends VTTask {
 			$changedFields = $focus->column_fields->getChanged();
 			if(count($changedFields) > 0){
 				// save only if any field is changed
-				$focus->saveentity($moduleName);
+				global $log;$log->debug("[".__FUNCTION__."]line:".__LINE__.":workflow_taskid:".$this->id);
+				if (strpos($fieldInfo['value'], 'aggregate') !== false) {
+					global $VTIGER_BULK_SAVE_MODE;
+					$VTIGER_BULK_SAVE_MODE = true;
+					RelationFieldHandler::$forceOnceAllowCrmId = $focus->id;
+					$focus->workflow_task_id = $this->id;
+					$focus->workflow_skip_field_array = $workflow_skip_field_array;
+					$focus->saveentity($moduleName);
+					$VTIGER_BULK_SAVE_MODE = false;
+				}else{
+					RelationFieldHandler::$forceOnceAllowCrmId = $focus->id;
+					$focus->workflow_task_id = $this->id;
+					$focus->saveentity($moduleName);
+				}
+
+				// ワークフローで更新された項目を参照している項目に反映させる
+				$tmpEntity = VTEntityData::fromCRMEntity($focus);
+
+				$vtEntityDelta = new VTEntityDelta();
+				$vtEntityDelta->setNewEntity($moduleName, $tmpEntity->getId(), $tmpEntity);
+				$vtEntityDelta->computeDelta($moduleName, $tmpEntity->getId());
+
+				$relHandler = new RelationFieldHandler();
+				$relHandler->isWorkFlowFieldUpdate = true;
+				$relHandler->updateFromParent($tmpEntity);
+				$relHandler->updateToChildren($tmpEntity);
 			}
 			if ($entityFields == true) {
 				Vtiger_Functions::updateCRMRecordLabel($moduleName, $focus->id);
@@ -335,7 +366,26 @@ class VTUpdateFieldsTask extends VTTask {
 						}
 						$referenceFocus->isLineItemUpdate = false;
 						$referenceFocus->isWorkFlowFieldUpdate = true;
-						$referenceFocus->saveentity($referenceFocus->moduleName);
+						$referenceFocus->workflow_task_id = $this->id;
+						$referenceFocus->workflow_skip_field_array = $workflow_skip_field_array;
+						if (strpos($fieldInfo['value'], 'aggregate') !== false) {
+							global $VTIGER_BULK_SAVE_MODE;
+							$VTIGER_BULK_SAVE_MODE = true;
+							$referenceFocus->saveentity($referenceFocus->moduleName);
+							$VTIGER_BULK_SAVE_MODE = false;
+						}else{
+							$referenceFocus->saveentity($referenceFocus->moduleName);
+						}
+						// ワークフローで更新された項目を参照している項目に反映させる
+						$tmpEntity = VTEntityData::fromCRMEntity($referenceFocus->id);
+						$vtEntityDelta->setEntityDelta($moduleName, $tmpEntity->getId(), $delta);
+						$vtEntityDelta->setNewEntity($moduleName, $tmpEntity->getId(), $tmpEntity);
+		
+						$relHandler = new RelationFieldHandler();
+						$relHandler->isWorkFlowFieldUpdate = true;
+						$relHandler->updateFromParent($tmpEntity);
+						$relHandler->updateToChildren($tmpEntity);
+
 						if ($referenceEntityFields == true) {
 							Vtiger_Functions::updateCRMRecordLabel($referenceFocus->moduleName, $referenceFocus->id);
 						}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #679

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローが項目を更新することで無限ループする

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動の場合は招待ユーザーが親のレコードを更新するため、値の更新を行うワークフローで無限ループが発生していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ワークフローの処理にて、タスクIDごと、CRMIDごとに1回のみ値を更新するように修正を入れた

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->