### PR TITLE
#658 ワークフローの誕生日の「範囲」を入力ができるように修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
@@ -295,9 +295,18 @@ Vtiger_Date_Field_Js('Workflows_Date_Field_Js',{},{
         var comparatorSelectedOptionVal = this.get('comparatorElementVal');
         var dateSpecificConditions = this.get('dateSpecificConditions');
         if(comparatorSelectedOptionVal.length > 0) {
-            if(comparatorSelectedOptionVal == 'between' || comparatorSelectedOptionVal == 'custom'){
+            if(comparatorSelectedOptionVal == 'custom'){
                 var html = '<div class="date"><input class="dateField inputElement" style="width:auto;" data-calendar-type="range" name="'+ this.getName() +'" data-date-format="'+ this.getDateFormat() +'" type="text" ReadOnly="true" value="'+  this.getValue() + '"></div>';
                 var element = jQuery(html);
+                return this.addValidationToElement(element);
+            } else if(comparatorSelectedOptionVal == 'between'){
+                var html = '<div class="date"><input class="dateField inputElement" style="width:auto;" data-calendar-type="range" name="'+ this.getName() +'" data-date-format="'+ this.getDateFormat() +'" type="text"  value="'+  this.getValue() + '"></div>';
+                var element = jQuery(html);
+                $(function(){
+                    $(element).keydown(function(event){
+                      return false;
+                    });
+                });
                 return this.addValidationToElement(element);
             } else if(this._specialDateComparator(comparatorSelectedOptionVal)) {
                 var html = '<input name="'+ this.getName() +'" type="text" value="'+this.getValue()+'" data-validation-engine="validate[funcCall[Vtiger_Base_Validator_Js.invokeValidation]]" data-validator="[{"name":"PositiveNumber"}]">\n\


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #658 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローの誕生日の「範囲」の機能していなかった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 入力欄のreadonly属性がtrueになっており、valueの値を持つことができていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. readonly属性をなくした。
2. キーボードからの入力ができないようにkeydownイベントが発生したらキャッチするようにした。(全角入力の時はキャッチすることができないため入力ができてしまう。)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/200209087-36c8a433-5588-4465-9919-6fc6607d218b.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフローの範囲が設定できる個所では入力ができないようになっている。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
入力が全角で行われたときは入力できてしまう。