### PR TITLE
ワークフローのアクションの選択肢をRAW入力できるようにする

### DIFF
--- a/data/VTEntityDelta.php
+++ b/data/VTEntityDelta.php
@@ -124,7 +124,7 @@ class VTEntityDelta extends VTEventHandler {
 			$fieldDelta_currentValue = explode(' |##| ', $fieldDelta['currentValue']);
 			$result = !empty(array_diff($fieldDelta_oldValue, $fieldDelta_currentValue)) || !empty(array_diff($fieldDelta_currentValue, $fieldDelta_oldValue));
 			if ($fieldValue !== NULL) { //$fieldValueは「～に変更された」条件のとき
-				$fieldValue = explode(',', $fieldValue);
+				$fieldValue = explode(' |##| ', $fieldValue);
 				$result = $result && (empty(array_diff($fieldValue, $fieldDelta_currentValue)) && empty(array_diff($fieldDelta_currentValue, $fieldValue)));
 			}
         }else{

--- a/languages/en_us/Settings/Workflows.php
+++ b/languages/en_us/Settings/Workflows.php
@@ -35,6 +35,7 @@ $languageStrings = array(
 	'LBL_SET_VALUE' => 'Set Value',
 	'LBL_USE_FIELD' => 'Use Field',
 	'LBL_USE_FUNCTION' => 'Use Function',
+	'LBL_USE_PICKLIST' => 'Use Pick list',
 	'LBL_RAW_TEXT' => 'Raw text',
 	'LBL_ENABLE_TO_CREATE_FILTERS' => 'Enable to create Filters',
 	'LBL_CREATED_IN_OLD_LOOK_CANNOT_BE_EDITED' => 'This workflow was created in older look. Conditions created in older look cannot be edited. You can choose to recreate the conditions, or use the existing conditions without changing them.',

--- a/languages/ja_jp/Settings/Workflows.php
+++ b/languages/ja_jp/Settings/Workflows.php
@@ -35,6 +35,7 @@ $languageStrings = array(
 	'LBL_SET_VALUE' => '値の設定',
 	'LBL_USE_FIELD' => '--項目の値を使用--',
 	'LBL_USE_FUNCTION' => '-- 関数を使用 --',
+	'LBL_USE_PICKLIST' => '-- 選択肢を使用 --',
 	'LBL_RAW_TEXT' => 'RAWテキスト',
 	'LBL_ENABLE_TO_CREATE_FILTERS' => 'リストを作成するには有効にします',
 	'LBL_CREATED_IN_OLD_LOOK_CANNOT_BE_EDITED' => 'このワークフローは旧方式にて作成されました 旧方式で作成された条件は編集できません。 条件を再作成するか、既存の条件を変更なしに使用します。',

--- a/layouts/v7/modules/Settings/Workflows/FieldExpressions.tpl
+++ b/layouts/v7/modules/Settings/Workflows/FieldExpressions.tpl
@@ -55,6 +55,10 @@
                             {/foreach}
                     </select>
                 </div>
+                <div class="col-sm-4 hide usePicklistContainer">
+                    <select id="usePicklist" class="usePicklist pull-right" data-placeholder="{vtranslate('LBL_USE_PICKLIST',$QUALIFIED_MODULE)}" style="min-width: 160px;" type="">
+                    </select>
+                </div>
             </div><br>
             <div class="row fieldValueContainer">
                 <div class="col-sm-12">

--- a/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
@@ -412,27 +412,22 @@ Vtiger_Field_Js('Vtiger_Boolean_Field_Js',{},{
 Vtiger_Owner_Field_Js('Workflows_Owner_Field_Js',{},{
 
     getUi : function() {
-        var html = '<select class="inputElement select2" name="'+ this.getName() +'">';
-        html += '<option value="">&nbsp;</option>';
+        // Workflowアクション設定：owner型で「項目選択」ができるよう、String型の getUi と同じ処理に変更
+        var html = '<input type="text" class="getPopupUi inputElement" name="'+ this.getName() +'"  /><input type="hidden" name="valuetype" value="'+this.get('workflow_valuetype')+'" />';
+        html = jQuery(html);
+        // デフォルト値をIDではなくユーザー名で表示する
         var pickListValues = this.getPickListValues();
-        var selectedOption = this.getValue();
+        var pickListValue = this.getValue();
         for(var optGroup in pickListValues){
-            html += '<optgroup label="'+ optGroup +'">';
             var optionGroupValues = pickListValues[optGroup];
-            for(var option in optionGroupValues) {
-                html += '<option value="'+option+'" ';
-                if(option == selectedOption) {
-                    html += ' selected ';
+            for(var option in optionGroupValues){
+                if(option == this.getValue()){
+                    pickListValue = optionGroupValues[this.getValue()];
                 }
-                html += '>'+optionGroupValues[option]+'</option>';
             }
-            html += '</optgroup>'
         }
-
-        html +='</select>';
-        var selectContainer = jQuery(html);
-		this.addValidationToElement(selectContainer);
-        return selectContainer;
+        html.filter('.getPopupUi').val(app.htmlDecode(pickListValue));
+        return this.addValidationToElement(html);
     }
 });
 

--- a/layouts/v7/modules/Settings/Workflows/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/Edit.js
@@ -131,6 +131,25 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
          var conditionsContainer = fieldValueElement.closest('.conditionsContainer');
          var conditionRow = fieldValueElement.closest('.conditionRow');
 
+         var fieldinfo = fieldUiHolder.find('[name="valuetype"]').data('fieldinfo');
+         var listtype = fieldinfo.type;
+         var usePicklist = jQuery('#usePicklist');
+         usePicklist.empty();
+         if(listtype == 'multipicklist' || listtype == 'picklist'){
+            var picklistvalue = fieldinfo.picklistvalues;
+            usePicklist.attr('type', listtype)
+            usePicklist.parent().removeClass('hide');
+            usePicklist.append('<option></option>');
+            Object.keys(picklistvalue).forEach(function(key) {
+               var val = this[key];
+               var str = '<option value="' + key + '">'+ val +'</option>';
+               usePicklist.append(str);
+            }, picklistvalue);
+         }else{
+            usePicklist.removeAttr('type');
+            usePicklist.parent().addClass('hide');
+         }
+
          var clonedPopupUi = conditionsContainer.find('.popupUi').clone(true, true).removeClass('hide').removeClass('popupUi').addClass('clonedPopupUi');
          clonedPopupUi.find('select').addClass('select2');
          clonedPopupUi.find('.fieldValue').val(fieldValue);
@@ -231,7 +250,7 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
    },
    
    registerSelectOptionEvent: function (data) {
-      jQuery('.useField,.useFunction', data).on('change', function (e) {
+      jQuery('.useField,.useFunction,.usePicklist', data).on('change', function (e) {
          var currentElement = jQuery(e.currentTarget);
          var newValue = currentElement.val();
          var oldValue = data.find('.fieldValue').filter(':visible').val();
@@ -241,6 +260,13 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
             if (oldValue != '' && textType != 'fieldname') {
                var concatenatedValue = oldValue + ' ' + newValue;
             } else {
+               concatenatedValue = newValue;
+            }
+         } else if (currentElement.hasClass('usePicklist')) {
+            var listtype = currentElement.closest('.clonedPopupUi').find('select.usePicklist').attr('type');
+            if (oldValue != '' && listtype == 'multipicklist') {
+               concatenatedValue = oldValue + ' |##| ' + newValue;
+            }else {
                concatenatedValue = newValue;
             }
          } else {
@@ -255,18 +281,26 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
          var valueType = jQuery(e.currentTarget).val();
          var useFieldContainer = jQuery('.useFieldContainer', data);
          var useFunctionContainer = jQuery('.useFunctionContainer', data);
+         var usePicklistContainer = jQuery('.usePicklistContainer', data);
          var uiType = jQuery(e.currentTarget).find('option:selected').data('ui');
          jQuery('.fieldValue', data).hide();
          jQuery('[data-' + uiType + ']', data).show();
-         if (valueType == 'fieldname') {
+         if (valueType == 'rawtext' && document.getElementById('usePicklist').childElementCount > 1) {
+            useFieldContainer.addClass('hide');
+            useFunctionContainer.addClass('hide');
+            usePicklistContainer.removeClass('hide');
+         } else if (valueType == 'fieldname') {
             useFieldContainer.removeClass('hide');
             useFunctionContainer.addClass('hide');
+            usePicklistContainer.addClass('hide');
          } else if (valueType == 'expression') {
             useFieldContainer.removeClass('hide');
             useFunctionContainer.removeClass('hide');
+            usePicklistContainer.addClass('hide');
          } else {
             useFieldContainer.addClass('hide');
             useFunctionContainer.addClass('hide');
+            usePicklistContainer.addClass('hide');
          }
          jQuery('.helpmessagebox', data).addClass('hide');
          jQuery('#' + valueType + '_help', data).removeClass('hide');

--- a/layouts/v7/modules/Settings/Workflows/resources/Edit.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/Edit.js
@@ -629,38 +629,9 @@ Settings_Vtiger_Edit_Js("Settings_Workflows_Edit_Js", {
                   rowValues[field] = jQuery('[name="' + field + '"]', rowElement).val();
                }
             }
-         } else if (fieldType == 'picklist' || fieldType == 'multipicklist') {
-            for (var key in fieldList) {
-               var field = fieldList[key];
-               if (field == 'value' && valueSelectElement.is('input')) {
-                  var commaSeperatedValues = valueSelectElement.val();
-                  var pickListValues = valueSelectElement.data('picklistvalues');
-                  var valuesArr = commaSeperatedValues.split(',');
-                  var newvaluesArr = [];
-                  for (i = 0; i < valuesArr.length; i++) {
-                     if (typeof pickListValues[valuesArr[i]] != 'undefined') {
-                        newvaluesArr.push(pickListValues[valuesArr[i]]);
-                     } else {
-                        newvaluesArr.push(valuesArr[i]);
-                     }
-                  }
-                  var reconstructedCommaSeperatedValues = newvaluesArr.join(',');
-                  rowValues[field] = reconstructedCommaSeperatedValues;
-               } else if (field == 'value' && valueSelectElement.is('select') && fieldType == 'picklist') {
-                  rowValues[field] = valueSelectElement.val();
-               } else if (field == 'value' && valueSelectElement.is('select') && fieldType == 'multipicklist') {
-                  var value = valueSelectElement.val();
-                  if (value == null) {
-                     rowValues[field] = value;
-                  } else {
-                     rowValues[field] = value.join(',');
-                  }
-               } else {
-                  rowValues[field] = jQuery('[name="' + field + '"]', rowElement).val();
-               }
-            }
-
          } else if (fieldType == 'text') {
+            // Workflowアクション設定：picklist型処理をString型と同じ処理にするため、条件変更
+            // Workflowアクション設定：multipicklist型処理をString型と同じ処理にするため、条件変更
             for (var key in fieldList) {
                var field = fieldList[key];
                if (field == 'value') {

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -273,7 +273,7 @@ class Activity extends CRMEntity {
 		$updateQuery = "UPDATE vtiger_activity SET duration_hours = ?, duration_minutes = ? WHERE activityid = ?";
 		$adb->pquery($updateQuery, array($hours, $minutes, $this->id));
 
-		$this->updateLastActionDate();
+		$this->updateLastActionDate($module);
 	}
 
 	/** Function to insert values in vtiger_activity_reminder_popup table for the specified module
@@ -1401,7 +1401,7 @@ function insertIntoRecurringTable(& $recurObj)
 		}
 	}
 
-	public function updateLastActionDate() {
+	public function updateLastActionDate($module) {
 		global $adb, $log;
 		$accountids = array();
 		$result = $adb->pquery("SELECT contactid, activityid FROM vtiger_cntactivityrel WHERE activityid = ?",array($this->id));
@@ -1416,7 +1416,7 @@ function insertIntoRecurringTable(& $recurObj)
 			if ($accountid > 0) {
 				$accountids[] = $accountid;
 			}
-			$recordContactModel->save();
+			$recordContactModel->getEntity()->saveentity($module, $contactid);
 		}
 
 		$parent_id = $this->column_fields["parent_id"];
@@ -1427,7 +1427,7 @@ function insertIntoRecurringTable(& $recurObj)
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
 				$recordParentModel->set('last_action_date', $this->getParentLastActionDate($parent_id, $moduleName));
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Potentials") {
 				$recordParentModel->set('id', $parent_id);
 				$recordParentModel->set('mode', 'edit');
@@ -1436,7 +1436,7 @@ function insertIntoRecurringTable(& $recurObj)
 				if($accountid > 0) {
 					$accountids[] = $accountid;
 				}
-				$recordParentModel->save();
+				$recordParentModel->getEntity()->saveentity($module, $parent_id);
 			} elseif ($moduleName == "Accounts") {
 				$accountids[] = $parent_id;
 			}
@@ -1473,7 +1473,7 @@ function insertIntoRecurringTable(& $recurObj)
 				} else {
 					$accountRecordModel->set('last_action_date', null);
 				}
-				$accountRecordModel->save();
+				$accountRecordModel->getEntity()->saveentity($module, $accountRecordModel->getId());
 		}
 	}
 

--- a/modules/Settings/Workflows/models/Record.php
+++ b/modules/Settings/Workflows/models/Record.php
@@ -489,7 +489,11 @@ class Settings_Workflows_Record_Model extends Settings_Vtiger_Record_Model {
 						$value = $currencyName[0];
 					}
 					if ($fieldModel && (in_array($fieldDataType, array('picklist', 'multipicklist')))) {
-						$picklistValues = explode(',', $value);
+						if ($value && strpos($value, ' |##| ') !== false){
+							$picklistValues = explode(' |##| ', $value);
+						} else {
+							$picklistValues = explode(',', $value);
+						}
 						if (count($picklistValues) > 1) {
 							$translatedValues = array();
 							foreach ($picklistValues as $selectedValue) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
merge #796 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローのアクションの選択肢をRAW入力できるようにしたい
2. 単数・複数選択肢・担当の場合、選択肢を選択できるようにしたい
3. #796 

※ 3について、こちらの修正を加えないと動作しなかったため追加しています。
##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 単数・複数選択肢・担当項目の場合もウィンドウをポップアップさせるように修正
2. 単数・複数選択肢・担当の場合、「--選択肢を使用--」から選択肢を選択できるようにする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
- ポップアップウィンドウ(複数選択肢項目)
![image](https://user-images.githubusercontent.com/75693720/223936153-2e414e08-46ab-4701-85dd-38c694ccb1bd.png)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- ワークフロー条件「単数選択肢」「複数選択肢」「担当」
- ワークフローアクション「項目の値の更新」

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->