### PR TITLE
#602 「TODO」にてインポートしたときにご担当者様が取り込まれるように修正

### DIFF
--- a/modules/Import/readers/FileReader.php
+++ b/modules/Import/readers/FileReader.php
@@ -150,7 +150,7 @@ class Import_FileReader_Reader {
 		$columnsListQuery = '';
 		$fieldName = $fieldObject->getName();
 		$dataType = $fieldObject->getFieldDataType();
-		$skipDataType = array('reference','owner', 'currencyList', 'date', 'datetime', 'productTax', 'ownergroup');
+		$skipDataType = array('reference','owner', 'currencyList', 'date', 'datetime', 'productTax', 'ownergroup','multireference');
 		if($fieldObject->get('name') == 'tags' && $fieldObject->get('displaytype') == 6){
 			$columnsListQuery .= ','.$fieldName.' varchar(500)';
 		} elseif(in_array($dataType, $skipDataType)){


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #602

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. TODOにおいてインポートに成功しても「ご担当者様」が取り込まれない
2. TODO、活動においてインポートに成功しても選択肢項目が取り込まれない。詳細画面では値が確認できるが、編集画面を開くと値が選択されていない状態になる。（修正中に発見）

##  原因 / Cause
<!-- バグの原因を記述 -->
1. イベントのcontact_id（ご担当者様）のデータタイプはmultireferenceになっているが、ファイルを読み込むときの型の割り当てでmultireferenceがないためintになってしまい、ご担当者様が正しく取り込まれなかった。
2. カレンダーをインポートする際、選択肢項目に翻訳した値を代入していたため。Pr#767にて修正済みでした。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. skipDataTypeにmultireferenceを追加して文字列として認識するように修正した


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
multireferenceのインポートのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->