### PR TITLE
#719 レポート画面の翻訳漏れの修正

### DIFF
--- a/layouts/v7/modules/Reports/DetailViewActions.tpl
+++ b/layouts/v7/modules/Reports/DetailViewActions.tpl
@@ -44,7 +44,7 @@
 											</li>
 											{foreach from=$DASHBOARD_TABS item=TAB_INFO}
 												<li class='dashBoardTab' data-tab-id='{$TAB_INFO.id}'>
-													<a href='javascript:void(0)'> {$TAB_INFO.tabname}</a>
+													<a href='javascript:void(0)'> {vtranslate($TAB_INFO.tabname,$MODULE)}</a>
 												</li>
 											{/foreach}
 										</ul>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #719

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポートの追加からグラフを作成後、ピンマークをクリックした際に出てくるタブの翻訳漏れ

##  原因 / Cause
<!-- バグの原因を記述 -->
翻訳前の項目名をそのまま表示していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
vtranslateを通した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (35)](https://user-images.githubusercontent.com/107910164/211769789-bf4f3959-8b10-4dd0-9c02-22694083f0f3.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->