### PR TITLE
#644 ワークフローで定期的に実行が選択できない不具合を修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/WorkFlowTrigger.tpl
+++ b/layouts/v7/modules/Settings/Workflows/WorkFlowTrigger.tpl
@@ -20,8 +20,8 @@
             {assign var=SINGLE_SELECTED_MODULE value="SINGLE_$SELECTED_MODULE"}
             <span><input type="radio" name="workflow_trigger" value="1" {if $EXECUTION_CONDITION eq '1'} checked="" {/if}> <span id="workflowTriggerCreate">{vtranslate($SINGLE_SELECTED_MODULE, $SELECTED_MODULE)} {vtranslate('LBL_CREATION', $QUALIFIED_MODULE)}</span></span><br>
             <span><input type="radio" name="workflow_trigger" value="3" {if $EXECUTION_CONDITION eq '3' or $EXECUTION_CONDITION eq '2'} checked="" {/if}> <span id="workflowTriggerUpdate">{vtranslate($SINGLE_SELECTED_MODULE, $SELECTED_MODULE)} {vtranslate('LBL_UPDATED', $QUALIFIED_MODULE)}</span> &nbsp;({vtranslate('LBL_INCLUDES_CREATION', $QUALIFIED_MODULE)})</span><br>
-			<span><input type="radio" name="workflow_trigger" value="6" {if $EXECUTION_CONDITION eq '6'} checked="" {else if $SCHEDULED_WORKFLOW_COUNT >= $MAX_ALLOWED_SCHEDULED_WORKFLOWS} disabled="disabled" {/if}> {vtranslate('LBL_TIME_INTERVAL', $QUALIFIED_MODULE)}
-				{if $SCHEDULED_WORKFLOW_COUNT >= $MAX_ALLOWED_SCHEDULED_WORKFLOWS}
+			<span><input type="radio" name="workflow_trigger" value="6" {if $EXECUTION_CONDITION eq '6'} checked="" {else if $SCHEDULED_WORKFLOW_COUNT >= $MAX_ALLOWED_SCHEDULED_WORKFLOWS && !is_null($MAX_ALLOWED_SCHEDULED_WORKFLOWS)} disabled="disabled" {/if}> {vtranslate('LBL_TIME_INTERVAL', $QUALIFIED_MODULE)}
+				{if $SCHEDULED_WORKFLOW_COUNT >= $MAX_ALLOWED_SCHEDULED_WORKFLOWS && !is_null($MAX_ALLOWED_SCHEDULED_WORKFLOWS)}
 					&nbsp;&nbsp;<span class="alert-info textAlignCenter"><i class="fa fa-info-circle"></i>&nbsp;&nbsp;({vtranslate('LBL_MAX_SCHEDULED_WORKFLOWS_EXCEEDED', $QUALIFIED_MODULE, $MAX_ALLOWED_SCHEDULED_WORKFLOWS)})</span>
 				{/if}
 			</span>
@@ -38,7 +38,7 @@
        </div>
     </div>
 
-    {if $SCHEDULED_WORKFLOW_COUNT < $MAX_ALLOWED_SCHEDULED_WORKFLOWS}
+    {if $SCHEDULED_WORKFLOW_COUNT < $MAX_ALLOWED_SCHEDULED_WORKFLOWS || is_null($MAX_ALLOWED_SCHEDULED_WORKFLOWS)}
         <div id="scheduleBox" class='contentsBackground {if $WORKFLOW_MODEL_OBJ->executionCondition neq 6} hide {/if}'>
             <div class="form-group">
                 <label class="col-sm-3 control-label"> {vtranslate('LBL_FREQUENCY', $QUALIFIED_MODULE)} </label>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #644 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローを作成する際に、最大数を設定していないのに「定期的に実行」を選択することができない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 最大数を設定していないとき、$MAX_ALLOWED_SCHEDULED_WORKFLOWSがnullであった。
2. ワークフロー数が常にnullと比較されていたため最大数を超えていると判定されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. $MAX_ALLOWED_SCHEDULED_WORKFLOWSがnullの場合は、「定期的に実行」を選択できるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (40)](https://user-images.githubusercontent.com/86254425/202947520-5df83602-3c07-49a4-a45c-b97ce9cdba84.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフロー最大数が関連する範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->