### PR TITLE
#489 一部罫線のスタイルの崩れを修正

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
@@ -74,7 +74,7 @@
 									<tr class="listViewEntries" data-id="{$LISTVIEW_ENTRY->getId()}"
 										{if method_exists($LISTVIEW_ENTRY,'getDetailViewUrl')}data-recordurl="{$LISTVIEW_ENTRY->getDetailViewUrl()}"{/if}
 										{if method_exists($LISTVIEW_ENTRY,'getRowInfo')}data-info="{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::Encode($LISTVIEW_ENTRY->getRowInfo()))}"{/if}>
-										<td width="10%">
+										<td width="10%" class="listViewEntryValue">
 											{include file="ListViewRecordActions.tpl"|vtemplate_path:$QUALIFIED_MODULE}
 										</td>
 										{foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #489 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
一番左の項目に罫線が入ってきてしまっていた。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
同じクラスを適用した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

> 修正後
![image](https://user-images.githubusercontent.com/95267222/209494127-b4b770ff-b23d-49a9-b23e-767b823028de.png)

> 修正前
![image](https://user-images.githubusercontent.com/95267222/209494159-0cb52a50-c0e9-4350-be42-9565dd375453.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->