### PR TITLE
#755 ワークフロー「TODOの作成」より特定の条件で発火すると処理が終わらない箇所の修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -273,7 +273,7 @@ class Activity extends CRMEntity {
 		$updateQuery = "UPDATE vtiger_activity SET duration_hours = ?, duration_minutes = ? WHERE activityid = ?";
 		$adb->pquery($updateQuery, array($hours, $minutes, $this->id));
 
-		$this->updateLastActionDate();
+		$this->updateLastActionDate($module);
 	}
 
 	/** Function to insert values in vtiger_activity_reminder_popup table for the specified module
@@ -1401,7 +1401,7 @@ function insertIntoRecurringTable(& $recurObj)
 		}
 	}
 
-	public function updateLastActionDate() {
+	public function updateLastActionDate($module) {
 		global $adb, $log;
 		$accountids = array();
 		$result = $adb->pquery("SELECT contactid, activityid FROM vtiger_cntactivityrel WHERE activityid = ?",array($this->id));
@@ -1416,7 +1416,7 @@ function insertIntoRecurringTable(& $recurObj)
 			if ($accountid > 0) {
 				$accountids[] = $accountid;
 			}
-			$recordContactModel->save();
+			$recordContactModel->getEntity()->saveentity($module, $contactid);
 		}
 
 		$parent_id = $this->column_fields["parent_id"];
@@ -1427,7 +1427,7 @@ function insertIntoRecurringTable(& $recurObj)
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
 				$recordParentModel->set('last_action_date', $this->getParentLastActionDate($parent_id, $moduleName));
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Potentials") {
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
@@ -1436,7 +1436,7 @@ function insertIntoRecurringTable(& $recurObj)
 				if($accountid > 0) {
 					$accountids[] = $accountid;
 				}
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Accounts") {
 				$accountids[] = $parent_id;
 			}
@@ -1473,7 +1473,7 @@ function insertIntoRecurringTable(& $recurObj)
 				} else {
 					$accountRecordModel->set('last_action_date', null);
 				}
-				$accountRecordModel->save();
+				$accountRecordModel->getEntity()->saveentity($module, $accountRecordModel->getId());
 		}
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #755 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローのアクション「TODOの作成」より特定の条件で発火すると処理が終わらない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ワークフロー実行することで元のレコードが更新されるため無限ループとなっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. イベントを発火させないために、saveentity()に置きかえた

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
関連に活動を持つモジュール
  - 案件
  - 顧客担当者
  - 顧客企業
  - リード
  - チケット
  - 見積
  - 発注
  - 請求
  - キャンペーン
  - プロジェクト(活動を関連に持たないが、ワークフローから活動を作成可能)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
同様の修正に#535 があった。
イベントを発生させないことが目的であるので、クエリによる更新ではなくsaveentity()に置きかえた。