### PR TITLE
[WIP] 見積を対象とするワークフローの活動作成にて製品名が先頭のものしか指定できない箇所の修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/Edit.js
@@ -769,7 +769,18 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
             inputElement.val(currentElement.val());
          } else {
             var oldValue = inputElement.val();
-            var newValue = oldValue + currentElement.val();
+            // 製品とサービスは複数紐づけられるため、$loop-products$で囲み全て出力する
+            var regexlp = /\$loop-products\$/;
+            var regexPS = /\((\w+) : \((Products|Services)\) (\w+)\)/;
+            var str = currentElement.val();
+            if(inputElement[0].id == 'description' && !regexlp.test(oldValue) && regexPS.test(str)){
+               str = '$loop-products$\n'+currentElement.val()+'\n\n$loop-products$\n'
+            }else if(regexPS.test(str)){
+               str = str + '\n';
+            }
+            var newValue = oldValue.substr(0, inputElement[0].selectionStart) 
+                           + str
+                           + oldValue.substr(inputElement[0].selectionStart);
             inputElement.val(newValue);
          }
       });

--- a/layouts/v7/modules/Settings/Workflows/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/Edit.js
@@ -775,8 +775,6 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
             var str = currentElement.val();
             if(inputElement[0].id == 'description' && !regexlp.test(oldValue) && regexPS.test(str)){
                str = '$loop-products$\n'+currentElement.val()+'\n\n$loop-products$\n'
-            }else if(regexPS.test(str)){
-               str = str + '\n';
             }
             var newValue = oldValue.substr(0, inputElement[0].selectionStart) 
                            + str

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -273,7 +273,7 @@ class Activity extends CRMEntity {
 		$updateQuery = "UPDATE vtiger_activity SET duration_hours = ?, duration_minutes = ? WHERE activityid = ?";
 		$adb->pquery($updateQuery, array($hours, $minutes, $this->id));
 
-		$this->updateLastActionDate();
+		$this->updateLastActionDate($module);
 	}
 
 	/** Function to insert values in vtiger_activity_reminder_popup table for the specified module
@@ -1401,7 +1401,7 @@ function insertIntoRecurringTable(& $recurObj)
 		}
 	}
 
-	public function updateLastActionDate() {
+	public function updateLastActionDate($module) {
 		global $adb, $log;
 		$accountids = array();
 		$result = $adb->pquery("SELECT contactid, activityid FROM vtiger_cntactivityrel WHERE activityid = ?",array($this->id));
@@ -1416,7 +1416,7 @@ function insertIntoRecurringTable(& $recurObj)
 			if ($accountid > 0) {
 				$accountids[] = $accountid;
 			}
-			$recordContactModel->save();
+			$recordContactModel->getEntity()->saveentity($module, $contactid);
 		}
 
 		$parent_id = $this->column_fields["parent_id"];
@@ -1427,7 +1427,7 @@ function insertIntoRecurringTable(& $recurObj)
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
 				$recordParentModel->set('last_action_date', $this->getParentLastActionDate($parent_id, $moduleName));
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Potentials") {
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
@@ -1436,7 +1436,7 @@ function insertIntoRecurringTable(& $recurObj)
 				if($accountid > 0) {
 					$accountids[] = $accountid;
 				}
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Accounts") {
 				$accountids[] = $parent_id;
 			}
@@ -1473,7 +1473,7 @@ function insertIntoRecurringTable(& $recurObj)
 				} else {
 					$accountRecordModel->set('last_action_date', null);
 				}
-				$accountRecordModel->save();
+				$accountRecordModel->getEntity()->saveentity($module, $accountRecordModel->getId());
 		}
 	}
 

--- a/modules/com_vtiger_workflow/VTSimpleTemplate.inc
+++ b/modules/com_vtiger_workflow/VTSimpleTemplate.inc
@@ -72,6 +72,16 @@ class VTSimpleTemplate{
 								}
 							}
 							return implode(',', $parts);
+						}elseif($referenceModule === 'Products' || $referenceModule === 'Services'){ //製品とサービスは複数紐づけられるので全て出力する
+							$parts = array(); 
+							foreach ($this->parent->data['LineItems'] as $key=>$value) {
+								$entity = $this->cache->forId($value['productid']);
+								$recordDetails = $entity->getData();
+								if($entity->getModuleName() == $referenceModule){
+									$parts[] = $recordDetails[$fieldname];
+								}
+							}
+							return implode(',', $parts);
 						}
 						$entity = $this->cache->forId($referenceId);
 						if($referenceModule==="Users" && $entity->getModuleName()=="Groups"){
@@ -127,12 +137,36 @@ class VTSimpleTemplate{
 
 	}
 
+	// $loop-products$で囲まれた箇所を各製品・サービスごとに出力する
+	private function matchproductsHandler($match){
+		$str = preg_replace('/\$loop-products\$/','',$match[0]);
+		$matchcount = preg_match_all('/\((\w+) : \(([_\w]+)\) (\w+)\)/',$str,$matches);
+		$result = array();
+		if(!empty($this->parent) && $matchcount != 0){
+			list($full, $referenceField, $referenceModule, $fieldname) = $matches;
+			foreach ($this->parent->data['LineItems'] as $key=>$value) {
+				$entity = $this->cache->forId($value['productid']);
+				$recordDetails = $entity->getData();
+				$parts = array();
+				for($i=0;$i<$matchcount;$i++){
+					if($entity->getModuleName() == $referenceModule[$i]){
+						$parts[] = $recordDetails[$fieldname[$i]];
+					}
+				}
+				$result[] = implode(',', $parts);
+			}
+			return implode(PHP_EOL, array_filter($result, 'strlen'));
+		}
+		return $result;
+	}
+
 	protected function useValue($data, $fieldname) {
 		return true;
 	}
 
 	function parseTemplate(){
-		return preg_replace_callback('/\\$(\w+|\((\w+) : \(([_\w]+)\) (\w+)\))/', array($this,"matchHandler"), $this->template);
+		$str = preg_replace_callback('/\$loop-products\$[\s\S]*\$loop-products\$/', array($this,"matchproductsHandler"), $this->template);
+		return preg_replace_callback('/\\$(\w+|\((\w+) : \(([_\w]+)\) (\w+)\))/', array($this,"matchHandler"), $str);
 	}
 
 	function getCompanySetting($fieldname) {

--- a/modules/com_vtiger_workflow/VTSimpleTemplate.inc
+++ b/modules/com_vtiger_workflow/VTSimpleTemplate.inc
@@ -72,16 +72,17 @@ class VTSimpleTemplate{
 								}
 							}
 							return implode(',', $parts);
-						}elseif($referenceModule === 'Products' || $referenceModule === 'Services'){ //製品とサービスは複数紐づけられるので全て出力する
-							$parts = array(); 
+						}elseif($referenceModule === 'Products' || $referenceModule === 'Services'){
+							// 製品とサービスは複数紐づけることができるので先頭のデータを出力する
+							// 全て出力したい場合は$loop-products$で囲む
 							foreach ($this->parent->data['LineItems'] as $key=>$value) {
 								$entity = $this->cache->forId($value['productid']);
 								$recordDetails = $entity->getData();
 								if($entity->getModuleName() == $referenceModule){
-									$parts[] = $recordDetails[$fieldname];
+									return $recordDetails[$fieldname];
 								}
 							}
-							return implode(',', $parts);
+							return '';
 						}
 						$entity = $this->cache->forId($referenceId);
 						if($referenceModule==="Users" && $entity->getModuleName()=="Groups"){
@@ -139,23 +140,30 @@ class VTSimpleTemplate{
 
 	// $loop-products$で囲まれた箇所を各製品・サービスごとに出力する
 	private function matchproductsHandler($match){
-		$str = preg_replace('/\$loop-products\$/','',$match[0]);
-		$matchcount = preg_match_all('/\((\w+) : \(([_\w]+)\) (\w+)\)/',$str,$matches);
-		$result = array();
+		$str_origin = preg_replace('/[\r\n]?\$loop-products\$[\r\n]?/','',$match[0]);
+		$matchcount = preg_match_all('/\((\w+) : \(([_\w]+)\) (\w+)\)/',$str_origin,$matches);
+		$result = '';
 		if(!empty($this->parent) && $matchcount != 0){
 			list($full, $referenceField, $referenceModule, $fieldname) = $matches;
+			$block = array();
 			foreach ($this->parent->data['LineItems'] as $key=>$value) {
 				$entity = $this->cache->forId($value['productid']);
 				$recordDetails = $entity->getData();
-				$parts = array();
+				if($entity->getModuleName() != $referenceModule[0]) continue;
+				$str = $str_origin;
 				for($i=0;$i<$matchcount;$i++){
-					if($entity->getModuleName() == $referenceModule[$i]){
-						$parts[] = $recordDetails[$fieldname[$i]];
+					$regex = '/\$\(('.$referenceField[$i].') : \(('.$referenceModule[$i].')\) ('.$fieldname[$i].')\)/';
+					if($referenceModule[$i] === '__VtigerMeta__' || $fieldname[$i] === 'dbLabel') {
+						$str = preg_replace($regex,$this->getMetaValue($fieldname[$i]),$str);
+					} else if ('__VtigerCompany__' == $referenceModule[$i]) {
+						$str = preg_replace($regex,$this->getCompanySetting($fieldname[$i]),$str);
+					}else{
+						$str = preg_replace($regex,$recordDetails[$fieldname[$i]],$str);
 					}
 				}
-				$result[] = implode(',', $parts);
+				$block[] = $str;
 			}
-			return implode(PHP_EOL, array_filter($result, 'strlen'));
+			$result = implode(PHP_EOL, $block);
 		}
 		return $result;
 	}
@@ -165,7 +173,7 @@ class VTSimpleTemplate{
 	}
 
 	function parseTemplate(){
-		$str = preg_replace_callback('/\$loop-products\$[\s\S]*\$loop-products\$/', array($this,"matchproductsHandler"), $this->template);
+		$str = preg_replace_callback('/\$loop-products\$[\s\S]*?\$loop-products\$/', array($this,"matchproductsHandler"), $this->template);
 		return preg_replace_callback('/\\$(\w+|\((\w+) : \(([_\w]+)\) (\w+)\))/', array($this,"matchHandler"), $str);
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #799 
- merge #796 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 見積を対象とするワークフローの活動作成にて、製品名が先頭のものしか指定できない。サービスが先頭にある場合、何も出力されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 製品とサービスは1つの見積に複数紐づけられるにも関わらず、他の項目と同様に処理されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `$loop-products$`で囲まれている項目は全製品を出力する
2. `$loop-products$`で囲まれていない項目は先頭のレコードのデータを出力する
3. 入力欄にてカーソルの位置に項目を入力できるようにする
4. 製品・サービスの項目を選択した場合、`$loop-products$`を自動挿入する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* 入力(ワークフロー)
![image](https://user-images.githubusercontent.com/75693720/222331823-f5889167-2eb4-4a6c-9f6a-f551674c2a2b.png)
* 出力(活動)
![image](https://user-images.githubusercontent.com/75693720/222331761-520aaeb7-891b-40aa-ae6b-395e575bcd4b.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* メールでの挙動が未確認(WIP)