### PR TITLE
#872 共有カレンダーの全チェックON/OFF機能の追加

### DIFF
--- a/layouts/v7/modules/Calendar/CalendarSharedUsers.tpl
+++ b/layouts/v7/modules/Calendar/CalendarSharedUsers.tpl
@@ -10,7 +10,12 @@
 {strip}
 
 <div class="calendarGroupSelect">
-<select id="calendar-groups" class="select2">
+	<div id="calendarview-feeds-all">
+		<span> {* すべて選択・解除用のチェックボックス *}
+			<input class="toggleCalendarFeed cursorPointer" type="checkbox">&nbsp;&nbsp;
+		</span>
+	</div>
+<select id="calendar-groups" class="select2" style="flex-grow: 1;">
 <option value="default">{vtranslate('My Group', $MODULE)}</option>
 <optgroup label="-- {vtranslate('Role', 'Users')} --">
 {foreach key=ROLE_ID item=ROLE from=$ALL_ROLES}

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -333,14 +333,22 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		var disabledFeeds = this.getDisabledFeeds();
 		var feedsList = widgetContainer.find('#calendarview-feeds > ul.feedslist');
 		var calendarfeeds = feedsList.find('[data-calendar-feed]');
+		var checkedCount = 0;
 		calendarfeeds.each(function () {
 			var feedCheckbox = jQuery(this);
 			var sourceKey = feedCheckbox.data('calendarSourcekey');
 			if (disabledFeeds.indexOf(sourceKey) === -1) {
 				feedCheckbox.attr('checked', true);
+				checkedCount++;
 			}
 			thisInstance.colorizeFeed(feedCheckbox);
 		});
+		
+		// 全選択チェックボックスを選択する（現時点では共有カレンダーにのみ実装）
+		var feedCheckbox = jQuery('#calendarview-feeds-all .toggleCalendarFeed');
+		if (feedCheckbox.length > 0 && calendarfeeds.length == checkedCount) {
+			feedCheckbox.attr('checked', true);
+		}
 	},
 	fetchEvents: function (feedCheckbox) {
 		var thisInstance = this;
@@ -385,6 +393,21 @@ Vtiger.Class("Calendar_Calendar_Js", {
 					return module === eventObj.module && eventObj.conditions === conditions && fieldName === eventObj.fieldName;
 				});
 	},
+	getCheckedCheckboxCounts: function () {
+		var checkedCount = 0;
+		var $area = $(".list-group.feedslist");
+		$area.children().each(function(){
+			var currentTarget = jQuery(this).find("input");
+			var sourceKey = currentTarget.data('calendarSourcekey');
+			if (sourceKey !== undefined && currentTarget.is(':checked')) {
+				checkedCount++;
+			}
+		})
+		return {
+			checkboxCount: $area.children().length,
+			checkedCount: checkedCount
+		}
+	},
 	registerFeedChangeEvent: function () {
 		var thisInstance = this;
 		jQuery('#calendarview-feeds').on('change',
@@ -399,8 +422,18 @@ Vtiger.Class("Calendar_Calendar_Js", {
 						thisInstance.disableFeed(sourceKey);
 						thisInstance.removeEvents(curentTarget);
 					}
+					// 全選択チェックボックスを選択・解除する
+					var feedCheckbox = jQuery('#calendarview-feeds-all .toggleCalendarFeed');
+					var params = thisInstance.getCheckedCheckboxCounts();
+					if (feedCheckbox.length > 0) {
+						if (params.checkboxCount > params.checkedCount) {
+							feedCheckbox.removeAttr('checked');
+						}else if (params.checkboxCount == params.checkedCount) {
+							feedCheckbox.attr('checked','checked');
+						}
+					}
 				});
-		// すべて選択・解除
+		// 全選択チェックボックス（現時点では共有カレンダーにのみ実装）
 		jQuery('#calendarview-feeds-all').on('change',
 		'input[type="checkbox"].toggleCalendarFeed',
 				function () {

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -400,6 +400,30 @@ Vtiger.Class("Calendar_Calendar_Js", {
 						thisInstance.removeEvents(curentTarget);
 					}
 				});
+		// すべて選択・解除
+		jQuery('#calendarview-feeds-all').on('change',
+		'input[type="checkbox"].toggleCalendarFeed',
+				function () {
+					var feedCheckbox = jQuery(this);
+					var $area = $(".list-group.feedslist");
+
+					$area.children().each(function(){
+						var currentTarget = jQuery(this).find("input");
+						var sourceKey = currentTarget.data('calendarSourcekey');
+			
+						if (sourceKey !== undefined) {
+							if (feedCheckbox.is(':checked') && !currentTarget.is(':checked')) {
+								currentTarget.attr('checked','checked');
+								thisInstance.enableFeed(sourceKey);
+								thisInstance.addEvents(currentTarget);
+							} else if (!feedCheckbox.is(':checked') && currentTarget.is(':checked')) {
+								currentTarget.removeAttr('checked');
+								thisInstance.disableFeed(sourceKey);
+								thisInstance.removeEvents(currentTarget);
+							}
+						}
+					})
+				});
 	},
 	updateRangeFields: function (container, options) {
 		var moduleName = container.find('select[name="modulesList"]').val();

--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -395,7 +395,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	},
 	getCheckedCheckboxCounts: function () {
 		var checkedCount = 0;
-		var $area = $(".list-group.feedslist");
+		var $area = jQuery("#calendarview-feeds .feedslist");
 		$area.children().each(function(){
 			var currentTarget = jQuery(this).find("input");
 			var sourceKey = currentTarget.data('calendarSourcekey');
@@ -438,7 +438,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		'input[type="checkbox"].toggleCalendarFeed',
 				function () {
 					var feedCheckbox = jQuery(this);
-					var $area = $(".list-group.feedslist");
+					var $area = jQuery("#calendarview-feeds .feedslist");
 
 					$area.children().each(function(){
 						var currentTarget = jQuery(this).find("input");

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -3917,6 +3917,11 @@ th {
 .calendar-sidebar-tabs .active-link {
   color: white;
 }
+.calendarGroupSelect {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+}
 .activitytypes .activitytype-indicator {
   padding: 5%;
   margin: 8px;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -3917,11 +3917,6 @@ th {
 .calendar-sidebar-tabs .active-link {
   color: white;
 }
-.calendarGroupSelect {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-}
 .activitytypes .activitytype-indicator {
   padding: 5%;
   margin: 8px;

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -644,3 +644,10 @@ ul#productsImageContainer > li a{
 #ccLink{
   margin-right: 5px;
 }
+
+/* 共有カレンダーのグループ選択の横にチェックボックスを追加する */
+.calendarGroupSelect {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #872 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワンボタンで現状表示されているグループの全チェック/全解除が出来るような機能が欲しい

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* マイグループの左に全チェック/全解除用のチェックボックスを配置
* 各ユーザーの状態と全チェックボックスの状態が連動するように修正
  * すべてのユーザーにチェックがついたら, 全チェックボックス→☑
  * いずれかのユーザーのチェックが外れていたら, 全チェックボックス→□

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* 選択前の状況
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/8ea4e311-27eb-4f5b-a543-2de1dfe836f7)

* 全選択
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/7cdc2888-b148-49cb-9d4d-52c1831c816b)

* 全解除
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/bda4e281-5911-489e-be34-b787625eaab1)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->