### PR TITLE
#790 選択肢項目に存在しない値をインポートしたとき、選択肢に追加しないよう修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -666,12 +666,15 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 						$moduleObject = Vtiger_Module::getInstance($moduleName);
 						$fieldObject = Vtiger_Field::getInstance($fieldName, $moduleObject);
-						$fieldObject->setPicklistValues(array($fieldValue));
-
+						//$fieldObject->setPicklistValues(array($fieldValue));
 						// Update cache state with new value added.
 						$wsFieldDetails[] = array('label' => $fieldValue, 'value' => $fieldValue);
-						Vtiger_Cache::getInstance()->setPicklistDetails($moduleObject->getId(), $fieldName, $wsFieldDetails);
+						//Vtiger_Cache::getInstance()->setPicklistDetails($moduleObject->getId(), $fieldName, $wsFieldDetails);
+						$fieldData[$fieldName] = $defaultFieldValues[$fieldName];
 
+						unset($this->allPicklistValues[$fieldName]);
+					} else {
+						$fieldData[$fieldName] = $defaultFieldValues[$fieldName];
 						unset($this->allPicklistValues[$fieldName]);
 					}
 				} else {
@@ -1057,7 +1060,9 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							}
 						} else if (!in_array($fieldName, array('date_start', 'due_date'))) {
 							if ($fieldModel) {
-								$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
+								if ($fieldDataType != 'picklist'){
+									$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #790 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーや案件等をインポートする際に選択肢項目に存在しない値が入っている場合、新たに選択肢に追加してしまう
2. カレンダーをインポートする際に選択肢項目の値が入らない（詳細画面では確認できるが編集画面を開くと空欄になる）。

##  原因 / Cause
<!-- バグの原因を記述 -->
1.仕様
2.インポートする際に選択肢項目をgetDisplayValueに通していたため、翻訳語の値がdbに登録されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インポートした値が項目の選択肢内に存在しない場合、デフォルトの値があればその値を入れ、なければ空欄になるように修正した。必須項目の場合は詳細画面上では???になり編集画面を開くと空欄になる。
2. 選択肢項目の場合はgetDisplayValueを通さないように修正した。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
インポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
#767 の修正も同時に機能しました
