### PR TITLE
#793 選択肢エディタで色を設定すると項目名が英語になる不具合を修正

### DIFF
--- a/layouts/v7/modules/Settings/Picklist/EditView.tpl
+++ b/layouts/v7/modules/Settings/Picklist/EditView.tpl
@@ -42,7 +42,7 @@
                     </div>
                     <div class="form-group">
                         <div class="control-label col-sm-3 col-xs-3"><span class="redColor">*</span>{vtranslate('LBL_ENTER_NEW_NAME',$QUALIFIED_MODULE)}</div>
-                        <div class="controls col-sm-4 col-xs-4"><input class="form-control" type="text"  name="renamedValue" {if in_array($FIELD_VALUE,$SELECTED_PICKLISTFIELD_NON_EDITABLE_VALUES)} disabled='disabled' {/if} data-rule-required="true" value="{Vtiger_Util_Helper::toSafeHTML($FIELD_VALUE)}"></div>
+                        <div class="controls col-sm-4 col-xs-4"><input class="form-control" type="text"  name="renamedValue" {if in_array($FIELD_VALUE,$SELECTED_PICKLISTFIELD_NON_EDITABLE_VALUES)} disabled='disabled' {/if} data-rule-required="true" value="{vtranslate(Vtiger_Util_Helper::toSafeHTML($FIELD_VALUE),$SOURCE_MODULE)}"></div>
                     </div>
                     <div class="form-group">
                         <div class="control-label col-sm-3 col-xs-3">{vtranslate('LBL_SELECT_COLOR', $QUALIFIED_MODULE)}</div>

--- a/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
+++ b/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
@@ -578,7 +578,7 @@ var Settings_Picklist_Js = {
         var template = '<tr class="pickListValue cursorPointer">'+
                             '<td class="textOverflowEllipsis fieldPropertyContainer">'+
                                 '<span class="pull-left">' +
-                                    '<img class="alignMiddle" src="' + dragImagePath + '" />&nbsp;&nbsp;' +
+                                    '<img class="alignMiddle" src="' + dragImagePath + '" /> &nbsp;&nbsp;' +
                                     '<span class="picklist-color" style="background-color: '+ color + ';color: '+ textColor +';">' + value + '</span>' + 
                                 '</span>' +
                                 actionsTemplate +


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #793 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 選択肢エディタで項目の色を設定すると項目名が英語になってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. jsで表示していた項目名（value）が英語で渡されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 選択肢エディタで編集したときに項目名として渡されるvalueを翻訳後の値にした。
2. 設定後の項目の表示がずれていたため、空白を追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (64)](https://user-images.githubusercontent.com/86254425/218960315-6b194883-5c3e-46d4-93f4-8d87a357773c.png)
![スクリーンショット (65)](https://user-images.githubusercontent.com/86254425/218960345-1f86fab6-d490-466c-b3e9-aaf110f8b501.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
選択肢エディタ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->