### PR TITLE
#847 リストで数値を範囲検索できる機能を追加

### DIFF
--- a/include/QueryGenerator/EnhancedQueryGenerator.php
+++ b/include/QueryGenerator/EnhancedQueryGenerator.php
@@ -821,6 +821,9 @@ class EnhancedQueryGenerator extends QueryGenerator {
 				} else {
 					$fieldGlue = ' OR';
 				}
+				if ($conditionInfo['operator'] == 'range') {
+					$fieldGlue = ' AND';
+				}
 			}
 			$tmpTableName = 'vtiger_crmentity'.$parentReferenceField;
 			if ($tmpTableName == $tableName && $referenceModule) {

--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1090,7 +1090,7 @@ class QueryGenerator {
 						$value = $dateTime[0];
 					}
 				}
-			} else if ($field->getFieldDataType() === 'currency') {
+			} else if ($field->getFieldDataType() === 'currency' && $operator != 'range') {
 				$uiType = $field->getUIType();
 				if ($uiType == 72) {
 					$value = CurrencyField::convertToDBFormat($value, null, true);
@@ -1117,6 +1117,37 @@ class QueryGenerator {
 			if(trim($value) == '' && ($operator == 'k') &&
 					$this->isStringType($field->getFieldDataType())) {
 				$sql[] = "NOT LIKE ''";
+				continue;
+			}
+
+			if($operator == 'range') {
+				$valueArray = explode(',' , $value);
+				if(count($valueArray) == 2) {
+					if($field->getFieldDataType() === 'currency') {
+						$uiType = $field->getUIType();
+						if($uiType == 72) {
+							if($valueArray[0] != ""){
+								$valueArray[0] = CurrencyField::convertToDBFormat($valueArray[0], null, true);
+							}
+							if($valueArray[1] != ""){
+								$valueArray[1] = CurrencyField::convertToDBFormat($valueArray[1], null, true);
+							}
+						} elseif($uiType == 71) {
+							if($valueArray[0] != ""){
+								$valueArray[0] = (string)CurrencyField::convertToDBFormat($valueArray[0]);
+							}
+							if($valueArray[1] != ""){
+								$valueArray[1] = (string)CurrencyField::convertToDBFormat($valueArray[1]);
+							}
+						}
+					}
+					if($valueArray[0] != "") {
+						$sql[] = ">= $valueArray[0]";
+					}
+					if($valueArray[1] != "") {
+						$sql[] = "<= $valueArray[1]";
+					}
+				}
 				continue;
 			}
 

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -620,10 +620,15 @@ Vtiger.Class("Vtiger_List_Js", {
 					fieldInfo.type == "picklist") {
 				searchOperator = 'e';
 			}
-			var storedOperator = searchContributorElement.parent().parent().find('.operatorValue').val();
-			if (storedOperator) {
-				searchOperator = storedOperator;
-				storedOperator = false;
+			// クリアを押さないと前のsearchOperatorが適用されてしまうためコメントアウト
+			// var storedOperator = searchContributorElement.parent().parent().find('.operatorValue').val();
+			// if (storedOperator) {
+			// 	searchOperator = storedOperator;
+			// 	storedOperator = false;
+			// }
+			if ((fieldInfo.type == 'percentage' || fieldInfo.type == "double" || fieldInfo.type == "integer"
+				|| fieldInfo.type == 'currency') && searchValue.indexOf(',') != -1) {
+				searchOperator = 'range';
 			}
 			searchInfo.push(fieldName);
 			searchInfo.push(searchOperator);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #847 

##  要望の内容 / Enhancement
<!-- バグ,要望やIssue内容を簡潔に記述 -->
一覧画面（リスト表示）の項目の下にある検索ボックスで、数値項目をピンポイントの数値しか検索できない。
以下のように数値項目を範囲検索できると嬉しい。（カンマで表現）

100以上：100,
100～200：100,200
200以下：,200


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
新たなsearchOperator"range"を追加し、数値項目の検索欄で","が入力されたときに適用した。
searchOperatorがrangeのときにカンマの前後の数値を取得して検索を行うようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
全体表示
![スクリーンショット (74)](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/083bf01a-6956-4b80-88b1-2e3143e9f1e1)
手数料率0以上、在庫数30以下、単価-5以上13000以下で検索
![スクリーンショット (73)](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/ef762cf3-086b-47df-8634-cf2a7959f316)
在庫数30以下で検索
![スクリーンショット (71)](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/d5f05fc7-3c33-4400-b4d4-a8dbdf0c68d4)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
一覧表示（リスト表示）の検索欄で検索時の挙動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->