### PR TITLE
#831 レポートの条件において、時間の範囲選択をマウスで行えるようにする

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
@@ -543,7 +543,22 @@ jQuery.Class("Vtiger_AdvanceFilter_Js",{
 						}
 					}
 
-				} else {
+				}
+				 else if (fieldType == 'time' && fieldDataInfo.comparatorElementVal == 'bw'){
+					var timeRange = {};
+					for(var key in fieldList) {
+						var field = fieldList[key];
+						if(field == 'value'){
+							valueSelectElement.each(function(i, timeRangeValueElement){
+								timeRange[i] = jQuery(timeRangeValueElement).val();
+							});
+							rowValues[field] = timeRange[0]+','+timeRange[1];
+						}  else {
+							rowValues[field] = jQuery('[name="'+field+'"]', rowElement).val();
+						}
+					}
+				}
+				 else {
 					for(var key in fieldList) {
 						var field = fieldList[key];
 						if(field == 'value'){
@@ -648,7 +663,7 @@ Vtiger_Field_Js('AdvanceFilter_Field_Js',{},{
 
 	getUiTypeSpecificHtml : function() {
 		var uiTypeModel = this.getUiTypeModel();
-		return uiTypeModel.getUi();
+		return uiTypeModel.getUi(this.get('comparatorElementVal'));
 	},
 	
 	getModuleName : function() {

--- a/layouts/v7/modules/Vtiger/resources/Field.js
+++ b/layouts/v7/modules/Vtiger/resources/Field.js
@@ -572,11 +572,32 @@ Vtiger_Field_Js('Vtiger_Time_Field_Js',{},{
 	 * Function to get the ui
 	 * @return - input text field
 	 */
-	getUi : function() {
+	getUi : function(comparatorElementVal) {
 		var html = '<div class="referencefield-wrapper">'+'<div class="input-group time">'+
 						'<input class="timepicker-default form-control inputElement" type="text" data-format="'+ this.getTimeFormat() +'" name="'+ this.getName() +'" value="'+ this.getValue() + '" />'+
 						'<span class="input-group-addon"><i class="fa fa-clock-o"></i></span>'+
 					'</div>'+'</div>';
+
+		if(comparatorElementVal == 'bw'){
+			timeRange=this.getValue().split(',');
+			if(timeRange.length == 1){
+				timeRange[1]='';
+			}
+			var starttime = '<div class="referencefield-wrapper">'+
+								'<div class="input-group time" style="min-width: 80px ! important">'+
+									'<input class="timepicker-default form-control inputElement" type="text" data-format="'+ this.getTimeFormat() +'" name="'+ this.getName() +'" value="'+ timeRange[0] + '" />'+
+									'<span class="input-group-addon"><i class="fa fa-clock-o"></i></span>'+
+								'</div>'+
+							'</div>';
+			var endttime = '<div class="referencefield-wrapper">'+
+								'<div class="input-group time" style="min-width: 80px ! important">'+
+									'<input class="timepicker-default form-control inputElement" type="text" data-format="'+ this.getTimeFormat() +'" name="'+ this.getName() +'" value="'+ timeRange[1] + '" />'+
+									'<span class="input-group-addon"><i class="fa fa-clock-o"></i></span>'+
+								'</div>'+
+							'</div>';
+			html = '<div style="display:flex">'+starttime+'<div style="left: 20px; padding: 2%;">~</div>'+endttime+'</div>';
+		}
+		
 		var element = jQuery(html);
 		return this.addValidationToElement(element);
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #831 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートの条件において、時間の範囲選択をする時に手入力する必要があった。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 入力個所を２か所に増やした。
2. getUi関数を呼び出す際に、条件の引数(等しい,範囲,などの情報)を渡すようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/4ebd82a5-55bd-4154-9dc1-faf106792c43)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
uitypeがtimeのgetUi関数を呼び出している部分。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
範囲の終了時間が開始時間よりも前に設定できてしまうため、バリデーションを追加する必要があります。
修正しだいコミットします。
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/daa6c234-f895-44b1-af8e-f9ef86ac8bdf)
