### PR TITLE
#830 共有リストに表示される下位の役割のユーザが作成したリストの表示を切り替えられるように修正

### DIFF
--- a/config.customize.php
+++ b/config.customize.php
@@ -1,0 +1,8 @@
+<?php
+
+$CUSTOMIZE_CONFIG = Array(
+	//Trueで下位の役割が作成した全てのリストを表示
+	'SHOW_SUBORDINATE_ROLES_LIST' => true,
+);
+
+?>

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -1144,6 +1144,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 	 * @return <Array> - Array of Vtiger_CustomView_Record models
 	 */
 	public static function getAll($moduleName='') {
+		require 'config.customize.php';
 		$db = PearDatabase::getInstance();
 		$userPrivilegeModel = Users_Privileges_Model::getCurrentUserPrivilegesModel();
 		$currentUser = Users_Record_Model::getCurrentUserModel();
@@ -1155,7 +1156,8 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$sql .= ' WHERE entitytype=?';
 			$params[] = $moduleName;
 		}
-		if(!$userPrivilegeModel->isAdminUser()) {
+		//adminではないとき,adminだけど全てのリストを表示したくないときに表示するリストを取得
+		if(!$userPrivilegeModel->isAdminUser() || ($userPrivilegeModel->isAdminUser() && !$CUSTOMIZE_CONFIG['SHOW_SUBORDINATE_ROLES_LIST'])) {
 			$userGroups = new GetUserGroups();
 			$userGroups->getAllUserGroups($currentUser->getId());
 			$groups = $userGroups->user_groups;
@@ -1169,14 +1171,18 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 
 			$userParentRoleSeq = $userPrivilegeModel->get('parent_role_seq');
 			$sql .= " AND ( vtiger_customview.userid = ? OR vtiger_customview.status = 0 OR vtiger_customview.status = 3
-							OR vtiger_customview.userid IN (
-								SELECT vtiger_user2role.userid FROM vtiger_user2role
-									INNER JOIN vtiger_users ON vtiger_users.id = vtiger_user2role.userid
-									INNER JOIN vtiger_role ON vtiger_role.roleid = vtiger_user2role.roleid
-								WHERE vtiger_role.parentrole LIKE '".$userParentRoleSeq."::%') 
 							OR vtiger_customview.cvid IN (SELECT vtiger_cv2users.cvid FROM vtiger_cv2users WHERE vtiger_cv2users.userid=?)";
 			$params[] = $currentUser->getId();
 			$params[] = $currentUser->getId();
+
+			//下位の役割のリストを共有リストに表示する
+			if($CUSTOMIZE_CONFIG['SHOW_SUBORDINATE_ROLES_LIST']) {
+				$sql .= 	"OR vtiger_customview.userid IN (
+								SELECT vtiger_user2role.userid FROM vtiger_user2role
+									INNER JOIN vtiger_users ON vtiger_users.id = vtiger_user2role.userid
+									INNER JOIN vtiger_role ON vtiger_role.roleid = vtiger_user2role.roleid
+								WHERE vtiger_role.parentrole LIKE '".$userParentRoleSeq."::%')";
+			}
 			if(!empty($groups)){
 				$sql .= "OR vtiger_customview.cvid IN (SELECT vtiger_cv2group.cvid FROM vtiger_cv2group WHERE vtiger_cv2group.groupid IN (".  generateQuestionMarks($groups)."))";
 				$params = array_merge($params,$groups);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #830 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 下位の役割のリスト（admin権限の場合は全体のリスト）が共有リストに表示される。ユーザーが大量にいると、共有リストが大量に表示されてしまい、本来アクセスしたいリストにアクセスしづらくなる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 表示するリストを取得する段階で、自分より下位の役割が作成したリストをすべて含める処理があった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 上記の処理をconfig.customize.phpで分岐させた


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
リスト欄


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->