### PR TITLE
#738 「項目の値の更新」のチェックボックスの表示の修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/Edit.js
@@ -161,7 +161,7 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
             } else {
                value = '';
             }
-            var clonedBooleanElement = '<input type="checkbox" style="width: 30%;" class="fieldValue inputElement" value="' + value + '" data-input="true" >';
+            var clonedBooleanElement = '<input type="checkbox" style="width:15px; height:15px;" class="fieldValue inputElement" value="' + value + '" data-input="true" >';
             clonedPopupUi.find('.fieldValueContainer div').prepend(clonedBooleanElement);
 
             var fieldValue = clonedPopupUi.find('.fieldValueContainer input').val();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #738 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ワークフローのアクション「項目の値の更新」にてチェックボックスの表示が長い

##  原因 / Cause
<!-- バグの原因を記述 -->
ワークフローのアクション「項目の値の更新」で表示されるポップアップ内のチェックボックスの設定がstyle="width: 30%"になっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
style="width:15px; height:15px;"に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (31)](https://user-images.githubusercontent.com/107910164/211718684-390e4760-408b-4d1a-bcf7-41b2f6c7101a.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ワークフローの「項目の値の更新」内のチェックボックス

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->