### PR TITLE
#682 キーボード入力を有効に戻す修正

### DIFF
--- a/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
@@ -302,11 +302,6 @@ Vtiger_Date_Field_Js('Workflows_Date_Field_Js',{},{
             } else if(comparatorSelectedOptionVal == 'between'){
                 var html = '<div class="date"><input class="dateField inputElement" style="width:auto;" data-calendar-type="range" name="'+ this.getName() +'" data-date-format="'+ this.getDateFormat() +'" type="text"  value="'+  this.getValue() + '"></div>';
                 var element = jQuery(html);
-                $(function(){
-                    $(element).keydown(function(event){
-                      return false;
-                    });
-                });
                 return this.addValidationToElement(element);
             } else if(this._specialDateComparator(comparatorSelectedOptionVal)) {
                 var html = '<input name="'+ this.getName() +'" type="text" value="'+this.getValue()+'" data-validation-engine="validate[funcCall[Vtiger_Base_Validator_Js.invokeValidation]]" data-validator="[{"name":"PositiveNumber"}]">\n\

--- a/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Settings/Workflows/resources/AdvanceFilter.js
@@ -295,9 +295,18 @@ Vtiger_Date_Field_Js('Workflows_Date_Field_Js',{},{
         var comparatorSelectedOptionVal = this.get('comparatorElementVal');
         var dateSpecificConditions = this.get('dateSpecificConditions');
         if(comparatorSelectedOptionVal.length > 0) {
-            if(comparatorSelectedOptionVal == 'between' || comparatorSelectedOptionVal == 'custom'){
+            if(comparatorSelectedOptionVal == 'custom'){
                 var html = '<div class="date"><input class="dateField inputElement" style="width:auto;" data-calendar-type="range" name="'+ this.getName() +'" data-date-format="'+ this.getDateFormat() +'" type="text" ReadOnly="true" value="'+  this.getValue() + '"></div>';
                 var element = jQuery(html);
+                return this.addValidationToElement(element);
+            } else if(comparatorSelectedOptionVal == 'between'){
+                var html = '<div class="date"><input class="dateField inputElement" style="width:auto;" data-calendar-type="range" name="'+ this.getName() +'" data-date-format="'+ this.getDateFormat() +'" type="text"  value="'+  this.getValue() + '"></div>';
+                var element = jQuery(html);
+                $(function(){
+                    $(element).keydown(function(event){
+                      return false;
+                    });
+                });
                 return this.addValidationToElement(element);
             } else if(this._specialDateComparator(comparatorSelectedOptionVal)) {
                 var html = '<input name="'+ this.getName() +'" type="text" value="'+this.getValue()+'" data-validation-engine="validate[funcCall[Vtiger_Base_Validator_Js.invokeValidation]]" data-validator="[{"name":"PositiveNumber"}]">\n\


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #682 #658 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. #682 の修正でキーボード入力に制限を掛けたが、キーボード入力を有効に戻した。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ほかの日付項目などではキーボード入力ができるため、別途日付形式全体での仕様を検討する必要がある。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 誕生日の範囲選択におけるキーボード入力を有効に戻した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/1ccee795-8b0d-4cab-8bab-484f10c5f111)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
日付の範囲選択に対するバリデーションの追加も行う必要がある。