### PR TITLE
#245 リスト機能にデフォルトのソートを設定する

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1220,6 +1220,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'リストを共有',
+	'LBL_DEFAULT_SORT' => '並び順',
 	'LBL_ADD_USERS_ROLES' => 'ユーザー、役割の追加',
 	'EmailTemplates' => 'メールテンプレート',
 	'LBL_BILLING' => '請求',

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -110,6 +110,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
+								<input type="hidden" name="orderby" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -118,6 +119,17 @@
 							<label class="filterHeaders">{vtranslate('LBL_CHOOSE_FILTER_CONDITIONS', $MODULE)} :</label>
 							<div class="filterElements well filterConditionContainer filterConditionsDiv">
 								{include file='AdvanceFilter.tpl'|@vtemplate_path}
+							</div>
+						</div>
+						<div class="form-group clearfix">
+							<div class="col-sm-1 col-xs-2">
+								<label>
+										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
+								</label>
+							</div>
+							<div class=" row col-sm-5 col-xs-5">
+								<select id='orderby' class="select2-container select2">
+								</select>
 							</div>
 						</div>
 						<div class="checkbox">

--- a/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -219,6 +219,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		this.makeColumnListSortable();
 		this.registerToogleShareList();
 		this.registerOnlyAllUsersInSharedList();
+		this.addColumnsOrderbyList();
 		var customViewForm = jQuery('#CustomView');
 
 		if(customViewForm.length > 0) {
@@ -227,7 +228,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					var form = jQuery(form); 
 						  var selectElement = form.find('#viewColumnsSelect'); 
 						  var mandatoryFieldsList = JSON.parse(jQuery('#mandatoryFieldsList').val()); 
-						  var selectedOptions = selectElement.val(); 
+						  var selectedOptions = selectElement.val();
 						  var mandatoryFieldsMissing = true; 
 						  for(var i=0; i<selectedOptions.length; i++) { 
 						if(jQuery.inArray(selectedOptions[i], mandatoryFieldsList) >= 0) { 
@@ -250,6 +251,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					}
 					var selectValues = JSON.stringify(selectedValues);
 					jQuery('input[name="columnslist"]', self.getContainer()).val(selectValues);
+					jQuery('input[name="orderby"]').val(jQuery('#orderby').val());
 					var allUsersStatusEle = jQuery('#allUsersStatusValue');
 					if(self.isAllUsersSelected() && (jQuery('[data-toogle-members]').is(":checked"))){
 						allUsersStatusEle.val(allUsersStatusEle.data('public'));
@@ -326,5 +328,40 @@ jQuery.Class("Vtiger_CustomView_Js",{
 				target.trigger('post.ToggleDefault.saved',data);
 			})
 		});
+	},
+
+	addElementsforOrderbyList :function(){
+		selectElement = this.getColumnSelectElement();
+		selectedOptions = selectElement.select2('data');
+		
+		for (var i= 0;i<selectedOptions.length;i++){
+			selectedOptionid = selectedOptions[i].id.split(':');
+			const newOption = document.createElement("option");
+			newOption.value = selectedOptionid[1];
+			newOption.textContent = selectedOptions[i].text;
+			jQuery("#orderby").append(newOption);
+		}
+	},
+
+	addColumnsOrderbyList :function(){
+		selectfield = document.getElementById('s2id_viewColumnsSelect');
+		this.addElementsforOrderbyList();
+
+		var observer = new MutationObserver(function(){
+			customview = new Vtiger_CustomView_Js();
+			var parent = document.getElementById("orderby");
+			
+			while(parent.lastChild){
+				parent.removeChild(parent.lastChild);
+			}
+			customview.addElementsforOrderbyList();
+		});
+		const config = { 
+			attributes: false, 
+			childList: true, 
+			characterData: false,
+			subtree:true
+		};
+		observer.observe(selectfield, config);
 	}
 });

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -58,7 +58,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'viewname' => $request->get('viewname'),
 					'setdefault' => $request->get('setdefault'),
 					'setmetrics' => $request->get('setmetrics'),
-					'status' => $request->get('status')
+					'status' => $request->get('status'),
+					'orderby' => $request->get('orderby')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -272,6 +272,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setDefault = $this->get('setdefault');
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
+		$orderby = $this->get('orderby');
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {
@@ -283,8 +284,8 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$cvId = $db->getUniqueID("vtiger_customview");
 			$this->set('cvid', $cvId);
 
-			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid) VALUES (?,?,?,?,?,?,?)';
-			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId());
+			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby) VALUES (?,?,?,?,?,?,?,?)';
+			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(),$orderby);
 			$db->pquery($sql, $params);
 
 		} else {

--- a/modules/Migration/schema/738_to_739.php
+++ b/modules/Migration/schema/738_to_739.php
@@ -1,0 +1,14 @@
+<?php
+/*+********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+    $db->query('ALTER TABLE vtiger_customview ADD orderby varchar(250);');
+
+}

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -180,6 +180,14 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		} else {
 			$listViewModel = $this->listViewModel;
 		}
+		if($orderBy == ''){
+			global $db;
+			$db = PearDatabase::getInstance();
+			$query = "SELECT orderby from vtiger_customview WHERE cvid = ?";
+			$result = $db->pquery($query, array($cvId));//orderbyの連結完了
+			$orderBy = $db->query_result($result,'orderby');
+
+		}
 
 		if(!empty($requestViewName) && empty($tag)) {
 			unset($_SESSION[$tagSessionKey]);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #245 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストを作成編集する際に、デフォルトのソートを設定できるようにする修正

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_customviewにorderbyとしてリストのデフォルトのソート情報を追加するようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/a4e966b4-4542-403c-b9ab-ed8df1d1d6b9)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
customviewの範囲

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
「項目と並び順の選択肢」の部分にソートの選択肢を対応させるために、observerを使っているが、「項目と並び順の選択肢」のすべての変更を監視しているため処理が重くなるかもしれない。
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/244e779d-6244-49ec-b792-4292b2318506)
