### PR TITLE
#810 PDFテンプレートのリスト画面でドロップダウンが消えない不具合の修正

### DIFF
--- a/layouts/v7/modules/PDFTemplates/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/PDFTemplates/ListViewRecordActions.tpl
@@ -16,7 +16,7 @@
     </span>
     {/if}
     <span class="more dropdown action">
-        <a href="javascript:;" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-ellipsis-v icon"></i></a>
+        <span href="javascript:;" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-ellipsis-v icon"></i></span>
         <ul class="dropdown-menu">
             <li><a data-id="{$LISTVIEW_ENTRY->getId()}" href="{$LISTVIEW_ENTRY->getFullDetailViewUrl()}">{vtranslate('LBL_DETAILS', $MODULE)}</a></li>
             <li><a data-id="{$LISTVIEW_ENTRY->getId()}" href="javascript:void(0);" data-url="{$LISTVIEW_ENTRY->getEditViewUrl()}" name="editlink">{vtranslate('LBL_EDIT', $MODULE)}</a></li>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #810

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
PDFテンプレートのリストにて、ボタンを押したときに表示されるドロップダウンがページを更新しない限り消えない。

##  原因 / Cause
<!-- バグの原因を記述 -->
PDFテンプレートのドロップダウンを表示する箇所のタグがspanではなくaタグになっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
aタグをspanタグに変更


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
PDFテンプレートリストのドロップダウン

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -箇所