### PR TITLE
php Dockerイメージ作成時 pecl install xdebugにてエラーとなる件の対処#789に関連

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -31,5 +31,5 @@ RUN set -xe; \
     # for imap
     && docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
     docker-php-ext-install -j$(nproc) imap
-RUN pecl install xdebug \
+RUN pecl install xdebug-3.1.6 \
   && docker-php-ext-enable xdebug


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.php docker イメージ作成のpecl install xdebug  エラー
docker-compose up 実行時、php dockerイメージ作成の段階で以下エラーが発生し、docker-compose upが中断しました。

 > [f-revocrm-php 5/5] RUN pecl install xdebug   && docker-php-ext-enable xdebug:
#0 3.667 pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.4.33
#0 3.667 No valid packages found
#0 3.667 install failed

##  原因 / Cause
<!-- バグの原因を記述 -->
1.xdebugの最新バージョンがphp 8.0対応版となったため、php7.4環境を対象に pecl install xdebugを行うとエラーになる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. php7.4に対応するxdebugのバージョンを以下より確認し、php/Dockerfile のpecl install xdebugにバージョンを追記してdocker-compose up にて正常動作を確認しました。
[https://xdebug.org/download/historical](https://xdebug.org/download/historical)

## 影響範囲  / Affected Area

特になし

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
特にありません。