### PR TITLE
Dockerfile内のxdebugのビルドをコメントアウト

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -31,5 +31,5 @@ RUN set -xe; \
     # for imap
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install -j$(nproc) imap
-RUN pecl install xdebug \
-  && docker-php-ext-enable xdebug
+# RUN pecl install xdebug \
+#   && docker-php-ext-enable xdebug


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #779

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. docker-compose up --buildを実行時に、xdebugのビルドに失敗する
=> ERROR [5/5] RUN pecl install xdebug && docker-php-ext-enable xdebug 4.4s
------

[5/5] RUN pecl install xdebug && docker-php-ext-enable xdebug:
#0 4.348 pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.4.33
#0 4.348 No valid packages found
#0 4.348 install failed
------
Dockerfile:34
--------------------
33 | docker-php-ext-install -j$(nproc) imap
34 | >>> RUN pecl install xdebug
35 | >>> && docker-php-ext-enable xdebug
36 |
--------------------
ERROR: failed to solve: process "/bin/sh -c pecl install xdebug && docker-php-ext-enable xdebug" did not complete successfully: exit code: 1
ERROR: Service 'php' failed to build : Build failed

##  原因 / Cause
<!-- バグの原因を記述 -->
1. xdebugのビルドにphp8が必要になったが、現状php7であるため
参考
https://qiita.com/kumanobori/items/49b5515e0922799035ea

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. commiterからのリクエストで、Dockerfileからxdebugのビルド部分をコメントアウト

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->