### PR TITLE
#840 閲覧権限のないレポートを非表示にするように修正

### DIFF
--- a/modules/Reports/Reports.php
+++ b/modules/Reports/Reports.php
@@ -530,6 +530,50 @@ class Reports extends CRMEntity{
 				array_push($params, $current_user->id);
 			}
 
+			//ALLとshared以外のフォルダを開いたときに、閲覧権限のあるレポートのみ表示させるように修正
+			if ($rpt_fldr_id !== false && $rpt_fldr_id !== 'shared' && $rpt_fldr_id !== 'All') {
+				if (!empty($user_groups)) {
+					$user_group_query = " (shareid IN (".generateQuestionMarks($user_groups).") AND setype='groups') OR";
+					$non_admin_query = " vtiger_report.reportid IN (SELECT reportid FROM vtiger_reportsharing WHERE $user_group_query (shareid=? AND setype='users'))";
+					$non_admin_query = "( $non_admin_query ) OR ";
+					foreach ($user_groups as $userGroup) {
+						array_push($params, $userGroup);
+					}
+					array_push($params, $current_user->id);
+				}
+
+				//現在のユーザーより下の役割のユーザーが作成したレポートを表示
+				$sql .= " AND ($non_admin_query vtiger_report.sharingtype='Public' OR "
+						. "vtiger_report.owner = ? OR vtiger_report.owner IN (SELECT vtiger_user2role.userid "
+						. "FROM vtiger_user2role INNER JOIN vtiger_users ON vtiger_users.id=vtiger_user2role.userid "
+						. "INNER JOIN vtiger_role ON vtiger_role.roleid=vtiger_user2role.roleid "
+						. "WHERE vtiger_role.parentrole LIKE '".$current_user_parent_role_seq."::%'))";
+				array_push($params, $current_user->id);
+
+				//現在のユーザに共有されているレポートを表示
+				$userRole = fetchUserRole($current_user->id);
+            	$parentRoles=getParentRole($userRole);
+            	$parentRolelist= array();
+            	foreach($parentRoles as $par_rol_id)
+            	{
+            	    array_push($parentRolelist, $par_rol_id);		
+           		}
+            	array_push($parentRolelist, $userRole);
+				$sql .= " OR vtiger_report.reportid IN (SELECT vtiger_report_shareusers.reportid FROM vtiger_report_shareusers WHERE vtiger_report_shareusers.userid=?)";
+				array_push($params, $current_user->id);
+
+				if(!empty($user_groups)){
+					$sql .= " OR vtiger_report.reportid IN (SELECT vtiger_report_sharegroups.reportid FROM vtiger_report_sharegroups WHERE vtiger_report_sharegroups.groupid IN (".  generateQuestionMarks($user_groups)."))";
+					$params = array_merge($params,$user_groups);
+				}
+
+				$sql.= " OR vtiger_report.reportid IN (SELECT vtiger_report_sharerole.reportid FROM vtiger_report_sharerole WHERE vtiger_report_sharerole.roleid =?)";
+				array_push($params, $userRole);
+				if(!empty($parentRolelist)){
+					$sql.= " OR vtiger_report.reportid IN (SELECT vtiger_report_sharers.reportid FROM vtiger_report_sharers WHERE vtiger_report_sharers.rsid IN (". generateQuestionMarks($parentRolelist) ."))";
+					$params = array_merge($params,$parentRolelist);
+				}
+			}
 			$queryObj = new stdClass();
             $queryObj->query = $sql;
             $queryObj->queryParams = $params;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #840 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
「全てのレポート」「自分自身にも共有」以外のフォルダからレポートを一覧表示すると、閲覧権限がないレポートを含めすべてのレポートが表示される。
閲覧権限がないレポートは非表示にしたい。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
「全てのレポート」「自分自身にも共有」以外のフォルダを開いたとき、閲覧権限のあるレポートのみ表示するように条件を追加。


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
「全てのレポート」「自分自身にも共有」以外のフォルダを開いた際のレポートの一覧表示画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
修正中に発見。レポートを作成する際、レポートの共有にて「役割と部下」から役割を選択すると、選択した役割の部下のユーザーでレポートを閲覧しようとしたときにエラーが起きる。
![スクリーンショット (70)](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/4f040281-8642-41fb-b87d-a9f6300fbbe3)


