### PR TITLE
#816 ユーザー画像が一部表示されない不具合を修正

### DIFF
--- a/layouts/v7/modules/Users/UserViewHeader.tpl
+++ b/layouts/v7/modules/Users/UserViewHeader.tpl
@@ -14,7 +14,7 @@
     <div class="col-sm-12 col-xs-12">
         <div class="detailViewTitle" id="userPageHeader">
             <div class = "row">
-                <div class="col-md-5">
+                <div class="col-md-5" style="margin-top: 18px;">
                     <div class="col-md-5 recordImage" style="height: 50px;width: 50px;">
                         {assign var=NOIMAGE value=0}
                         {foreach key=ITER item=IMAGE_INFO from=$RECORD->getImageDetails()}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #816

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー画面にて、ユーザー画像が一部表示されない場合がある。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ユーザー画像の余白が十分でなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ユーザー画像の上部に余白を追加した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット (71)](https://user-images.githubusercontent.com/86254425/229424704-5c56ff08-fa98-4791-9a4d-16d3a71ee348.png)
![スクリーンショット (70)](https://user-images.githubusercontent.com/86254425/229424736-eea5c611-f430-42c0-8bd1-69ac857922e4.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー画像の表示範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->