### PR TITLE
#844 レポートの共有相手を「役職と部下」から選択したとき、閲覧時にエラーが発生しないように修正

### DIFF
--- a/modules/Reports/models/Report.php
+++ b/modules/Reports/models/Report.php
@@ -21,8 +21,8 @@ class Vtiger_Report_Model extends Reports {
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 		$userId = $currentUser->getId();
 		$currentUserRoleId = $currentUser->get('roleid');
-		$subordinateRoles = getRoleSubordinates($currentUserRoleId);
-		array_push($subordinateRoles, $currentUserRoleId);
+		$parentRoles = getParentRole($currentUserRoleId);
+		array_push($parentRoles, $currentUserRoleId);
 
 		$this->initListOfModules();
 
@@ -68,14 +68,14 @@ class Vtiger_Report_Model extends Reports {
 					}
 					$ssql .= " OR (vtiger_report.reportid IN (SELECT reportid FROM vtiger_report_sharerole WHERE roleid = ?))
 							   OR (vtiger_report.reportid IN (SELECT reportid FROM vtiger_report_sharers 
-								WHERE rsid IN (".generateQuestionMarks($subordinateRoles).")))
+								WHERE rsid IN (".generateQuestionMarks($parentRoles).")))
 							  )";
 					array_push($params, $userId, $userId, $userId);
 					foreach($userGroupsList as $groups) {
 						array_push($params, $groups);
 					}
 					array_push($params, $currentUserRoleId);
-					foreach($subordinateRoles as $role) {
+					foreach($parentRoles as $role) {
 						array_push($params, $role);
 					}
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #844 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポート作成時、共有相手を「役割と部下」から選択すると、選択した役割の配下のユーザーがレポートを閲覧するときにエラーが起きる。

##  原因 / Cause
<!-- バグの原因を記述 -->
レコードを選択したときに閲覧権限の有無を確認するsql文と、レコードを取得するsql文の「役割と部下」に関する箇所で矛盾があった。

レコードを選択し閲覧権限の有無を確認するときは選択した役割とその配下に閲覧権限があるが、レコードを取得するときは選択した役割より上の役割で検索をかけていたためレコードを取得できず、閲覧権限があるのにレコードが存在しない状態になっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
レコードを取得するsql文の「役割と部下」の箇所を、閲覧権限の確認sql文と同じにした

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
共有相手を「役割と部下」から選択した際のレコードの閲覧権限


## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
#840 の修正とも合わせてテスト行いました。