### PR TITLE
ダッシュボードのセールスファネルのグラフの数値がずれている問題を修正

### DIFF
--- a/modules/Potentials/dashboards/GroupedBySalesStage.php
+++ b/modules/Potentials/dashboards/GroupedBySalesStage.php
@@ -74,6 +74,12 @@ class Potentials_GroupedBySalesStage_Dashboard extends Vtiger_IndexAjax_View {
 
 		$viewer->assign('WIDGET', $widget);
 		$viewer->assign('MODULE_NAME', $moduleName);
+		foreach($data as $key => $value)
+		{
+			$sort_keys[$key] = $value['1'];
+		}
+		array_multisort($sort_keys, SORT_DESC, $data);
+
 		$viewer->assign('DATA', $data);
 
 		//Include special script and css needed for this widget


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #821 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ダッシュボードのセールスファネルのグラフの数値と、クリック先のリストの件数が合わない問題

##  原因 / Cause
<!-- バグの原因を記述 -->
1. セールスファネルのグラフは値が大きい順に上から配置されるように並び替える。その時に凡例も一緒に並び替えがされるべきなのにされていなかった。
(issueの例でいうと、「最終交渉」は20件でありグラフだと下のほうに配置される。それに応じて凡例の「最終交渉」も下に移動し色も変わるべきなのだが、それがされていなかった。)


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. phpで$dataに値をセットする際に件数の多い順にリストに入れるように修正した。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://user-images.githubusercontent.com/95267222/233270206-563a2382-8db4-4b67-bee1-20fcdadb3169.png)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ダッシュボードのセールスステージ情報を用いる範囲。
リストの順番を変えただけなので影響なし。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
jsのほうで凡例もグラフと対応するように修正したほうが都合がいい等ありましたらコメントください。
(php側でサニタイズしてtplにデータを持たせていたたため、js側で修正するのが少し大変そうに感じたためこのような修正になりました。）