### PR TITLE
#776 活動の参加者登録の際にSQLエラーが発生しないように修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -547,6 +547,12 @@ function insertIntoRecurringTable(& $recurObj)
 			if(empty($inviteeid)) {
 				continue;
 			}
+
+			$result = $adb->pquery("SELECT 1 FROM vtiger_invitees WHERE activityid = ? AND inviteeid = ?", array($this->invitee_parentid, $inviteeid));
+			if($adb->num_rows($result) > 0) {
+				continue;
+			}
+
 			$query="INSERT INTO vtiger_invitees VALUES (?,?,?)";
 			$adb->pquery($query, array($this->invitee_parentid, $inviteeid, 'sent'));
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #776 

##  不具合の内容 / Bug
vtiger_inviteesのPK違反

##  原因 / Cause
ワークフローで活動を更新した際に正しく$invitees_arrayが構築されない。

##  変更内容 / Details of Change
レコードの存在有無を確認するように修正

## スクリーンショット / Screenshot
なし

## 影響範囲  / Affected Area
なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
none;