### PR TITLE
#721 メニュー設定の翻訳漏れの修正

### DIFF
--- a/languages/ja_jp/Settings/MenuEditor.php
+++ b/languages/ja_jp/Settings/MenuEditor.php
@@ -9,6 +9,7 @@
  *************************************************************************************/
 
 $languageStrings = array(
+    'MenuEditor'=>'メニュー設定',
     'LBL_SELECT_MARKETING_MODULES' => 'マーケティングに表示するモジュールを選択してください',
     'LBL_SELECT_SALES_MODULES' => '営業に表示するモジュールを選択してください',
     'LBL_SELECT_INVENTORY_MODULES' => '販売管理に表示するモジュールを選択してください',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #721

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
システム設定のメニュー設定の翻訳漏れ

##  原因 / Cause
<!-- バグの原因を記述 -->
MenuEditorの翻訳が登録されていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
'MenuEditor'=>'メニュー設定'を登録

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (34)](https://user-images.githubusercontent.com/107910164/211766888-eecac375-c1f7-4128-9da8-12297d632afd.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
メニュー設定


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->