### PR TITLE
refs #691 レポート作成・編集画面での翻訳漏れ修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -181,7 +181,7 @@ $languageStrings = array(
 	//DropDown Category
 	'LBL_USERS' => 'ユーザー',
 	'LBL_GROUPS' => 'グループ',
-	'LBL_ROLEANDSUBORDINATES' => 'ユーザーとその下位',
+	'LBL_ROLEANDSUBORDINATES' => '役割と部下',
 
 	//EditView Form Links
 	'LBL_FULL_FORM' => '詳細フォーム',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -181,6 +181,7 @@ $languageStrings = array(
 	//DropDown Category
 	'LBL_USERS' => 'ユーザー',
 	'LBL_GROUPS' => 'グループ',
+	'LBL_ROLEANDSUBORDINATES' => 'ユーザーとその下位',
 
 	//EditView Form Links
 	'LBL_FULL_FORM' => '詳細フォーム',
@@ -1336,6 +1337,7 @@ $languageStrings = array(
 	'LBL_ROLES' => '役割',
 	'Roles' => '役割',
 	'LBL_ROLEANDSUBORDINATE' => '役割と部下',
+	'RoleAndSubordinates' => '役割と部下',
 	'LBL_YOUR_LEARNING_SCORE' => 'CRM学習スコア',
 	'LBL_SWITCH_TO_VTIGER7_NOW' => '2月15日までにVtiger7に切り替え',
 	'LBL_VTIGER6_RETIREMENT_NOTICE' => 'このバージョンは2016年2月15日に廃止されます',

--- a/layouts/v7/modules/Reports/Step1.tpl
+++ b/layouts/v7/modules/Reports/Step1.tpl
@@ -111,7 +111,7 @@
                                     </option>
                             </optgroup>
                             {foreach from=$MEMBER_GROUPS key=GROUP_LABEL item=ALL_GROUP_MEMBERS}
-                                <optgroup label="{$GROUP_LABEL}">
+                                <optgroup label="{vtranslate($GROUP_LABEL)}">
                                     {foreach from=$ALL_GROUP_MEMBERS item=MEMBER}
                                         {if $GROUP_LABEL neq 'Users' || $MEMBER->getId() neq 'Users:'|cat:$CURRENT_USER->getId()}
                                             <option value="{$MEMBER->getId()}"  data-member-type="{$GROUP_LABEL}" {if isset($SELECTED_MEMBERS_GROUP[$GROUP_LABEL][$MEMBER->getId()])}selected="true"{/if}>{$MEMBER->getName()}</option>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #691 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポート作成・編集画面でUser、Role、RoleAndSubordinatesに翻訳が当たっていないバグの修正

##  原因 / Cause
<!-- バグの原因を記述 -->
1. User、Roleはvtransrateが当たっていなかった。
2. RoleAndSubordinatesについてはlanguagesファイルから項目が洩れていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtransrate関数を追加
2. languagesファイルにRoleAndSubordinates項目を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/112600172/201472806-0ba047be-ee95-40e3-9116-753a0ecddf9f.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポート編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->