### PR TITLE
#486 にて再編集時にデフォルト値が削除されてしまう箇所の修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -972,7 +972,9 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					case 'MultiSelectCombo':type = 'Multipicklist';break;
 				}
 				data.type = type;
-				typeBeforeChange = type;
+				if(form.find('[name="fieldType"]').attr('disabled') != 'disabled'){
+					typeBeforeChange = type;
+				}
 
 				if (typeof data.picklistvalues == "undefined")
 					data.picklistvalues = {};


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #486 
- fix #487 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. デフォルト値を設定して、複数選択肢を作成
2. 作成した項目を再編集
  →設定したはずのデフォルト値が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. #487で追加した新規作成時のデフォルト値初期化処理が、再編集時にも流れてしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 再編集時で初期化処理が流れないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/75693720/207823390-9c3df1b6-b8cc-40fb-9fd0-0ae865639706.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->