### PR TITLE
#768 リストの日付項目でのSQLエラー

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1030,11 +1030,19 @@ class QueryGenerator {
 				$value = trim($value);
 			}
 			if ($operator == 'empty' || $operator == 'y') {
-				$sql[] = sprintf("IS NULL OR %s = ''", $this->getSQLColumn($field->getFieldName(), $field));
+				if($this->isDateType($field->getFieldDataType())) {
+					$sql[] = sprintf("IS NULL", $this->getSQLColumn($field->getFieldName(), $field));
+				} else {
+					$sql[] = sprintf("IS NULL OR %s = ''", $this->getSQLColumn($field->getFieldName(), $field));
+				}
 				continue;
 			}
 			if($operator == 'ny'){
-				$sql[] = sprintf("IS NOT NULL AND %s != ''", $this->getSQLColumn($field->getFieldName(), $field));
+				if($this->isDateType($field->getFieldDataType())) {
+					$sql[] = sprintf("IS NOT NULL", $this->getSQLColumn($field->getFieldName(), $field));
+				} else {
+					$sql[] = sprintf("IS NOT NULL AND %s != ''", $this->getSQLColumn($field->getFieldName(), $field));
+				}
 				continue;
 			}
 			if((strtolower(trim($value)) == 'null') ||


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #768 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストで日付項目に対して「空である」「空ではない」を選択したときにSQLエラーが発生する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. SQLを生成する際に「= ''」が含まれていたため、MySQL8.0からは日付型に対して指定するとエラーになる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. SQLを生成する際の条件を追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リストの表示範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->