### PR TITLE
#673 リストの検索条件の形式が誤っていると、リストが見れなくなる不具合を修正。

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1388,7 +1388,7 @@ Vtiger.Class("Vtiger_List_Js", {
             element.trigger('change');
             listSearchContributorChangeHandler(e);
         });
-		listViewPageDiv.on('keydown','.row-fluid', function(e){
+		listViewPageDiv.on('keydown','.dateField', function(e){
 			return false;
 		});
 	},

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1388,8 +1388,11 @@ Vtiger.Class("Vtiger_List_Js", {
             element.trigger('change');
             listSearchContributorChangeHandler(e);
         });
-    },
-    
+		listViewPageDiv.on('keydown','.row-fluid', function(e){
+			return false;
+		});
+	},
+
 	saveMassEdit: function (event, form_original_data, isOwnerChanged) {
 		event.preventDefault();
 		var form = $('#massEdit');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #673 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストのソート条件に誤った形式を入力すると、リストが見えなくなってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. date型の項目で自由にキーボード入力することが可能であったため、date型でない入力がされたときにエラーが出ていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.datepickerを使用している項目では、キーボード入力を無効にした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (38)](https://user-images.githubusercontent.com/86254425/200261702-9667e042-520d-4b66-b51d-960018575ea5.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リスト内での検索

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
