### PR TITLE
#716 リストの項目設定での翻訳漏れを修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1150,6 +1150,25 @@ $languageStrings = array(
 	'LBL_SELECTED_FIELDS' => '選択済みの項目',
 	'LBL_AVAILABLE_FIELDS' => '利用可能な項目',
 	'LBL_SEARCH_FIELDS' => '検索項目',
+	'Hot Leads' => '確度の高い顧客',
+	'This Month Leads' => '今月のリード',
+	'Contacts Address' => '郵送先リスト',
+	'Todays Birthday' => '本日誕生日',
+	'Prospect Accounts' => '潜在顧客一覧',
+	'New This Week' => '今週登録された顧客一覧',
+	'Potentials Won' => '受注案件',
+	'Prospecting'=>'発掘',
+	'Open Quotes' => '未承認の見積',
+	'Rejected Quotes' => '却下された見積',
+	'Open Invoices' => '登録済み請求',
+	'Paid Invoices' => '領収済み請求',
+	'Pending Sales Orders' => '登録済み受注',
+	'Open Purchase Orders' => '登録済み発注',
+	'Received Purchase Orders' => '入庫済み受注',
+	'High Prioriy Tickets' => '優先度が高のチケット',
+	'Open Ticket'=>'未解決のチケット',
+	'Drafted FAQ' => '下書き',
+	'Published FAQ' => '公開済み',
 
 	// Extensions
 	'ExtensionStore' =>'Extension Store',
@@ -2116,6 +2135,7 @@ $jsLanguageStrings = array(
 	'Changed password successfully'=>'パスワードの変更に成功しました',
 	'LBL_MASS_PDF_EXPORT_CONFIRMATION' => '選択したレコードに関するPDFを生成してもよろしいですか？',
 	'JS_THIS_FILE_HAS_ALREADY_BEEN_SELECTED' => 'このファイルは既に選択されています', 
+	'JS_ATLEAST_SELECT_ONE_FIELD' => '少なくとも1つの項目を選択してください',
 
 	//個人カレンダー
 	'Planned' => '計画済み',

--- a/layouts/v7/modules/Vtiger/ListColumnsEdit.tpl
+++ b/layouts/v7/modules/Vtiger/ListColumnsEdit.tpl
@@ -11,7 +11,7 @@
 	<div class="modal-dialog modal-lg configColumnsContainer">
 		<div class="modal-content">
 			{assign var=HEADER_TITLE value={vtranslate('LBL_CONFIG_COLUMNS', $MODULE)}}
-			{include file="ModalHeader.tpl"|vtemplate_path:$MODULE TITLE=$HEADER_TITLE|cat:' - '|cat:$CV_MODEL->get('viewname')}
+			{include file="ModalHeader.tpl"|vtemplate_path:$MODULE TITLE=$HEADER_TITLE|cat:' - '|cat:{vtranslate($CV_MODEL->get('viewname'))}}
 			<form class="form-horizontal configColumnsForm" method="post" action="index.php">
 				<input type="hidden" name="module" value="CustomView"/>
 				<input type="hidden" name="action" value="SaveAjax"/>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #716 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストの項目設定をする際の、リスト名の翻訳漏れ
2. 項目をすべて削除した際の、警告文の翻訳漏れ

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 翻訳が追加されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Vtiger.phpに翻訳を追加した。
2. リスト名を表示する箇所をvtranslateに通した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (59)](https://user-images.githubusercontent.com/86254425/217474723-5135787f-4e1e-4e92-89f8-2665730412a8.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リストの項目設定

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->