### PR TITLE
[要望]日報モジュールの概要画面の「活動」部分が読みづらいため、

### DIFF
--- a/layouts/v7/modules/Dailyreports/RelatedActivities.tpl
+++ b/layouts/v7/modules/Dailyreports/RelatedActivities.tpl
@@ -1,0 +1,161 @@
+{*<!--
+/*********************************************************************************
+** The contents of this file are subject to the vtiger CRM Public License Version 1.0
+* ("License"); You may not use this file except in compliance with the License
+* The Original Code is: vtiger CRM Open Source
+* The Initial Developer of the Original Code is vtiger.
+* Portions created by vtiger are Copyright (C) vtiger.
+* All Rights Reserved.
+*
+********************************************************************************/
+-->*}
+{strip}
+	{assign var=MODULE_NAME value="Calendar"}
+	<div class="summaryWidgetContainer">
+		<div class="widget_header clearfix">
+			<h4 class="display-inline-block pull-left">{vtranslate('LBL_ACTIVITIES',$MODULE_NAME)}</h4>
+			{*<div class="">
+			<button class="btn addButton createActivity" type="button" data-url="sourceModule={$RECORD->getModuleName()}&sourceRecord={$RECORD->getId()}&relationOperation=true">
+			<strong>{vtranslate('LBL_ADD',$MODULE_NAME)}</strong>
+			</button>
+			</div>*}
+			{assign var=CALENDAR_MODEL value = Vtiger_Module_Model::getInstance('Calendar')}
+			<div class="pull-right" style="margin-top: -5px;">
+				{if $CALENDAR_MODEL->isPermitted('CreateView')}
+					<button class="btn addButton btn-sm btn-default createActivity toDotask textOverflowEllipsis max-width-100" title="{vtranslate('LBL_ADD_TASK',$MODULE_NAME)}" type="button" href="javascript:void(0)" data-url="sourceModule={$RECORD->getModuleName()}&sourceRecord={$RECORD->getId()}&relationOperation=true" >
+						<i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD_TASK',$MODULE_NAME)}
+					</button>&nbsp;&nbsp;
+					<button class="btn addButton btn-sm btn-default createActivity textOverflowEllipsis max-width-100" title="{vtranslate('LBL_ADD_EVENT',$MODULE_NAME)}" data-name="Events"
+							data-url="index.php?module=Events&view=QuickCreateAjax" href="javascript:void(0)" type="button">
+						<i class="fa fa-plus"></i>&nbsp;&nbsp;{vtranslate('LBL_ADD_EVENT',$MODULE_NAME)}
+					</button>
+				{/if}
+			</div>
+			{assign var=SOURCE_MODEL value=$RECORD}
+		</div>
+		<div class="widget_contents">
+			{if count($ACTIVITIES) neq '0'}
+				{foreach item=RECORD key=KEY from=$ACTIVITIES}
+					{assign var=START_DATE value=$RECORD->get('date_start')}
+					{assign var=START_TIME value=$RECORD->get('time_start')}
+					{assign var=EDITVIEW_PERMITTED value=isPermitted('Calendar', 'EditView', $RECORD->get('crmid'))}
+					{assign var=DETAILVIEW_PERMITTED value=isPermitted('Calendar', 'DetailView', $RECORD->get('crmid'))}
+					{assign var=DELETE_PERMITTED value=isPermitted('Calendar', 'Delete', $RECORD->get('crmid'))}
+					<div class="activityEntries">
+						<input type="hidden" class="activityId" value="{$RECORD->get('activityid')}"/>
+						<div class='media'>
+							<div class='row'>
+								<div class='media-left module-icon col-lg-1 col-md-1 col-sm-1 textAlignCenter'>
+									<span class='vicon-{strtolower($RECORD->get('activitytype'))}'></span>
+								</div>
+								<div class='media-body col-lg-9 col-md-9 col-sm-9'>
+									<div class="summaryViewEntries">
+										{if $DETAILVIEW_PERMITTED == 'yes'}<a href="{$RECORD->getDetailViewUrl()}" title="{$RECORD->get('subject')}">{$RECORD->get('subject')}</a>{else}{$RECORD->get('subject')}{/if}&nbsp;&nbsp;
+										{if $EDITVIEW_PERMITTED == 'yes'}<a href="{$RECORD->getEditViewUrl()}&sourceModule={$SOURCE_MODEL->getModuleName()}&sourceRecord={$SOURCE_MODEL->getId()}&relationOperation=true" class="fieldValue"><i class="summaryViewEdit fa fa-pencil" title="{vtranslate('LBL_EDIT',$MODULE_NAME)}"></i></a>{/if}&nbsp;
+										{if $DELETE_PERMITTED == 'yes'}<a onclick="Vtiger_Detail_Js.deleteRelatedActivity(event);" data-id="{$RECORD->getId()}" data-recurring-enabled="{$RECORD->isRecurringEnabled()}" class="fieldValue"><i class="summaryViewEdit fa fa-trash " title="{vtranslate('LBL_DELETE',$MODULE_NAME)}"></i></a>{/if}
+									</div>
+								{assign var=START_DATE_AND_TIME value=Vtiger_Util_Helper::formatDateTimeIntoDayString("$START_DATE $START_TIME")}
+								{assign var=OWNER value=$RECORD->get('smownerid')}
+								{assign var=ACTIVITYTYPE value=$RECORD->get('activitytype')}
+								{assign var=DESCRIPTION value=$RECORD->get('description')}
+								<table>
+									<tr class="relatedActivitiesEntries">
+										<td class="relatedActivitiesLabel">{vtranslate('Start Date & Time','Calendar')}</td>
+										<td class="relatedActivitiesValue">{$START_DATE_AND_TIME}</td>
+									</tr>
+									<tr class="relatedActivitiesEntries">
+										<td class="relatedActivitiesLabel">{vtranslate('Assigned To')}</td>
+										<td class="relatedActivitiesValue">{getUserFullName($OWNER)}</td>
+									</tr>
+									<tr class="relatedActivitiesEntries">
+										<td class="relatedActivitiesLabel">{vtranslate('Activity Type','Calendar')}</td>
+										<td class="relatedActivitiesValue">{vtranslate($ACTIVITYTYPE,$MODULE_NAME)}</td>
+									</tr>
+									<tr class="relatedActivitiesEntries">
+										<td class="relatedActivitiesLabel" valign="top">{vtranslate('Description')}</td>
+										<td class="relatedActivitiesValue">{$DESCRIPTION|nl2br}</td>
+									</tr>
+								</table>
+							</div>
+
+							<div class='col-lg-2 col-md-2 col-sm-2 activityStatus' style='line-height: 0px;padding-right:30px;'>
+								<div class="row">
+									{if $RECORD->get('activitytype') eq 'Task'}
+										{assign var=MODULE_NAME value=$RECORD->getModuleName()}
+										<input type="hidden" class="activityModule" value="{$RECORD->getModuleName()}"/>
+										<input type="hidden" class="activityType" value="{$RECORD->get('activitytype')}"/>
+										<div class="pull-right">
+											 {assign var=FIELD_MODEL value=$RECORD->getModule()->getField('taskstatus')}
+											<style>
+												{assign var=PICKLIST_COLOR_MAP value=Settings_Picklist_Module_Model::getPicklistColorMap('taskstatus', true)}
+												{foreach item=PICKLIST_COLOR key=PICKLIST_VALUE from=$PICKLIST_COLOR_MAP}
+													{assign var=PICKLIST_TEXT_COLOR value=Settings_Picklist_Module_Model::getTextColor($PICKLIST_COLOR)}
+													{assign var=CONVERTED_PICKLIST_VALUE value=Vtiger_Util_Helper::convertSpaceToHyphen($PICKLIST_VALUE)}
+														.picklist-{$FIELD_MODEL->getId()}-{Vtiger_Util_Helper::escapeCssSpecialCharacters($CONVERTED_PICKLIST_VALUE)} {
+															background-color: {$PICKLIST_COLOR};color: {$PICKLIST_TEXT_COLOR};
+														}
+												{/foreach}
+											</style>
+											<strong><span class="value picklist-color picklist-{$FIELD_MODEL->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RECORD->get('status'))}">{vtranslate($RECORD->get('status'),$MODULE_NAME)}</span></strong>&nbsp&nbsp;
+											{if $EDITVIEW_PERMITTED == 'yes'}
+												<span class="editStatus cursorPointer"><i class="fa fa-pencil" title="{vtranslate('LBL_EDIT',$MODULE_NAME)}"></i></span>
+												<span class="edit hide">
+													{assign var=FIELD_VALUE value=$FIELD_MODEL->set('fieldvalue', $RECORD->get('status'))}
+													{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE_NAME) FIELD_MODEL=$FIELD_MODEL USER_MODEL=$USER_MODEL MODULE=$MODULE_NAME OCCUPY_COMPLETE_WIDTH='true'}
+													<input type="hidden" class="fieldname" value='{$FIELD_MODEL->get('name')}' data-prev-value='{$FIELD_MODEL->get('fieldvalue')}' />
+												</span>
+											{/if}
+										</div>
+									{else}
+										{assign var=MODULE_NAME value="Events"}
+										<input type="hidden" class="activityModule" value="Events"/>
+										<input type="hidden" class="activityType" value="{$RECORD->get('activitytype')}"/>
+										<div class="pull-right">
+											{assign var=FIELD_MODEL value=$RECORD->getModule()->getField('eventstatus')}
+											<style>
+												{assign var=PICKLIST_COLOR_MAP value=Settings_Picklist_Module_Model::getPicklistColorMap('eventstatus', true)}
+												{foreach item=PICKLIST_COLOR key=PICKLIST_VALUE from=$PICKLIST_COLOR_MAP}
+													{assign var=PICKLIST_TEXT_COLOR value=Settings_Picklist_Module_Model::getTextColor($PICKLIST_COLOR)}
+													{assign var=CONVERTED_PICKLIST_VALUE value=Vtiger_Util_Helper::convertSpaceToHyphen($PICKLIST_VALUE)}
+														.picklist-{$FIELD_MODEL->getId()}-{Vtiger_Util_Helper::escapeCssSpecialCharacters($CONVERTED_PICKLIST_VALUE)} {
+															background-color: {$PICKLIST_COLOR};color: {$PICKLIST_TEXT_COLOR};
+														}
+												{/foreach}
+											</style>
+											<strong><span class="value picklist-color picklist-{$FIELD_MODEL->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RECORD->get('eventstatus'))}">{vtranslate($RECORD->get('eventstatus'),$MODULE_NAME)}</span></strong>&nbsp&nbsp;
+											{if $EDITVIEW_PERMITTED == 'yes'}
+												<span class="editStatus cursorPointer"><i class="fa fa-pencil" title="{vtranslate('LBL_EDIT',$MODULE_NAME)}"></i></span>
+												<span class="edit hide">
+													{assign var=FIELD_VALUE value=$FIELD_MODEL->set('fieldvalue', $RECORD->get('eventstatus'))}
+													{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE_NAME) FIELD_MODEL=$FIELD_MODEL USER_MODEL=$USER_MODEL MODULE=$MODULE_NAME OCCUPY_COMPLETE_WIDTH='true'}
+													{if $FIELD_MODEL->getFieldDataType() eq 'multipicklist'}
+														<input type="hidden" class="fieldname" value='{$FIELD_MODEL->get('name')}[]' data-prev-value='{$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'))}' />
+													{else}
+														<input type="hidden" class="fieldname" value='{$FIELD_MODEL->get('name')}' data-prev-value='{$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'))}' />
+													{/if}
+												</span>
+											</div>
+										{/if}
+									{/if}
+								</div>
+							</div>
+						</div>
+					</div>
+					<hr>
+				</div>
+			{/foreach}
+		{else}
+			<div class="summaryWidgetContainer noContent">
+				<p class="textAlignCenter">{vtranslate('LBL_NO_PENDING_ACTIVITIES',$MODULE_NAME)}</p>
+			</div>
+		{/if}
+		{if $PAGING_MODEL->isNextPageExists()}
+			<div class="row">
+				<div class="textAlignCenter">
+					<a href="javascript:void(0)" class="moreRecentActivities">{vtranslate('LBL_SHOW_MORE',$MODULE_NAME)}</a>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>
+{/strip}

--- a/layouts/v7/modules/Dailyreports/SummaryViewWidgets.tpl
+++ b/layouts/v7/modules/Dailyreports/SummaryViewWidgets.tpl
@@ -18,7 +18,7 @@
 		{/if}
 	{/foreach}
 
-	<div class="left-block col-lg-4 col-md-4 col-sm-4">
+	<div class="left-block col-lg-4">
 		{* Module Summary View*}
 		<div class="summaryView">
 			<div class="summaryViewHeader">
@@ -31,7 +31,7 @@
 		{* Module Summary View Ends Here*}
 	</div>
 
-	<div class="middle-block col-lg-4 col-md-4 col-sm-4">
+	<div class="middle-block col-lg-8">
 		{* Summary View Related Activities Widget*}
 		<div id="relatedActivities">
 			{$RELATED_ACTIVITIES}
@@ -41,7 +41,7 @@
 		{if $COMMENTS_WIDGET_MODEL}
 			<div class="summaryWidgetContainer">
 				<div class="widgetContainer_comments" data-url="{$COMMENTS_WIDGET_MODEL->getUrl()}" data-name="{$COMMENTS_WIDGET_MODEL->getLabel()}">
-					<div class="widget_header clearfix">
+					<div class="widget_header">
 						<input type="hidden" name="relatedModule" value="{$COMMENTS_WIDGET_MODEL->get('linkName')}" />
 						<h4 class="display-inline-block">{vtranslate($COMMENTS_WIDGET_MODEL->getLabel(),$MODULE_NAME)}</h4>
 					</div>
@@ -52,32 +52,4 @@
 		{/if}
 		{* Summary View Comments Widget Ends Here*}
 	</div>
-
-	<div class="right-block col-lg-4 col-sm-4 col-md-4">
-		{* Summary View Updates Widget *}
-		{if $UPDATES_WIDGET_MODEL}
-			<div class="summaryWidgetContainer">
-				<div class="widgetContainer_updates" data-url="{$UPDATES_WIDGET_MODEL->getUrl()}" data-name="{$UPDATES_WIDGET_MODEL->getLabel()}">
-					<div class="widget_header clearfix">
-						<span class="span9">
-						<h4 class="display-inline-block pull-left">{vtranslate($UPDATES_WIDGET_MODEL->getLabel(),$MODULE_NAME)}</h4></span>
-
-						<span class="span3">
-							{if $UPDATES_WIDGET_MODEL->get('action')}
-								<button class="btn pull-right addButton createRecord" type="button" data-url="{$UPDATES_WIDGET_MODEL->get('actionURL')}">
-									<strong>{vtranslate('LBL_ADD',$MODULE_NAME)}</strong>
-								</button>
-							{/if}
-						</span>
-						<input type="hidden" name="relatedModule" value="{$UPDATES_WIDGET_MODEL->get('linkName')}" />
-					</div>
-					<div class="widget_contents">
-					</div>
-				</div>
-			</div>
-		{/if}
-		{* Summary View Updates Widget Ends Here*}
-
-	</div>
-
 {/strip}


### PR DESCRIPTION
「更新履歴」を非表示にして活動の幅を広げたい(#891)

##  関連Issue / Related Issue

- fix #891 [要望]日報モジュールの概要画面の「活動」部分が読みづらいため、「更新履歴」を非表示にして活動の幅を広げたい

##  変更内容 / Details of Change
1. 日報の概要画面のレイアウトの修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/65175138/8331d685-070e-4a29-bba9-1cd23e514773)

## 影響範囲  / Affected Area
日報の概要画面

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
特になし