### PR TITLE
#767翻訳がかかっている選択肢項目のエクスポート、インポートについての修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -653,6 +653,13 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					$allPicklistValues[] = $picklistDetails['value'];
 				}
 
+				//$fieldValueが日本語の場合に翻訳可能か調べる。
+				foreach($allPicklistDetails as $picklistDetails){
+					if($fieldValue == $picklistDetails['label']){
+						$fieldValue = $picklistDetails['value'];
+					}
+				}
+
 				$picklistValueInLowerCase = strtolower($fieldValue);
 				$allPicklistValuesInLowerCase = array_map('strtolower', $allPicklistValues);
 				if (sizeof($allPicklistValuesInLowerCase) > 0 && sizeof($allPicklistValues) > 0) {
@@ -1138,6 +1145,20 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					$recordData['mode'] = 'edit';
 				}
 
+				//選択肢項目の翻訳前の値を取得
+				foreach ($recordData as $fieldName => $fieldValue) {
+					$fieldModel = $moduleFields[$fieldName];
+					$fieldDataType = ($fieldModel) ? $fieldModel->getFieldDataType() : '';
+					if ($fieldDataType == 'picklist') {
+						$picklistValues = $fieldModel->getPicklistValues();
+						foreach($picklistValues as $key => $value){
+							if($value == $fieldValue){
+								$recordData[$fieldName] = $key;
+							}
+						}
+					}
+				}
+
 				try {
 					if ($recordData['id']) {
 						$recordModel = Vtiger_Record_Model::getInstanceById($recordData['id'], $moduleName);
@@ -1168,6 +1189,23 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 		try {
 			if ($recordData) {
+
+				//選択肢項目の翻訳前の値を取得
+				$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+				$moduleFields = $moduleModel->getFields();
+				foreach ($recordData as $fieldName => $fieldValue) {
+					$fieldModel = $moduleFields[$fieldName];
+					$fieldDataType = ($fieldModel) ? $fieldModel->getFieldDataType() : '';
+					if ($fieldDataType == 'picklist') {
+						$picklistValues = $fieldModel->getPicklistValues();
+						foreach($picklistValues as $key => $value){
+							if($value == $fieldValue){
+								$recordData[$fieldName] = $key;
+							}
+						}
+					}
+				}
+				
 				switch($operation) {
 					case 'create' : $entityInfo = vtws_create($moduleName, $recordData, $user);
 									$entityInfo['status'] = self::$IMPORT_RECORD_CREATED;

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -60,6 +60,30 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			$entries[] = $this->sanitizeValues($db->fetchByAssoc($result, $j));
 		}
 
+		//エクスポート時の選択肢項目の翻訳処理
+		for ($i = 0; $i < $j; $i++){
+			$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+			$moduleFields = $moduleModel->getFields();
+			foreach ($entries[$i] as $columnName => $fieldValue) {
+				$fieldModel = $moduleFields[$columnName];
+				if(empty($fieldModel)){
+					foreach($moduleFields as $key => $fieldinfo){
+						if($fieldinfo->column == $columnName){
+							$fieldName = $fieldinfo->name;
+						}
+					}
+					$fieldModel = $moduleFields[$fieldName];
+				}
+
+				$fieldDataType = ($fieldModel) ? $fieldModel->getFieldDataType() : '';
+
+				if ($fieldDataType == 'picklist') {
+					$entries[$i][$columnName] = vtranslate($fieldValue,$moduleName);
+				}
+			}
+
+		}
+
 		$this->output($request, $translatedHeaders, $entries);
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #767 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 翻訳が掛かっている選択肢項目をエクスポートすると英語で出力される
2. 翻訳が掛かっている選択肢項目を日本語でインポートするとフィルターの条件が一致していても一覧に表示されない。また、新しい選択肢として同名の選択肢が追加されてしまった

##  原因 / Cause
<!-- バグの原因を記述 -->
1. データベース上で英語で登録されている項目名をそのまま出力していたから
2. インポートされた選択肢項目は翻訳前の選択肢項目と比較されるため、別の選択肢として扱われてしまい、フィルターの条件が一致していても一覧に表示されなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 選択肢項目を翻訳してからエクスポートするように修正
エクスポート時に選択肢項目のみvtranslateにかけた
エクスポート時の項目名が、フィールド名ではなくカラム名になっている項目はフィールド名に変更したあと、選択肢項目ならvtranslateにかけるようにした

2. 翻訳がかかっている選択肢項目を日本語でインポートしてもフィルターに引っかかるように修正 
インポートする際に各項目のデータタイプを調べ、選択肢項目だった場合翻訳前後を取得、入力項目の翻訳前が存在する場合翻訳前の値を入れた。また、同名の選択肢が追加されるのを防ぐためにData.phpの655行目あたりで翻訳前が存在する場合に翻訳前の値を入れた。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
インポートエクスポート
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->