### PR TITLE
#718 ブックマークの一覧画面の翻訳漏れの修正

### DIFF
--- a/languages/ja_jp/Portal.php
+++ b/languages/ja_jp/Portal.php
@@ -9,6 +9,8 @@
  *************************************************************************************/
 $languageStrings = array(
 	'Portal' => 'ブックマーク',
+	'List' => 'リスト',
+	'Detail' => '詳細',
 	'LBL_ADD_BOOKMARK' => 'ブックマークの追加',
 	'LBL_BOOKMARK_NAME' => 'サイト名',
 	'LBL_BOOKMARK_URL' => 'URL',

--- a/layouts/v7/modules/Portal/ModuleHeader.tpl
+++ b/layouts/v7/modules/Portal/ModuleHeader.tpl
@@ -23,7 +23,7 @@
 					<a title="{vtranslate($MODULE, $MODULE)}" href='{$DEFAULT_FILTER_URL}'><h4 class="module-title pull-left text-uppercase">&nbsp;{vtranslate($MODULE, $MODULE)}&nbsp;</h4></a>
 				</span>
 				<span>
-					<p class="current-filter-name pull-left">&nbsp;<span class="fa fa-angle-right" aria-hidden="true"></span>&nbsp;{$VIEW}&nbsp;</p>
+					<p class="current-filter-name pull-left">&nbsp;<span class="fa fa-angle-right" aria-hidden="true"></span>&nbsp;{vtranslate($VIEW,$MODULE)}&nbsp;</p>
 				</span>
 				{if $VIEWID}
 					{foreach item=FILTER_TYPES from=$CUSTOM_VIEWS}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #718 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ブックマークでの翻訳漏れ

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 翻訳前の文字を表示していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Portal.phpに翻訳を追加した。
2. vtranslateに通した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (55)](https://user-images.githubusercontent.com/86254425/217437572-aba62069-0417-4bd0-99b5-91762132e2fa.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ブックマークの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->