### PR TITLE
refs #629 初期設定でメールの「クリック数」のカウントをオン

### DIFF
--- a/config.template.php
+++ b/config.template.php
@@ -185,8 +185,8 @@ $default_layout = 'v7';
 // スケジュールワークフローの設定最大数
 $max_scheduled_workflows = 50;
 
-include_once 'config.security.php';
-
 // メールの「クリック数」のカウント
 $email_tracking = 'Yes';
+
+include_once 'config.security.php';
 ?>

--- a/config.template.php
+++ b/config.template.php
@@ -186,4 +186,7 @@ $default_layout = 'v7';
 $max_scheduled_workflows = 50;
 
 include_once 'config.security.php';
+
+// メールの「クリック数」のカウント
+$email_tracking = 'Yes';
 ?>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #629 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 初回インストール時にメールの「クリック数カウント」がオフになっているので、初回インストール時オンに修正

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 初回インストール時にメールの「クリック数カウント」がオフになっている

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. config.template.phpに初期インストール時オンを追加

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
config.inc.php

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->