### PR TITLE
#830 [再]共有リストの切り替えの修正

### DIFF
--- a/config.customize.php
+++ b/config.customize.php
@@ -7,3 +7,4 @@ $chromeurl = "http://localhost:30080/converthtmltopdf.php";// headlless chrome�
 $hostfiledirectory = "/var/www/html2pdf/";//PDF作成場所（Linux）
 #$hostfiledirectory = "D:/Applications/F-RevoCRM/crm/test/pdf/";//PDF作成場所（Windows）
 $dokerfiledirectory = "/html2pdf/";//コマンド実行の場合はコメントアウトする
+$show_subordinate_roles_list = true;// trueの場合：共有リスト欄に下位の役割が作成した全てのリストを表示。


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #830 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 下位の役割のリスト（admin権限の場合は全体のリスト）が共有リストに表示される。ユーザーが大量にいると、共有リストが大量に表示されてしまい、本来アクセスしたいリストにアクセスしづらくなる。


##  原因 / Cause
<!-- バグの原因を記述 -->
1. 表示するリストを取得する段階で、自分より下位の役割が作成したリストをすべて含める処理があった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. config.customize.phpに$show_subordinate_roles_listを追加し、上記の処理を分岐できるように修正した。


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->