### PR TITLE
#574 共有カレンダーにて、予定をマウス移動すると非表示にしていたユーザーの予定も表示される

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1359,6 +1359,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		}
 		var params = {
 			"module": "Calendar",
+			"view": app.view(),
 			"action": "DeleteAjax",
 			"record": eventId,
 			"sourceModule": sourceModule

--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -291,6 +291,8 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 				var sourceKey = currentTarget.data('calendarSourcekey');
 				if($(this).is(".mine")) {
 					myId = currentTarget.attr("data-calendar-userid");
+					// 自分以外のユーザーの活動を移動した場合に、自分の予定が変更されないためrefreshFeedを実行する
+					thisInstance.refreshFeed($(".activitytype-indicator.calendar-feed-indicator.mine").find("input[type='checkbox']"));
 				} else {
 					// thisInstance.disableFeed(sourceKey);
 					thisInstance.removeEvents(currentTarget);

--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -292,7 +292,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 				if($(this).is(".mine")) {
 					myId = currentTarget.attr("data-calendar-userid");
 				} else {
-					thisInstance.disableFeed(sourceKey);
+					// thisInstance.disableFeed(sourceKey);
 					thisInstance.removeEvents(currentTarget);
 					$(this).remove();
 				}
@@ -300,6 +300,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 
 			var users = thisInstance.userList['users'];
 			var sharedInfo = thisInstance.userList['sharedinfo'] ? thisInstance.userList['sharedinfo'] : {};
+			var cashDisabledFeedsStorageKey = thisInstance.getDisabledFeeds();
 
 			Object.keys(users).forEach(function (id) {
 				var user = users[id];
@@ -332,7 +333,12 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 
 					thisInstance.colorizeFeed(newFeedCheckbox);
 
-					thisInstance.enableFeed('Events_'+id);
+					if(cashDisabledFeedsStorageKey.indexOf('Events_'+id) !== -1){
+						// thisInstance.disableFeed('Events_'+id);
+						newFeedCheckbox.removeAttr('checked');
+					}else{
+						// thisInstance.enableFeed('Events_'+id);
+					}
 					thisInstance.addEvents(newFeedCheckbox);
 
 					if(target != "Calendar") {

--- a/modules/Calendar/actions/DeleteAjax.php
+++ b/modules/Calendar/actions/DeleteAjax.php
@@ -45,7 +45,12 @@ class Calendar_DeleteAjax_Action extends Vtiger_DeleteAjax_Action {
 		
 		$recordModel = Vtiger_Record_Model::getInstanceById($recordId, $moduleName);
 		$recordModel->set('recurringEditMode', $recurringEditMode);
-		$deletedRecords = $recordModel->delete();
+		if($request->get('view') == 'SharedCalendar'){ // 共有カレンダーの場合, 共同参加者の予定もJavaScript側にて削除する
+			$deletedRecords = $recordModel->getInviteeRecordById($recordId);
+			$recordModel->delete();
+		}else{
+			$deletedRecords = $recordModel->delete();
+		}
 
 		$cvId = $request->get('viewname');
 		deleteRecordFromDetailViewNavigationRecords($recordId, $cvId, $moduleName);

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -250,6 +250,29 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 		}
 	}
 
+	// 共同参加者のカレンダーidを取得する関数
+	// deleteInviteeRecord()にて削除するカレンダーが対象
+	public function getInviteeRecordById($id) {
+		global $adb;
+		
+		$result = $adb->pquery("SELECT
+									a.activityid
+								FROM
+									vtiger_activity a
+									INNER JOIN vtiger_crmentity c ON c.crmid = a.activityid
+								WHERE
+									c.deleted = 0
+									AND a.invitee_parentid = (SELECT a2.invitee_parentid FROM vtiger_activity a2 WHERE a2.activityid = ?)
+		", array($id));
+
+		$recordids = array();
+		for($i=0; $i<$adb->num_rows($result); $i++) {
+			$recordids[] = $adb->query_result($result, $i, 'activityid');
+		}
+
+		return $recordids;
+	}
+
 	public function isAllDay() {
 		global $adb;
 		$isAllDay = false;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #574
- fix #549 
- fix #325 再修正

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 共有カレンダーにて、予定をマウス移動すると非表示にしていたユーザーの予定も表示される
2. 共有カレンダーにて、現在のログインユーザーの予定が参加者の予定と一緒に移動しない
3. カレンダーのスケジュール削除時に共同参加者も削除してほしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. changeUserListにて、インジケータ(左のチェックボックス等)を再構成するときに、再構成前のチェックボックスの状態が考慮されていなかった
2. カレンダーが移動した際に更新されるユーザーリストの中に自分が含まれていなかった
3. php側にて、削除対象となる活動のidのみが送信されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 再構成前のチェックボックスの状態をgetDisabledFeeds()にて取得できるように変更
2. リストに自分を追加するのではなく、自分の活動に対してrefreshFeed()を実行する
3. リクエストにviewの情報も追加しphp側で判定できるようにし、共同参加者の活動のidも含めて送信するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
不具合内容の1について。
layouts/v7/modules/Calendar/resources/SharedCalendar.jsのchangeUserList
このコードでは、最初にわざわざインジケータを削除してから、インジケータの再作成・活動の削除＆追加の処置が行われています。
活動の移動で発火するイベントなのに、インジケータを削除する理由が分かりませんでした。
