### PR TITLE
#562 関連項目で使用しなくなった「カレンダー」「TODO」を非表示に設定する

### DIFF
--- a/modules/Migration/schema/736_to_737.php
+++ b/modules/Migration/schema/736_to_737.php
@@ -25,4 +25,14 @@ if (defined('VTIGER_UPGRADE')) {
     if($moduleModel){
         $moduleModel->setRelatedList(Vtiger_Module_Model::getInstance('Assets'), 'Assets', 'ADD,SELECT', 'get_related_list');
     }
+
+    // uitype10の「カレンダー」および「TODO」を非表示に変更する
+    $db->query('UPDATE vtiger_field vf
+        LEFT JOIN vtiger_relatedlists vr 
+        ON vf.fieldid = vr.relationfieldid
+        SET vf.presence = 1
+        WHERE vf.presence = 2
+        AND vf.uitype = 10
+        AND vr.tabid in (9,16);
+    ');
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #562 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連項目に「カレンダー」及び「TODO」を使用不可に修正したが、過去に作成された項目は表示されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 選択肢から「カレンダー」「TODO」を選択できないように修正したため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 737のアップデート時にuitype=10の「カレンダー」「TODO」の項目を非表示にする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* モジュールの項目の表示/非表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->