### PR TITLE
#678 ドキュメントのクイック作成の非表示項目を表示しないようにする

### DIFF
--- a/layouts/v7/modules/Documents/CreateDocument.tpl
+++ b/layouts/v7/modules/Documents/CreateDocument.tpl
@@ -116,68 +116,72 @@
 								{assign var=HARDCODED_FIELDS value=','|explode:"filename,assigned_user_id,folderid,notecontent,notes_title"}
 								{assign var=COUNTER value=0}
 								{foreach key=FIELD_NAME item=FIELD_MODEL from=$FIELD_MODELS}
-									{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
-										{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
-										{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
-										{assign var="referenceListCount" value=count($referenceList)}
-										{if $FIELD_MODEL->get('uitype') eq "19"}
-											{if $COUNTER eq '1'}
-												<td></td><td></td></tr><tr>
-												{assign var=COUNTER value=0}
-											{/if}
-										{/if}
-										{if $COUNTER eq 2}
-										</tr><tr>
-											{assign var=COUNTER value=1}
-										{else}
-											{assign var=COUNTER value=$COUNTER+1}
-										{/if}
-										<td class='fieldLabel col-lg-2'>
-											{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
-												{if $isReferenceField eq "reference"}
-													{if $referenceListCount > 1}
-														{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
-														{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
-														{if !empty($REFERENCED_MODULE_STRUCT)}
-															{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
-														{/if}
-														<span class="pull-right">
-															<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
-																{foreach key=index item=value from=$referenceList}
-																	<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
-																{/foreach}
-															</select>
-														</span>
-													{else}
-														<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
+									{foreach key=STRUCTURE_NAME item=STRUCTURE_MODEL from=$RECORD_STRUCTURE}
+										{if $FIELD_NAME eq $STRUCTURE_NAME}
+											{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
+												{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
+												{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
+												{assign var="referenceListCount" value=count($referenceList)}
+												{if $FIELD_MODEL->get('uitype') eq "19"}
+													{if $COUNTER eq '1'}
+														<td></td><td></td></tr><tr>
+														{assign var=COUNTER value=0}
 													{/if}
-												{else if $FIELD_MODEL->get('uitype') eq '83'}
-													{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
-													{if $TAXCLASS_DETAILS}
-														{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
-														{if $taxCount eq 0}
-															{if $COUNTER eq 2}
-																{assign var=COUNTER value=1}
-															{else}
-																{assign var=COUNTER value=2}
-															{/if}
-														{/if}
-													{/if}
-												{else}
-													{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
 												{/if}
-												{if $isReferenceField neq "reference"}</label>{/if}
-										</td>
-										{if $FIELD_MODEL->get('uitype') neq '83'}
-											<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
-											{if $FILE_LOCATION_TYPE neq 'W'}
-												{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) type = "E"}
-											{else}
-												{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+												{if $COUNTER eq 2}
+												</tr><tr>
+													{assign var=COUNTER value=1}
+												{else}
+													{assign var=COUNTER value=$COUNTER+1}
+												{/if}
+												<td class='fieldLabel col-lg-2'>
+													{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
+														{if $isReferenceField eq "reference"}
+															{if $referenceListCount > 1}
+																{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
+																{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
+																{if !empty($REFERENCED_MODULE_STRUCT)}
+																	{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
+																{/if}
+																<span class="pull-right">
+																	<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
+																		{foreach key=index item=value from=$referenceList}
+																			<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
+																		{/foreach}
+																	</select>
+																</span>
+															{else}
+																<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
+															{/if}
+														{else if $FIELD_MODEL->get('uitype') eq '83'}
+															{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
+															{if $TAXCLASS_DETAILS}
+																{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
+																{if $taxCount eq 0}
+																	{if $COUNTER eq 2}
+																		{assign var=COUNTER value=1}
+																	{else}
+																		{assign var=COUNTER value=2}
+																	{/if}
+																{/if}
+															{/if}
+														{else}
+															{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
+														{/if}
+														{if $isReferenceField neq "reference"}</label>{/if}
+												</td>
+												{if $FIELD_MODEL->get('uitype') neq '83'}
+													<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
+													{if $FILE_LOCATION_TYPE neq 'W'}
+														{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) type = "E"}
+													{else}
+														{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+													{/if}
+													</td>
+												{/if}
 											{/if}
-											</td>
 										{/if}
-									{/if}
+									{/foreach}
 								{/foreach}
 							</tr>
 						</table>

--- a/layouts/v7/modules/Documents/UploadDocument.tpl
+++ b/layouts/v7/modules/Documents/UploadDocument.tpl
@@ -118,64 +118,68 @@
 										{assign var=HARDCODED_FIELDS value=','|explode:"filename,assigned_user_id,folderid,notecontent,notes_title"}
 										{assign var=COUNTER value=0}
 										{foreach key=FIELD_NAME item=FIELD_MODEL from=$FIELD_MODELS} 
-											{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
-												{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
-												{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
-												{assign var="referenceListCount" value=count($referenceList)}
-												{if $FIELD_MODEL->get('uitype') eq "19"}
-													{if $COUNTER eq '1'}
-														<td></td><td></td></tr><tr>
-														{assign var=COUNTER value=0}
+											{foreach key=STRUCTURE_NAME item=STRUCTURE_MODEL from=$RECORD_STRUCTURE}
+												{if $FIELD_NAME eq $STRUCTURE_NAME}
+													{if !in_array($FIELD_NAME,$HARDCODED_FIELDS) && $FIELD_MODEL->isQuickCreateEnabled()}
+														{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
+														{assign var="referenceList" value=$FIELD_MODEL->getReferenceList()}
+														{assign var="referenceListCount" value=count($referenceList)}
+														{if $FIELD_MODEL->get('uitype') eq "19"}
+															{if $COUNTER eq '1'}
+																<td></td><td></td></tr><tr>
+																{assign var=COUNTER value=0}
+															{/if}
+														{/if}
+														{if $COUNTER eq 2}
+														</tr><tr>
+															{assign var=COUNTER value=1}
+														{else}
+															{assign var=COUNTER value=$COUNTER+1}
+														{/if}
+														<td class='fieldLabel col-lg-2'>
+															{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
+																{if $isReferenceField eq "reference"}
+																	{if $referenceListCount > 1}
+																		{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
+																		{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
+																		{if !empty($REFERENCED_MODULE_STRUCT)}
+																			{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
+																		{/if}
+																		<span class="pull-right">
+																			<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
+																				{foreach key=index item=value from=$referenceList}
+																					<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
+																				{/foreach}
+																			</select>
+																		</span>
+																	{else}
+																		<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
+																	{/if}
+																{else if $FIELD_MODEL->get('uitype') eq '83'}
+																	{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
+																	{if $TAXCLASS_DETAILS}
+																		{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
+																		{if $taxCount eq 0}
+																			{if $COUNTER eq 2}
+																				{assign var=COUNTER value=1}
+																			{else}
+																				{assign var=COUNTER value=2}
+																			{/if}
+																		{/if}
+																	{/if}
+																{else}
+																	{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
+																{/if}
+																{if $isReferenceField neq "reference"}</label>{/if}
+														</td>
+														{if $FIELD_MODEL->get('uitype') neq '83'}
+															<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
+																{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+															</td>
+														{/if}
 													{/if}
 												{/if}
-												{if $COUNTER eq 2}
-												</tr><tr>
-													{assign var=COUNTER value=1}
-												{else}
-													{assign var=COUNTER value=$COUNTER+1}
-												{/if}
-												<td class='fieldLabel col-lg-2'>
-													{if $isReferenceField neq "reference"}<label class="muted pull-right">{/if}
-														{if $isReferenceField eq "reference"}
-															{if $referenceListCount > 1}
-																{assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
-																{assign var="REFERENCED_MODULE_STRUCT" value=$FIELD_MODEL->getUITypeModel()->getReferenceModule($DISPLAYID)}
-																{if !empty($REFERENCED_MODULE_STRUCT)}
-																	{assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
-																{/if}
-																<span class="pull-right">
-																	<select style="width:150px;" class="select2 referenceModulesList {if $FIELD_MODEL->isMandatory() eq true}reference-mandatory{/if}">
-																		{foreach key=index item=value from=$referenceList}
-																			<option value="{$value}" {if $value eq $REFERENCED_MODULE_NAME} selected {/if} >{vtranslate($value, $value)}</option>
-																		{/foreach}
-																	</select>
-																</span>
-															{else}
-																<label class="muted pull-right">{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}</label>
-															{/if}
-														{else if $FIELD_MODEL->get('uitype') eq '83'}
-															{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE) COUNTER=$COUNTER MODULE=$MODULE}
-															{if $TAXCLASS_DETAILS}
-																{assign 'taxCount' count($TAXCLASS_DETAILS)%2}
-																{if $taxCount eq 0}
-																	{if $COUNTER eq 2}
-																		{assign var=COUNTER value=1}
-																	{else}
-																		{assign var=COUNTER value=2}
-																	{/if}
-																{/if}
-															{/if}
-														{else}
-															{vtranslate($FIELD_MODEL->get('label'), $MODULE)}&nbsp;{if $FIELD_MODEL->isMandatory() eq true} <span class="redColor">*</span> {/if}
-														{/if}
-														{if $isReferenceField neq "reference"}</label>{/if}
-												</td>
-												{if $FIELD_MODEL->get('uitype') neq '83'}
-													<td class="fieldValue col-lg-4" {if $FIELD_MODEL->get('uitype') eq '19'} colspan="3" {assign var=COUNTER value=$COUNTER+1} {/if}>
-														{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
-													</td>
-												{/if}
-											{/if}
+											{{/foreach}}
 										{/foreach}
 									</tr>
 								</table>

--- a/modules/Documents/views/QuickCreateAjax.php
+++ b/modules/Documents/views/QuickCreateAjax.php
@@ -73,6 +73,7 @@ class Documents_QuickCreateAjax_View extends Vtiger_IndexAjax_View {
 		$viewer->assign('QUICK_CREATE_CONTENTS', $quickCreateContents);
 		$viewer->assign('USER_MODEL', Users_Record_Model::getCurrentUserModel());
 		$viewer->assign('FIELDS_INFO', json_encode($fieldsInfo));
+		$viewer->assign('RECORD_STRUCTURE', $recordStructure);
 		$viewer->assign('FIELD_MODELS', $fieldList);
 		$viewer->assign('FILE_LOCATION_TYPE', $request->get('type'));
 		$viewer->assign('SCRIPTS', $this->getHeaderScripts($request));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #678 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ドキュメントのカスタム項目においてクイック作成をオンにしていると、非表示にしてもクイック作成に表示されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 表示させる項目においてクイック作成についての情報しか参照していなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. fieldlistの項目がRecordStructureに存在するかの条件分岐を入れた。
　存在しなかった場合は表示しないように設定。
　（RecordStructureには非表示の項目は存在しないため、非表示かつクイック作成がオンの項目のみ表示するようになっている。）
## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

> 修正前
![image](https://user-images.githubusercontent.com/95267222/201579988-0c41e25c-ed27-4abe-a882-7ff8cf606139.png)
> 修正後
![image](https://user-images.githubusercontent.com/95267222/201579539-0831f781-48bc-45aa-8c57-966612f1480b.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->