### PR TITLE
#539 繰り返し予定の編集について、選択したレコードに対して二回処理を行っている問題を修正

### DIFF
--- a/modules/Calendar/RepeatEvents.php
+++ b/modules/Calendar/RepeatEvents.php
@@ -212,7 +212,7 @@ class Calendar_RepeatEvents {
 					$recordModel = Vtiger_Record_Model::getInstanceById($recordId);
 					$recordModel->set("is_allday", $focus->is_allday); //recordModulにis_alldayが無いので追加
 					$recordModel->set('mode', 'edit');
-					if($focus->column_fields['recurringEditMode'] == 'future' && $recordModel->get('date_start') >= $eventStartDate) {
+					if($focus->column_fields['recurringEditMode'] == 'future' && $recordModel->get('date_start') >= $eventStartDate && $recordModel->get('date_start') != $eventStartDate) {
 						$startDateTimestamp = strtotime($startDate);
 						$endDateTime = $startDateTimestamp + $interval;
 						$endDate = date('Y-m-d', $endDateTime);
@@ -239,7 +239,7 @@ class Calendar_RepeatEvents {
 						if(self::$recurringTypeChanged) {
 							$adb->pquery("INSERT INTO vtiger_activity_recurring_info VALUES (?,?)", array($parentId, $recordId));
 						}
-					} else if($focus->column_fields['recurringEditMode'] == 'all') {
+					} else if($focus->column_fields['recurringEditMode'] == 'all' && $recordModel->get('date_start') != $eventStartDate) {
 						$startDateTimestamp = strtotime($startDate);
 						$endDateTime = $startDateTimestamp + $interval;
 						$endDate = date('Y-m-d', $endDateTime);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #539 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 繰り返し予定の担当者を変更時、「以降の～」「全て」を選択すると一日だけ変更前・変更後の担当者が参加者に残る

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 選択した活動に対して編集内容を保存した後に、「以降の～」「全て」の条件に合う活動に対して編集内容を保存していた。そのため選択した活動に対して二回保存の処理が行われていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「以降の～」「全て」の条件に合う活動に対しての保存処理を、選択した活動に対しては行わないようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

> 変更前
![image](https://user-images.githubusercontent.com/95267222/209614982-40376ef7-3573-4ec7-9580-64d004b79646.png)

> 変更後
![image](https://user-images.githubusercontent.com/95267222/209614846-14ff70bd-0468-40e2-b4a5-14c7711a7230.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーモジュールの繰り返し予定の範囲。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
繰り返し予定に対して「以降の～」を選択して担当者の変更を行った後に「全て」を選択して担当者の変更を行うと一部のレコードが二重に登録されてしまう。
修正が終わり次第pushします。
![image](https://user-images.githubusercontent.com/95267222/209615251-09074d94-0e15-47e2-9d1e-f5bf3b00cd96.png)
