### PR TITLE
#863 カスタム項目にて作成した選択肢(複数)のデフォルト値が表示されるように修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -950,10 +950,20 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					data = {};
 				}
 
+				//編集か追加かを確認し、追加の時のみデフォルト値のリセットを行う
+				form.attr('id', 'createFieldForm');
+				var isEditMode = false;
+				var formFieldId = form.find('input[name="fieldid"]').val();
+				if (formFieldId.length > 0) {
+					isEditMode = true;
+				}
+
 				data.name = nameAttr;
 				data.value = defaultValueUi.val();
 				//チェックボックス項目から、または選択肢(複数)からの変更の場合、デフォルト値に何も表示されないようにする
-				if(nameAttr == 'fieldDefaultValue' && (typeBeforeChange == 'Boolean' || typeBeforeChange == 'Multipicklist')){
+				//選択肢(複数)で編集を開いたとき、デフォルト値が空になってしまうため、編集の時はデフォルトを空にしないようにする
+				if(nameAttr == 'fieldDefaultValue' && (typeBeforeChange == 'Boolean' || typeBeforeChange == 'Multipicklist')
+						&& !isEditMode){
 					data.value = "";
 				}
 				if (currentTarget.val() == "MultiSelectCombo") {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #863 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カスタム項目にて作成した選択肢（複数）のデフォルト値が表示されない。

再現手順
1,モジュール管理＞項目設定から任意のモジュールに選択肢(複数)の項目を作成する
2,作成した項目にデフォルト値を設定して保存する
3,作成した項目の編集画面を開くと設定したはずのデフォルト値が表示されない

※デフォルト値は1度表示された後, 消える挙動となっている。

##  原因 / Cause
<!-- バグの原因を記述 -->
Pr #394 の修正で、カスタム項目の項目タイプを変更する際に変更前の項目を保持し、その項目がチェックボックスか選択肢（複数）のとき、デフォルトの値を空にするようにしていた。
既存のカスタム項目の編集を行う際、上記の処理が2回走っていたため、項目タイプが選択肢（複数）の項目の編集を行うと2度目に項目タイプが選択肢（複数）になってしまい、デフォルト値が一瞬表示され、消える挙動になっていた。（項目タイプがチェックボックスの時はデフォルト値を空にした後に元に戻す処理をしていたため不具合無し）


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
カスタム項目の設定を行うとき、項目の編集の場合は項目タイプは変更できないため、デフォルト値を空にする必要がない。編集なのか追加なのかを取得し、編集の時はデフォルト値を空にしないように修正した


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目設定

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->