### PR TITLE
#649 TODOをマウス移動する際の不具合を修正

### DIFF
--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -276,6 +276,12 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 					$result['recurringRecords'] = true;
 				} else {
                     $oldStartDateTime = $this->getFormattedDateTime($record->get('date_start'), $record->get('time_start'));
+					if($activityType == 'Task'){
+						$oldhour = substr($oldStartDateTime,11,2);
+						$oldminute = substr($oldStartDateTime,14,2);
+						$alldaystartdatetime = (60*60*$oldhour) + (60*$oldminute);
+						$secondsDelta = $secondsDelta - $alldaystartdatetime;
+					}
 					$resultDateTime = $this->changeDateTime($oldStartDateTime,$dayDelta,$minuteDelta,$secondsDelta);
 					$parts = explode(' ',$resultDateTime);
 					$record->set('date_start',$parts[0]);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #649 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.ToDoをカレンダー上でマウス移動すると意図しない時刻に保存されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「終日」の欄から移動する際、移動前の設定時刻が何時であっても０時からの移動分の時間が設定時刻に加算されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. マウス移動後の日時が正しくなるようにコードを追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー画面でのマウス移動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
ToDoの終了日時は日単位でしか設定できないため「終日」の欄でのみ移動可能。
マウス移動した後にページを更新すると、移動したToDoは「終日」の欄に表示されるが時刻はマウス移動した先の時刻に設定される。
また、#379も動作確認済みです。