### PR TITLE
活動に項目を追加するとゴミ箱のカレンダーでエラーが発生する不具合を修正

### DIFF
--- a/modules/Vtiger/models/ListView.php
+++ b/modules/Vtiger/models/ListView.php
@@ -167,6 +167,12 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 				$matches=null;
 			} else {
 				$fieldInstance = Vtiger_Field_Model::getInstance($fieldName,$module);
+				
+				if(!$fieldInstance && $module->getName() === 'Calendar') {
+					$eventsModule = Vtiger_Module_Model::getInstance('Events');
+					$fieldInstance = Vtiger_Field_Model::getInstance($fieldName,$eventsModule);
+				}
+				
 				$fieldInstance->set('listViewRawFieldName', $fieldInstance->get('column'));
 				$headerFieldModels[$fieldName] = $fieldInstance;
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #912

##  不具合の内容 / Bug
活動の追加項目を共有リスト「すべて」に表示した状態にて、ゴミ箱のカレンダーのリストを開くとFatalエラーが発生し、ゴミ箱の中身を表示することができない。

##  原因 / Cause
ゴミ箱でリスト表示する際に、Calendarのフィールドモデルしか取得を行っていなかったことが原因。
Eventsにしか存在しないフィールドがあった場合、フィールドモデルが取得できず、表示に使用するフィールド名をセットするメソッドによりFatalエラーが発生していた。

##  変更内容 / Details of Change
Vtiger_ListView_Model クラスのgetListViewHeadersメソッドにて、モジュール名がCalendarかつCalendarモジュールのフィールドモデルで取得が出来なかった場合、Eventsモジュールのフィールドモデルで取得を行うように修正。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
Vtiger_ListView_Model クラスのgetListViewHeadersメソッドを利用する処理

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->