### PR TITLE
#835 見積の新規作成画面にて控除された税金のキャンセルが効くように修正

### DIFF
--- a/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/layouts/v7/modules/Inventory/resources/Edit.js
@@ -2364,10 +2364,15 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
 			var deductTaxForm = self.dedutTaxesContainer.closest('.lineItemPopover');
 
 			deductTaxForm.find('.popoverButton').on('click', function(e){
-				var validate = deductTaxForm.find('input').valid();
-				if (validate) {
+				var inputEle = deductTaxForm.find('input');
+				if(inputEle.length == 0){
 					deductTaxForm.closest('.popover').css('opacity',0).css('z-index','-1');
-					self.calculateDeductTaxes();
+				}else{
+					var validate = deductTaxForm.find('input').valid();
+					if (validate) {
+						deductTaxForm.closest('.popover').css('opacity',0).css('z-index','-1');
+						self.calculateDeductTaxes();
+					}
 				}
 			});
 		});
@@ -2853,12 +2858,16 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
             e.preventDefault();
             var element = jQuery(e.currentTarget);
             var popOverEle = element.closest('.popover');
-			var validate = popOverEle.find('input').valid();
-			if (!validate) {
-				popOverEle.find('.input-error').val(0).valid();
+			var inputEle = popOverEle.find('input');
+			if(inputEle.length == 0){
+				popOverEle.css('opacity',0).css('z-index','-1');
+			}else{
+				var validate = popOverEle.find('input').valid();
+				if (!validate) {
+					popOverEle.find('.input-error').val(0).valid();
+				}
+				popOverEle.css('opacity',0).css('z-index','-1');
 			}
-			popOverEle.css('opacity',0).css('z-index','-1');
-
         });
     },
     registerBasicEvents: function(container){


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #835 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
見積の新規作成画面にて控除された税金のキャンセルが効かない。

再現手順（To Reproduce）
1,見積の作成画面を開く
2,ページ下の方にある控除された税金をクリックする
3,キャンセルを押しても保存を押しても閉じない


##  原因 / Cause
<!-- バグの原因を記述 -->
控除された税金が登録されていないときは入力欄が存在しないため、.find('input').valid();でエラーが発生してキャンセル等が効かなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
入力欄の存在を確認してから.find('input').valid()を行うように修正した。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
見積や請求等（請求でも修正確認いたしました。）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->