### PR TITLE
Revert "#744 マイグループのチェックボックスが変化しないよう修正"

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1329,7 +1329,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				thisInstance.updateAllEventsOnCalendar();
 			}
 			if(thisInstance.changeUserList) {
-				//thisInstance.changeUserList();
+				thisInstance.changeUserList();
 			}
 		});
 	},


### PR DESCRIPTION
Reverts thinkingreed-inc/F-RevoCRM#758

## リバート理由
* 以下のpull requestとissue内容が同じ. 修正済み.
    * #865
* `thisInstance.changeUserList()`をコメントアウトする修正だと、活動のマウス移動時に参加者の予定が移動しなくなってしまう.