### PR TITLE
#667 複数のユーザーにメールを送るときの、ドキュメント添付のエラーを修正

### DIFF
--- a/layouts/v7/modules/Emails/resources/MassEdit.js
+++ b/layouts/v7/modules/Emails/resources/MassEdit.js
@@ -857,7 +857,7 @@ jQuery.Class("Emails_MassEdit_Js",{},{
 			this.registerSelectEmailTemplateEvent();
 			this.registerEventsForToField();
 			this.registerEventForRemoveCustomAttachments();
-
+			app.event.off("post.DocumentsList.click");
 			app.event.on("post.DocumentsList.click",function(event, data){
 				var responseData = JSON.parse(data);
 				jQuery('.popupModal').modal('hide');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #667 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一覧画面から複数のユーザーにメール送信を行う際に、「ドキュメントを参照」から添付を選択すると、エラーが出る（添付・送付はできる）

##  原因 / Cause
<!-- バグの原因を記述 -->
1. すでに添付したドキュメントかを判断するonイベントをメールを送信する画面を開くたびに読み込んでいた。そのため複数個の同じonイベントが登録されてしまい、エラーが発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. onイベントの登録の直前にonイベントのリセットを行った。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/212597105-d9bf2f6b-2d18-4645-95ad-f7074ba9b0d8.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
一覧画面から複数のユーザーにメールを送信する場合。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->