### PR TITLE
#744 マイグループのチェックボックスが変化しないよう修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1270,7 +1270,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				thisInstance.updateAllEventsOnCalendar();
 			}
 			if(thisInstance.changeUserList) {
-				thisInstance.changeUserList();
+				//thisInstance.changeUserList();
 			}
 		});
 	},


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #744

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
共有カレンダーマイグループで、記入済みの予定を別日や別の時間へドラッグ移動すると、チェックを外していた人全員にチェックが入って表示されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
カレンダー上のイベントをアップデートするときにマイグループのユーザーリストにチェックを入れる処理があった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
原因箇所をコメントアウト

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
該当箇所をコメントアウトしても、ドラッグ移動した予定の変更やマイグループのチェックボックスの情報は正しく保存はできましたが、少し不安なのでご確認お願い致します。