### PR TITLE
#541 ユーザーのカレンダー設定ブロックにカスタム項目を追加できないように修正

### DIFF
--- a/modules/Settings/LayoutEditor/models/Block.php
+++ b/modules/Settings/LayoutEditor/models/Block.php
@@ -23,7 +23,7 @@ class Settings_LayoutEditor_Block_Model extends Vtiger_Block_Model {
 	 * @return <Boolean> true/false
 	 */
 	public function isAddCustomFieldEnabled() {
-        $actionNotSupportedModules = array_merge(getInventoryModules(), array('Calendar', 'Events', 'Faq', 'HelpDesk'));
+        $actionNotSupportedModules = array_merge(getInventoryModules(), array('Calendar', 'Events', 'Faq', 'HelpDesk', 'Users'));
 		$blocksEliminatedArray = array(	'Calendar'		=> array('LBL_TASK_INFORMATION', 'LBL_DESCRIPTION_INFORMATION'),
 										'HelpDesk'		=> array('LBL_TICKET_RESOLUTION', 'LBL_COMMENTS'),
 										'Faq'			=> array('LBL_COMMENT_INFORMATION'),
@@ -31,7 +31,8 @@ class Settings_LayoutEditor_Block_Model extends Vtiger_Block_Model {
 										'Quotes'		=> array('LBL_ITEM_DETAILS'),
 										'SalesOrder'	=> array('LBL_ITEM_DETAILS'),
 										'PurchaseOrder'	=> array('LBL_ITEM_DETAILS'),
-										'Events'		=> array('LBL_INVITE_USER_BLOCK'));
+										'Events'		=> array('LBL_INVITE_USER_BLOCK'),
+									    'Users'         => array('LBL_CALENDAR_SETTINGS'));
         if(in_array($this->module->name, $actionNotSupportedModules)) {
 			if(!empty($blocksEliminatedArray[$this->module->name])) {
 				if(in_array($this->get('label'), $blocksEliminatedArray[$this->module->name])) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #541 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ユーザーのカレンダー設定ブロックにカスタム項目を追加できてしまう。
追加すると、項目の表示形式がおかしくなる。

##  原因 / Cause
<!-- バグの原因を記述 -->
カスタム項目を追加できない項目の中にユーザーの「カレンダー設定」がなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
カスタム項目を追加できない項目にユーザーの「カレンダー設定」を追加。
「カスタム項目の追加」を非表示に変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (32)](https://user-images.githubusercontent.com/107910164/211747723-7e15a884-5e3b-4e1f-8314-c881efe093cd.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目設定

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->