### PR TITLE
#726 関連項目として価格表を設定できない不具合を修正

### DIFF
--- a/modules/PriceBooks/views/Popup.php
+++ b/modules/PriceBooks/views/Popup.php
@@ -37,7 +37,7 @@ class PriceBooks_Popup_View extends Vtiger_Popup_View {
 		}
 
 		if(empty($getUrl) && !empty($sourceField) && !$multiSelectMode) {
-			$getUrl = 'getProductListPriceURL';
+			$getUrl = 'getParentPopupContentsUrl';
 		}
 
 		if(empty($cvId)) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #726

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
関連項目として価格表を登録しても設定できない。
1,任意モジュール（例として案件）の項目設定にて価格表を関連に持つ項目を作成する。
2,案件の作成・編集画面から登録した項目で任意の価格表を選択する。
3,選択した価格表が反映されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
関連項目にて価格表がリストで表示されるが、リスト内に表示されている価格表が持っているdata-urlの値が正しくなかったため、選択しても反映されなかった。（data-urlはなくても反映された）

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
リストで表示される際に持っているdata-urlを他モジュールと同じ関数で取得するように変更した。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
関連としての価格表

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
正しくないurlを生成している関数を、InventoryのEdit.js内の関数pricebooksPopupHandlerでも使用していたが、呼び出すタイミングがわからなかったため、Edit.js内は変更しなかった。