### PR TITLE
#797 レポートの副モジュールにカレンダーを設定した時に正しくレポートが出力されるように修正

### DIFF
--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -2995,7 +2995,8 @@ class ReportRun extends CRMEntity {
 			$secondarymodule = explode(":", $this->secondarymodule);
 			foreach ($secondarymodule as $value) {
 				if ($value == 'Calendar') {
-					$wheresql .= " AND vtiger_activity.visibility != 'Private' ";
+					$this->queryPlanner->addTable('vtiger_activity');
+					$wheresql .= " AND (vtiger_activity.visibility != 'Private' OR vtiger_activity.visibility IS NULL) ";
 				}
 			}
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #797 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートの副モジュールにカレンダーを設定して時に正しくレポートが出力されないことがあった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 非公開のスケジュールを表示しないようにvtiger_activity.visibility != 'Private' という条件があるが、レポートのカラムの選択にカレンダーのカラムが選択されていないとvtiger_activityを取得しないためここで不具合が発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 副モジュールがカレンダーだった場合はvtiger_activityを取得するよう変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/219295847-5cf71e87-be0f-434c-a855-ad00c2f95d40.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポートにおいて、カレンダーが副モジュールとして設定された場合。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->