### PR TITLE
#706 顧客企業⇒案件⇒活動と紐づいた活動を顧客企業の画面から削除できるように修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -1093,6 +1093,8 @@ function insertIntoRecurringTable(& $recurObj)
 			$this->db->pquery($sql, array($return_id, $id));
 			$sql = 'DELETE FROM vtiger_cntactivityrel WHERE activityid = ? AND contactid IN	(SELECT contactid from vtiger_contactdetails where accountid=?)';
 			$this->db->pquery($sql, array($id, $return_id));
+			$sql = 'DELETE FROM vtiger_seactivityrel WHERE activityid = ? AND crmid IN	(SELECT relcrmid from vtiger_crmentityrel where crmid=?)';
+			$this->db->pquery($sql, array($id, $return_id));
 		} else {
 			$sql='DELETE FROM vtiger_seactivityrel WHERE activityid=?';
 			$this->db->pquery($sql, array($id));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #706

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 顧客企業⇒案件⇒活動と紐づいた活動の場合、顧客企業の画面から関連を解除することができない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 顧客担当者のvtiger_cntactivityrelや直接vtiger_seactivityrelに関連がある場合は削除されていた一方で、間接的に紐づいている案件の活動は関連を解除するクエリが存在しなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 顧客企業⇒案件⇒活動のひも付きを解除するクエリを追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
顧客企業、案件、活動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- **正常に削除できるように修正しましたが、関連の関連は削除できないようにする修正のほうが適切かもしれません**