### PR TITLE
refs #369 タグの所有者をわかるように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/DetailViewTagList.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewTagList.tpl
@@ -57,6 +57,11 @@
 {assign var=TAG_MODEL value=Vtiger_Tag_Model::getCleanInstance()}
 {include file="Tag.tpl"|vtemplate_path:$MODULE}
 </div>
+
+
+
+
+
 <div>
     <div  class="editTagContainer hide" >
         <input type="hidden" name="id" value="" />
@@ -71,6 +76,10 @@
                         <input type="checkbox" name="visibility" value="{Vtiger_Tag_Model::PUBLIC_TYPE}" />
                         &nbsp; {vtranslate('LBL_SHARE_TAG',$MODULE)}
                     </label>
+                </div>
+                <div class="tag_owner_name">
+                    <p>作成者：</p>
+                    <p type="text" class="tagOwnerName" value="" style="width:100%" maxlength="25"></p>
                 </div>
             </div>
         </div>

--- a/layouts/v7/modules/Vtiger/Tag.tpl
+++ b/layouts/v7/modules/Vtiger/Tag.tpl
@@ -10,6 +10,7 @@
  <span class="tag {if $ACTIVE eq true} active {/if}" title="{$TAG_MODEL->getName()}" data-type="{$TAG_MODEL->getType()}" data-id="{$TAG_MODEL->getId()}">
     <i class="activeToggleIcon fa {if $ACTIVE eq true} fa-circle-o {else} fa-circle {/if}"></i>
     <span class="tagLabel display-inline-block textOverflowEllipsis" title="{$TAG_MODEL->getName()}">{$TAG_MODEL->getName()}</span>
+    <input type="hidden" class="tagOwner" value="{getOwnerName($TAG_MODEL->get('owner'))}">
     {if !$NO_EDIT}
         <i class="editTag fa fa-pencil"></i>
     {/if}

--- a/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
@@ -138,11 +138,12 @@
             <div class="menu-scroller scrollContainer" style="position:relative; top:0; left:0;">
                 <div class="list-menu-content">
                     <div id="listViewTagContainer" class="multiLevelTagList" 
-                    {if $ALL_CUSTOMVIEW_MODEL} data-view-id="{$ALL_CUSTOMVIEW_MODEL->getId()}" {/if}
-                    data-list-tag-count="{Vtiger_Tag_Model::NUM_OF_TAGS_LIST}">
+                        {if $ALL_CUSTOMVIEW_MODEL} data-view-id="{$ALL_CUSTOMVIEW_MODEL->getId()}" {/if}
+                        data-list-tag-count="{Vtiger_Tag_Model::NUM_OF_TAGS_LIST}">
                         {foreach item=TAG_MODEL from=$TAGS name=tagCounter}
                             {assign var=TAG_LABEL value=$TAG_MODEL->getName()}
                             {assign var=TAG_ID value=$TAG_MODEL->getId()}
+                            {assign var=TAG_OWNER value=$TAG_MODEL->get('owner')}
                             {if $smarty.foreach.tagCounter.iteration gt Vtiger_Tag_Model::NUM_OF_TAGS_LIST}
                                 {break}
                             {/if}
@@ -154,13 +155,13 @@
                                 &nbsp;{vtranslate('LBL_MORE',$MODULE)|strtolower}
                             </a>
                             <div class="moreListTags hide">
-                        {foreach item=TAG_MODEL from=$TAGS name=tagCounter}
-                            {if $smarty.foreach.tagCounter.iteration le Vtiger_Tag_Model::NUM_OF_TAGS_LIST}
-                                {continue}
-                            {/if}
-                            {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE= $CURRENT_TAG eq $TAG_ID}
-                        {/foreach}
-                             </div>
+                                {foreach item=TAG_MODEL from=$TAGS name=tagCounter}
+                                    {if $smarty.foreach.tagCounter.iteration le Vtiger_Tag_Model::NUM_OF_TAGS_LIST}
+                                        {continue}
+                                    {/if}
+                                    {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE= $CURRENT_TAG eq $TAG_ID}
+                                {/foreach}
+                            </div>
                         </div>
                     </div>
                     {include file="AddTagUI.tpl"|vtemplate_path:$MODULE RECORD_NAME="" TAGS_LIST=array()}
@@ -183,6 +184,10 @@
                                         <input type="checkbox" name="visibility" value="{Vtiger_Tag_Model::PUBLIC_TYPE}" />
                                         &nbsp; {vtranslate('LBL_SHARE_TAG',$MODULE)}
                                     </label>
+                                    <div class="tag_owner_name">
+                                        <p>作成者：</p>
+                                        <p type="text" class="tagOwnerName" value="" style="width:100%" maxlength="25"></p>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/layouts/v7/modules/Vtiger/resources/Tag.js
+++ b/layouts/v7/modules/Vtiger/resources/Tag.js
@@ -259,6 +259,7 @@ Vtiger.Class("Vtiger_Tag_Js",{},{
             var editTagContainer = self.editTagContainerCached.clone();
             editTagContainer.find('[name="id"]').val(tag.data('id'));
             editTagContainer.find('[name="tagName"]').val(tag.find('.tagLabel').text());
+            editTagContainer.find(".tagOwnerName").text(tag.find('.tagOwner').val());
             if(tag.attr('data-type') == "public") {
                 editTagContainer.find('[type="checkbox"]').prop('checked',true);
             }else{

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -632,3 +632,7 @@ ul#productsImageContainer > li a{
   padding-right: 15px; 
   padding-left: 15px; 
 }
+
+.tag_owner_name p{
+  display: inline;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #369 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. タグのポップアップで出てくる編集画面に作成者の表示がないため、作成者の名前を表示してほしい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 作成者を表示する機能がなかったため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. タグに紐づいているowner情報を作成者として表示した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/112600172/201464926-13caa266-1a7c-4c7a-9731-7ddf45a7581e.png)
![image](https://user-images.githubusercontent.com/112600172/201464946-566350c4-12d3-4971-ac9b-1ef1d2884950.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
タグの一覧が表示されるモジュールすべて

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->