### PR TITLE
#783 受注で入力不可であるべき項目を入力不可になるよう修正

### DIFF
--- a/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
@@ -130,7 +130,14 @@
 													<input type="hidden" class="fieldBasicData" data-name='{$FIELD_MODEL->get('name')}' data-type="{$fieldDataType}" data-displayvalue='{$FIELD_DISPLAY_VALUE}' data-value="{$FIELD_VALUE}" />
 												{/if}
 											</span>
-											<span class="action pull-right"><a href="#" onclick="return false;" class="editAction fa fa-pencil"></a></span>
+
+											{if $FIELD_MODEL->get('name') eq "enable_recurring"}
+												{assign var=recurringValue value=$FIELD_MODEL->get('fieldvalue')}
+											{/if}
+
+											{if $BLOCK_LABEL_KEY neq "Recurring Invoice Information" or $FIELD_MODEL->get('name') eq "enable_recurring" or $recurringValue eq 1}
+												<span class="action pull-right"><a href="#" onclick="return false;" class="editAction fa fa-pencil"></a></span>
+											{/if}
 										{/if}
 									</td>
 								{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #783 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 受注で繰り返し有効が「いいえ」の時でも、詳細から繰り返し請求情報を入力できてしまう。
2. 更新しても保存はされないが、編集画面同様に入力不可であったほうが良い。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 繰り返しの有効無効にかかわらず、繰り返し請求情報が入力できるようになっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 繰り返し有効が「いいえ」の場合のみ、他の繰り返し請求情報の入力をさせない。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レコードの詳細画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
繰り返し有効のチェックボックスを変更し、ページを更新したときに処理が行われる。