### PR TITLE
ワークフローアクション「項目の値の更新」にて、エラーが発生し正常に保存できない箇所の修正

### DIFF
--- a/data/VTEntityDelta.php
+++ b/data/VTEntityDelta.php
@@ -90,6 +90,10 @@ class VTEntityDelta extends VTEventHandler {
 		return self::$entityDelta[$moduleName][$recordId];
 	}
 
+	function setEntityDelta($moduleName, $recordId, $entityDelta) {
+		return self::$entityDelta[$moduleName][$recordId] = $entityDelta;
+	}
+
 	function getOldValue($moduleName, $recordId, $fieldName) {
 		$entityDelta = self::$entityDelta[$moduleName][$recordId];
 		return $entityDelta[$fieldName]['oldValue'];

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -547,8 +547,12 @@ function insertIntoRecurringTable(& $recurObj)
 			if(empty($inviteeid)) {
 				continue;
 			}
-			$query="INSERT INTO vtiger_invitees VALUES (?,?,?)";
-			$adb->pquery($query, array($this->invitee_parentid, $inviteeid, 'sent'));
+			$result = $adb->pquery("SELECT 1 FROM vtiger_invitees WHERE activityid = ? AND inviteeid = ?", array($this->invitee_parentid, $inviteeid));
+			// 招待活動が存在しない場合は、作成する。
+			if($adb->num_rows($result) == 0) {
+				$query="INSERT INTO vtiger_invitees VALUES (?,?,?)";
+				$adb->pquery($query, array($this->invitee_parentid, $inviteeid, 'sent'));
+			}
 
 			$result = $adb->pquery("SELECT 1 FROM vtiger_activity a INNER JOIN vtiger_crmentity c ON c.crmid = a.activityid WHERE c.deleted = 0 AND c.smownerid = ? AND a.invitee_parentid = ?", array($inviteeid, $this->invitee_parentid));
 			if($adb->num_rows($result) == 0) {

--- a/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
+++ b/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
@@ -354,8 +354,11 @@ class VTUpdateFieldsTask extends VTTask {
 			foreach($referenceModuleUpdated as $module => $info){
 				foreach($info as $refFieldName => $referenceRecordId){
 					$referenceFocus = $this->referenceFieldFocusList[$refFieldName][$referenceRecordId];
+					$vtEntityDelta = new VTEntityDelta();
+					$delta = $vtEntityDelta->getEntityDelta($moduleName, $entity->getId(), false);
 						foreach ($referenceFocus->column_fields as $fieldName => $fieldValue) {
 							$referenceFocus->column_fields[$fieldName] = html_entity_decode($fieldValue, ENT_QUOTES, $default_charset);
+							$delta[$fieldName]['currentValue'] = html_entity_decode($fieldValue, ENT_QUOTES, $default_charset);
 						}
 						$referenceFocus->isLineItemUpdate = false;
 						$referenceFocus->isWorkFlowFieldUpdate = true;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #679 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
【バグ①】
1. WFを下記内容で設定
```
対象モジュール：案件
タイミング：案件　更新（作成時を含む）
■全ての条件
選択肢複数　～に変更された　A、B
■アクション（項目の値の更新）
チケット：（チケット）優先度　緊急
```
2. 案件＞編集ボタン＞項目を更新
3. Fatalエラー発生

【バグ②】
設定したWFが起動する条件で活動を新規作成時、招待者がいる場合エラーがでる
テストしたWFの条件：活動タイプが「会議」のとき優先度を「高」にする

##  原因 / Cause
<!-- バグの原因を記述 -->
1. クラスが宣言されていなかった
2. 定義されていない関数が使用されていた
3. 重複したレコードがインサートされていた

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* WF活動
* WFアクション値の更新

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->