### PR TITLE
#746活動を作成している途中で活動タイプを変更しても終了側の日付が変更されないように修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Edit.js
+++ b/layouts/v7/modules/Calendar/resources/Edit.js
@@ -522,7 +522,7 @@ Vtiger_Edit_Js("Calendar_Edit_Js",{
 	registerActivityTypeChangeEvent : function(container) {
 		container.find('[name="activitytype"]').on('change', function() {
 			var time_start_element = container.find('[name="time_start"]');
-				time_start_element.trigger('changeTime');
+				//time_start_element.trigger('changeTime');
 		});
 	},
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #746 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
活動追加において、活動を作成している途中で”活動タイプ”を変更すると終了側の日付が開始側の日付と同日に変更されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
活動タイプを変更したときに動作する関数registerActivityTypeChangeEvent内で、活動の時刻を変更していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
活動タイプを変更しても時刻の変更を行わないように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
活動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->