### PR TITLE
#800 一覧画面で表示される関連項目のtooltipの表記をデータの詳細に変更

### DIFF
--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -212,6 +212,8 @@
 													{if !empty($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX + 1])},{/if}
 												</span>
 											{/foreach}
+										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'reference'}
+											{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
 										{else}
 											{$LISTVIEW_ENTRY_VALUE}
 										{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #800

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
顧客担当者等の一覧画面にて関連項目のリンクにカーソルを合わせたときに表示されるツールチップに、モジュールの項目名ではなくデータの詳細を表記したい

例えば、案件一覧を開いて関連したモジュールの項目である顧客企業名のリンクにカーソルを合わせると「顧客企業名」とだけ表示され、リンクから少しカーソルを外すと「○○会社」と詳細企業名が表示される。
顧客企業名のリンクにカーソルを合わせたときも詳細を表示したい。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
一覧画面を表示するときにデータタイプが関連ならばgetTitleを通らせた

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (53)](https://user-images.githubusercontent.com/107910164/221532652-2014f8ec-90a2-42bc-8f74-cf2f58bc089d.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
一覧表示画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->