### PR TITLE
#882 項目を追加した際のcf_XXXが連番になっていない箇所の修正

### DIFF
--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -148,7 +148,10 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 			throw new Exception(vtranslate('LBL_WRONG_FIELD_TYPE', 'Settings::LayoutEditor'), 513);
 		}
 
-		$max_fieldid = $db->getUniqueID("vtiger_field");
+		$max_fieldid = $this->getSequenceNumber() + 1;
+		if(empty($max_fieldid)){
+			$max_fieldid = $db->getUniqueID("vtiger_field");
+		}
 		$columnName = 'cf_'.$max_fieldid;
 		$custfld_fieldid = $max_fieldid;
 		$moduleName = $this->getName();
@@ -232,6 +235,21 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 			}
 		}
 		return $fieldModel;
+	}
+
+	// getUniqueID()などは実行時にインクリメントされてしまう.
+	// columnName(cf_xxx)を決定するときなどのインクリメント不要時に使用する.
+	public function getSequenceNumber(){
+		if($this->hasSequenceNumberField()){
+			global $adb;
+			$query = 'SELECT id FROM vtiger_field_seq';
+			$result = $adb->pquery($query, array());
+			$rows = $adb->num_rows($result);
+			if($rows > 0){
+				return $adb->query_result($result, 0, 'id');
+			}
+		}
+		return null;
 	}
 
 	public function getTypeDetailsForAddField($fieldType,$params) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #882 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
* 項目を追加した際のcf_XXXが連番になっていない

##  原因 / Cause
<!-- バグの原因を記述 -->
*  項目の追加時に、getUniqueID()を**2度**使用していることが原因.
    * getUniqueID()は番号を取得すると同時に、**idをインクリメント**してしまう.
    * 1回目はカラム名(cf_xxx)を作成するために、2回目はaddField()にて使用されている.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* getUniqueID()を使用せずにcf_xxxを作成する..
  * vtiger_field_seqを参照する関数getSequenceNumber()を作成した.

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* vtiger_fields
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/f9508cc3-7967-4461-8c52-3fb700e9cf68)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* 項目の新規作成時

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->