### PR TITLE
#766 活動モジュール項目の並べ替えができない不具合を修正

### DIFF
--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -407,10 +407,6 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 	 * @return <Boolean> true/false
 	 */
 	public function isSortableAllowed() {
-		$moduleName = $this->getName();
-		if (in_array($moduleName, array('Calendar', 'Events'))) {
-			return false;
-		}
 		return true;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #766 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動モジュールで並び替え可能な項目（カスタム情報）を並び替えた際に、「並び順を保存」ボタンが出てこず、保存ができない。
2. TODOモジュールの並び替え可能な項目（アラーム情報、カスタム情報）についても同様の不具合があった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動・TODOモジュールでは「並び順を保存」ボタンを出さないように設定されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動・TODOモジュールでも他のモジュールと同様、並び替えた直後に「並び替えを保存」ボタンが出るようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目設定の各モジュール内での項目の並び替え

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
TODOモジュールの「アラーム情報」で、デフォルトの項目（事前にメールを送信）はドラッグのアイコンが出ないが、新規追加した項目のみドラッグのアイコンが出る。（どちらもドラッグ可能である。）
![スクリーンショット (53)](https://user-images.githubusercontent.com/86254425/212616458-7a0ab2ee-f864-4078-a26e-150af7bf7aad.png)
