### PR TITLE
headlesschromeのpdf出力機能を追加

### DIFF
--- a/config.template.php
+++ b/config.template.php
@@ -84,6 +84,11 @@ $site_URL = '_SITE_URL_';
 
 // url for customer portal (Example: http://vtiger.com/portal)
 $PORTAL_URL = $site_URL.'/customerportal';
+
+$is_headlesschrome = false;
+// url for headlesschrome
+$chromeurl = "headlesschrome/converthtmltopdf.php";
+
 // root directory path
 $root_directory = '_VT_ROOTDIR_';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,29 @@ services:
       # Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
       XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
       TZ: "Asia/Tokyo"
+  webdb:
+    container_name: headlesschrome
+    image: headlesschrome:latest
+    build:
+      context: "."
+      dockerfile: ./docker/headlesschrome/Dockerfile
+    volumes:
+      - ./docker/chrome-headless:/var/www/html
+      - ./test:/var/www/html/html2pdf/test
+    ports:
+     - "30080:80"
+    privileged: true
+    # command: /sbin/init
+    command: >
+      sh -c 'usermod -u `stat -c %u /html2pdf/` www-data
+             groupmod -g `stat -c %u /html2pdf/` www-data
+             chown -R www-data.www-data /var/www/html
+             chown -R www-data.www-data /html2pdf
+             exec /sbin/init'
+    dns: 8.8.8.8
+    # 自動起動の有効化
+    restart: always
+
   db:
     build:
       context: "."

--- a/docker/chrome-headless/Dockerfile
+++ b/docker/chrome-headless/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu
+RUN apt update -y
+RUN apt install -y wget unzip
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install  tzdata libu2f-udev libvulkan1 -y
+RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt-get install fonts-liberation libasound2 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2   libexpat1 libgbm1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 libcurl3-gnutls libcurl3-nss libcurl4 xdg-utils fonts-noto -y
+RUN fc-cache -fv
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install libappindicator1 -y
+RUN dpkg -i google-chrome-stable_current_amd64.deb
+RUN apt -f install -y
+RUN apt install apache2 php -y
+RUN apt-get autoremove -y
+COPY converthtmltopdf.php /var/www/html/converthtmltopdf.php
+RUN chown -R www-data.www-data /var/www/html/

--- a/docker/chrome-headless/README.md
+++ b/docker/chrome-headless/README.md
@@ -1,0 +1,21 @@
+1. Install Docker (If installed, skip this.)
+1. Execute buildDockerImage.sh
+1. config.inc.phpの編集
+```php
+$is_headlesschrome = true;// trueの場合：headless chromeを使用。falseの場合：TCPDFを使用。
+$chromeurl = "headlesschrome/converthtmltopdf.php";// headlless chromeの場所 同じdockerネットワークに属している場合は左記のurlになる
+```
+```bash
+#動かない場合は以下を参考にパーミッションを変更する
+centosの場合は以下を実行する
+#docker内に入る
+docker exec -ti headlesschrome /bin/bash
+#uid48をwww-dataユーザーに設定する
+systemctl stop apache2
+usermod -u 48 www-data
+groupmod -g 48 www-data
+#/var/www/htmlディレクトリの所有者をwww-dataにする。
+chown -R www-data.www-data /var/www/html
+systemctl start apache2
+```
+end

--- a/docker/chrome-headless/converthtmltopdf.php
+++ b/docker/chrome-headless/converthtmltopdf.php
@@ -1,0 +1,8 @@
+<?php
+$filepath = $_POST['filepath'];
+
+
+if($filepath){
+    shell_exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --print-to-pdf-no-header --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html");
+    shell_exec("chmod a+r ".$filepath . ".pdf");
+}

--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -296,7 +296,7 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 		$recordId = $this->getId();
 		$moduleName = $this->getModuleName();
 
-		global $adb;
+		global $adb, $is_headlesschrome;
 		$template = null;
 
 		$result = $adb->pquery("SELECT templatename, body FROM vtiger_pdftemplates WHERE templateid = ?", array($templateId));
@@ -308,22 +308,27 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 			$template = Vtiger_InventoryPDFController::getMergedDescription($template, $recordId, $moduleName);
 		}
 
-		$tcpdf = new TCPDF();
-		$tcpdf->setPrintHeader(false);
-		$tcpdf->setPrintFooter(false);
-		$tcpdf->AddPage();
-		$tcpdf->SetFont('ume-tgo4','B');
-		$tcpdf->writeHTML($template);
-		$pdf = $tcpdf->Output($templateName.'.pdf', 'S');//Dの場合は日本語が消える
-		if(!$isheader) return $pdf;
+		if(!$is_headlesschrome){
+			$tcpdf = new TCPDF();
+			$tcpdf->setPrintHeader(false);
+			$tcpdf->setPrintFooter(false);
+			$tcpdf->AddPage();
+			$tcpdf->SetFont('ume-tgo4','B');
+			$tcpdf->writeHTML($template);
+			$pdf = $tcpdf->Output($templateName.'.pdf', 'S');//Dの場合は日本語が消える
+			if(!$isheader) return $pdf;
 
-		header("Pragma: public");
-		header("Expires: 0");
-		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-		header("Content-Transfer-Encoding: binary ");
-		header('Content-Type: application/octet-streams');
-		header("Content-Disposition: attachment; filename=\"{$templateName}.pdf\"");
-		echo $pdf;
+			header("Pragma: public");
+			header("Expires: 0");
+			header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+			header("Content-Transfer-Encoding: binary ");
+			header('Content-Type: application/octet-streams');
+			header("Content-Disposition: attachment; filename=\"{$templateName}.pdf\"");
+			echo $pdf;
+		}else{
+			if(!$isheader) return $this->getPDFfromheadlesschrome($template ,$templateName,$isheader);
+			$this->getPDFfromheadlesschrome($template ,$templateName,$isheader);
+		}
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #711 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. pdf出力を行う際にheadlesschromeを使いたい。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. headlesschrome用のコンテナを立てた。
1. config.inc.phpの$is_headlesschromeがtrueかどうかを確認しturueの場合、htmlファイルのパスをchromeのコンテナに投げて、そのファイルをpdfに変換するようになっている。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
headlesschrome利用時
![image](https://user-images.githubusercontent.com/95267222/224246026-e5c7e520-f667-4384-8a85-a5367900f7d4.png)

tcpdf利用時
![image](https://user-images.githubusercontent.com/95267222/224246211-ee54bf86-fbfe-4066-923d-817e2d7e12ea.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
・pdf出力の範囲。
・dockerのコンテナが一つ増える。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
headlesschromeを用いたPDFのレイアウトがあまりきれいではない。
修正しだい、pushいたします。