### PR TITLE
headless chromeのPDF出力機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Vtiger Public License 1.2
 * F-RevoCRM6.5からのバージョンアップはインストール方法の後に記載があります。
 * F-RevoCRM7.3のパッチ適用方法については各パッチ付属のREADMEを参照してください。
 * 本レポジトリをDockerで構築する場合は、[docker/README.md](./docker/README.md)を参照してください。
+* PDF出力にheadlesschromeを利用する場合は、[docker/chrome-headless/README.md](./docker/chrome-headless/README.md)を参照してください。
 
 ### configファイルを独自に設定する場合
 configファイルは`config.inc.php`として、インストール後に生成されます。  

--- a/config.customize.php
+++ b/config.customize.php
@@ -1,6 +1,6 @@
 <?php
 
-$is_headlesschrome = true;
+$is_headlesschrome = false;
 // url for headlesschrome
 $chromeurl = "headlesschrome/converthtmltopdf.php";
 

--- a/config.customize.php
+++ b/config.customize.php
@@ -1,0 +1,7 @@
+<?php
+
+$is_headlesschrome = true;
+// url for headlesschrome
+$chromeurl = "headlesschrome/converthtmltopdf.php";
+
+?>

--- a/config.template.php
+++ b/config.template.php
@@ -84,6 +84,11 @@ $site_URL = '_SITE_URL_';
 
 // url for customer portal (Example: http://vtiger.com/portal)
 $PORTAL_URL = $site_URL.'/customerportal';
+
+$is_headlesschrome = false;
+// url for headlesschrome
+$chromeurl = "headlesschrome/converthtmltopdf.php";
+
 // root directory path
 $root_directory = '_VT_ROOTDIR_';
 

--- a/config.template.php
+++ b/config.template.php
@@ -84,11 +84,6 @@ $site_URL = '_SITE_URL_';
 
 // url for customer portal (Example: http://vtiger.com/portal)
 $PORTAL_URL = $site_URL.'/customerportal';
-
-$is_headlesschrome = false;
-// url for headlesschrome
-$chromeurl = "headlesschrome/converthtmltopdf.php";
-
 // root directory path
 $root_directory = '_VT_ROOTDIR_';
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
       XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
       TZ: "Asia/Tokyo"
-  webdb:
+  headlesschrome:
     container_name: headlesschrome
     image: headlesschrome:latest
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,29 @@ services:
       # Xdebugの設定を有効にしたい場合は、mode=debug に変更してください
       XDEBUG_CONFIG: "mode=off client_host=host.docker.internal client_port=9003 start_with_request=yes"
       TZ: "Asia/Tokyo"
+  webdb:
+    container_name: headlesschrome
+    image: headlesschrome:latest
+    build:
+      context: "."
+      dockerfile: ./docker/headlesschrome/Dockerfile
+    volumes:
+      - ./docker/chrome-headless:/var/www/html
+      - ./test:/var/www/html/html2pdf/test
+    ports:
+     - "30080:80"
+    privileged: true
+    # command: /sbin/init
+    command: >
+      sh -c 'usermod -u `stat -c %u /html2pdf/` www-data
+             groupmod -g `stat -c %u /html2pdf/` www-data
+             chown -R www-data.www-data /var/www/html
+             chown -R www-data.www-data /html2pdf
+             exec /sbin/init'
+    dns: 8.8.8.8
+    # 自動起動の有効化
+    restart: always
+
   db:
     build:
       context: "."

--- a/docker/chrome-headless/Dockerfile
+++ b/docker/chrome-headless/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu
+RUN apt update -y
+RUN apt install -y wget unzip
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install  tzdata libu2f-udev libvulkan1 -y
+RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt-get install fonts-liberation libasound2 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2   libexpat1 libgbm1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 libcurl3-gnutls libcurl3-nss libcurl4 xdg-utils fonts-noto -y
+RUN fc-cache -fv
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install libappindicator1 -y
+RUN dpkg -i google-chrome-stable_current_amd64.deb
+RUN apt -f install -y
+RUN apt install apache2 php -y
+RUN apt-get autoremove -y
+COPY converthtmltopdf.php /var/www/html/converthtmltopdf.php
+RUN chown -R www-data.www-data /var/www/html/

--- a/docker/chrome-headless/README.md
+++ b/docker/chrome-headless/README.md
@@ -1,0 +1,21 @@
+1. Install Docker (If installed, skip this.)
+1. Execute buildDockerImage.sh
+1. config.inc.phpの編集
+```php
+$is_headlesschrome = true;// trueの場合：headless chromeを使用。falseの場合：TCPDFを使用。
+$chromeurl = "headlesschrome/converthtmltopdf.php";// headlless chromeの場所 同じdockerネットワークに属している場合は左記のurlになる
+```
+```bash
+#動かない場合は以下を参考にパーミッションを変更する
+centosの場合は以下を実行する
+#docker内に入る
+docker exec -ti headlesschrome /bin/bash
+#uid48をwww-dataユーザーに設定する
+systemctl stop apache2
+usermod -u 48 www-data
+groupmod -g 48 www-data
+#/var/www/htmlディレクトリの所有者をwww-dataにする。
+chown -R www-data.www-data /var/www/html
+systemctl start apache2
+```
+end

--- a/docker/chrome-headless/README.md
+++ b/docker/chrome-headless/README.md
@@ -5,12 +5,14 @@
 $is_headlesschrome = true;// trueの場合：headless chromeを使用。falseの場合：TCPDFを使用。
 $chromeurl = "headlesschrome/converthtmltopdf.php";// headlless chromeの場所 同じdockerネットワークに属している場合は左記のurlになる
 ```
-```bash
 #動かない場合は以下を参考にパーミッションを変更する
 centosの場合は以下を実行する
 #docker内に入る
+```bash
 docker exec -ti headlesschrome /bin/bash
+```
 #uid48をwww-dataユーザーに設定する
+```bash
 systemctl stop apache2
 usermod -u 48 www-data
 groupmod -g 48 www-data

--- a/docker/chrome-headless/README.md
+++ b/docker/chrome-headless/README.md
@@ -1,6 +1,6 @@
 1. Install Docker (If installed, skip this.)
 1. Execute buildDockerImage.sh
-1. config.inc.phpの編集
+1.  config.customize.phpの編集
 ```php
 $is_headlesschrome = true;// trueの場合：headless chromeを使用。falseの場合：TCPDFを使用。
 $chromeurl = "headlesschrome/converthtmltopdf.php";// headlless chromeの場所 同じdockerネットワークに属している場合は左記のurlになる

--- a/docker/chrome-headless/converthtmltopdf.php
+++ b/docker/chrome-headless/converthtmltopdf.php
@@ -1,0 +1,8 @@
+<?php
+$filepath = $_POST['filepath'];
+
+
+if($filepath){
+    shell_exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --print-to-pdf-no-header --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html");
+    shell_exec("chmod a+r ".$filepath . ".pdf");
+}

--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -296,8 +296,10 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 		$recordId = $this->getId();
 		$moduleName = $this->getModuleName();
 
-		global $adb, $is_headlesschrome;
+		global $adb;
 		$template = null;
+		include_once('config.customize.php');
+		
 
 		$result = $adb->pquery("SELECT templatename, body FROM vtiger_pdftemplates WHERE templateid = ?", array($templateId));
 		if($adb->num_rows($result) > 0) {

--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -296,7 +296,7 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 		$recordId = $this->getId();
 		$moduleName = $this->getModuleName();
 
-		global $adb;
+		global $adb, $is_headlesschrome;
 		$template = null;
 
 		$result = $adb->pquery("SELECT templatename, body FROM vtiger_pdftemplates WHERE templateid = ?", array($templateId));
@@ -308,22 +308,27 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 			$template = Vtiger_InventoryPDFController::getMergedDescription($template, $recordId, $moduleName);
 		}
 
-		$tcpdf = new TCPDF();
-		$tcpdf->setPrintHeader(false);
-		$tcpdf->setPrintFooter(false);
-		$tcpdf->AddPage();
-		$tcpdf->SetFont('ume-tgo4','B');
-		$tcpdf->writeHTML($template);
-		$pdf = $tcpdf->Output($templateName.'.pdf', 'S');//Dの場合は日本語が消える
-		if(!$isheader) return $pdf;
+		if(!$is_headlesschrome){
+			$tcpdf = new TCPDF();
+			$tcpdf->setPrintHeader(false);
+			$tcpdf->setPrintFooter(false);
+			$tcpdf->AddPage();
+			$tcpdf->SetFont('ume-tgo4','B');
+			$tcpdf->writeHTML($template);
+			$pdf = $tcpdf->Output($templateName.'.pdf', 'S');//Dの場合は日本語が消える
+			if(!$isheader) return $pdf;
 
-		header("Pragma: public");
-		header("Expires: 0");
-		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
-		header("Content-Transfer-Encoding: binary ");
-		header('Content-Type: application/octet-streams');
-		header("Content-Disposition: attachment; filename=\"{$templateName}.pdf\"");
-		echo $pdf;
+			header("Pragma: public");
+			header("Expires: 0");
+			header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
+			header("Content-Transfer-Encoding: binary ");
+			header('Content-Type: application/octet-streams');
+			header("Content-Disposition: attachment; filename=\"{$templateName}.pdf\"");
+			echo $pdf;
+		}else{
+			if(!$isheader) return $this->getPDFfromheadlesschrome($template ,$templateName,$isheader);
+			$this->getPDFfromheadlesschrome($template ,$templateName,$isheader);
+		}
 	}
 
 	/**

--- a/modules/Vtiger/models/Record.php
+++ b/modules/Vtiger/models/Record.php
@@ -774,7 +774,7 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
 		header("Content-Transfer-Encoding: binary ");
 		header('Content-Type: application/octet-streams');
-		header("Content-Disposition: attachment; filename=\"".$templateName."headless.pdf\"");
+		header("Content-Disposition: attachment; filename=\"".$templateName.".pdf\"");
 		echo file_get_contents($pdfdataarray[array_keys($pdfdataarray)[0]]);
 	}
 

--- a/modules/Vtiger/models/Record.php
+++ b/modules/Vtiger/models/Record.php
@@ -750,7 +750,10 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 	}
 	public function getPDFfromheadlesschrome($template,$templateName,$isheader){
 		// $template $templateName
-		global $chromeurl;
+		if(file_exists('config.customize.php')){
+			include 'config.customize.php';
+		}
+		
 		$hostfiledirectory = "docker/chrome-headless/html2pdf/";
 		$dokerfiledirectory = "/var/www/html/html2pdf/";
 		$pdfdataarray = array();

--- a/modules/Vtiger/models/Record.php
+++ b/modules/Vtiger/models/Record.php
@@ -758,6 +758,7 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 		$hostfilepath = $hostfiledirectory.$uniquekey;
 		$dockerfilepath = $dokerfiledirectory.$uniquekey;
 		$template = str_replace('cellspacing="1"','cellspacing="0"',$template);
+		$template = str_replace('body','body  style="font-family: Noto Sans CJK JP"',$template);
 		file_put_contents($hostfilepath. ".html", $template);
 		$paramsarray = array("filepath" => $dockerfilepath);
 		$curl = curl_init($chromeurl);

--- a/modules/Vtiger/models/Record.php
+++ b/modules/Vtiger/models/Record.php
@@ -768,7 +768,11 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 		curl_close($curl);
 		$pdfdataarray[] = $hostfilepath . ".pdf";
 		unlink($hostfilepath . ".html");
-		if(!$isheader) return file_get_contents($pdfdataarray[0]);
+		if(!$isheader){
+			$returnpdfdata = file_get_contents($pdfdataarray[0]);
+			shell_exec("rm ".$pdfdataarray[0]);
+			return $returnpdfdata;
+		} 
 		header("Pragma: public");
 		header("Expires: 0");
 		header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
@@ -776,6 +780,7 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 		header('Content-Type: application/octet-streams');
 		header("Content-Disposition: attachment; filename=\"".$templateName.".pdf\"");
 		echo file_get_contents($pdfdataarray[array_keys($pdfdataarray)[0]]);
+		shell_exec("rm ".$pdfdataarray[0]);
 	}
 
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #711 #809 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDF出力を行う際にheadlesschromeを使いたい。

前回のブランチがMerging is blockedになってしまったので、上げ直しました。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
headlesschromeを使ったpdf
![image](https://user-images.githubusercontent.com/95267222/232428146-0df3b20e-0dc7-4f55-8852-d46c40004398.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
・pdf出力の範囲。
・dockerのコンテナが一つ増える。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
設定の方法などはREADMEファイルを参照してください。
PDFのスタイル等に関しては改善の余地があるかもしれません。
