### PR TITLE
fixed #919 ドキュメント：作成されたリスト、レポートの条件でフォルダ名を使用すると正しく動作しない

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
@@ -655,7 +655,7 @@ Vtiger_Field_Js('AdvanceFilter_Field_Js',{},{
 		var currentModule = app.getModuleName();
 
 		var type = this.getType();
-		if(type == 'picklist' || type == 'multipicklist' || type == 'owner' || type == 'ownergroup' || type == 'date' || type == 'datetime' || type == 'currencyList') {
+		if(type == 'picklist' || type == 'multipicklist' || type == 'owner' || type == 'ownergroup' || type == 'date' || type == 'datetime' || type == 'currencyList' || type == 'documentsFolder') {
             currentModule = 'AdvanceFilter';
 		}
 		return currentModule;
@@ -791,6 +791,40 @@ Vtiger_Multipicklist_Field_Js('AdvanceFilter_Multipicklist_Field_Js',{},{
 		} else {	
 			return this._super();
 		} 
+	}
+});
+
+Vtiger_Documentsfolder_Field_Js('AdvanceFilter_Documentsfolder_Field_Js',{},{
+
+	/**
+	 * Function to get the ui
+	 * @return - select element and chosen element
+	 */
+	getUi : function() {
+		//added class inlinewidth
+		var html = '<select class="select2 inputElement inlinewidth" name="'+ this.getName() +'" id="field_Documents_'+this.getName()+'">';
+		var pickListValues = this.getPickListValues();
+		var selectedOption = app.htmlDecode(this.getValue());
+
+		if(typeof pickListValues[' '] == 'undefined' || pickListValues[' '].length <= 0 || pickListValues[' '] != 'Select an Option') {
+			html += '<option value="">'+app.vtranslate('JS_SELECT_OPTION')+'</option>';
+		}
+
+		var data = this.getData();
+
+		var fieldName = this.getName();
+		for(var option in pickListValues) {
+			html += '<option value="'+pickListValues[option]+'" ';
+			if(pickListValues[option] == selectedOption) {
+				html += ' selected ';
+			}
+			html += '>'+pickListValues[option]+'</option>';
+		}
+		html +='</select>';
+
+		var selectContainer = jQuery(html);
+		this.addValidationToElement(selectContainer);
+		return selectContainer;
 	}
 });
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #919

##  不具合の内容 / Bug
1. リストの新規作成
1. 条件にフォルダ名を入れた条件を作成
1. 作成したリストでリスト表示
1. 1件も表示されない

##  原因 / Cause
1. QueryGeneratorではフォルダ名で比較を行っているが、保存されている内容はIDで行っているため不一致が起きていた

##  変更内容 / Details of Change
1. AdvanceFilterを使用した際はフォルダ名を保存するように修正

## 影響範囲  / Affected Area
1. ドキュメントのリスト追加の条件 (フォルダ名を使用した場合)
1. レポートの条件 (フォルダ名を使用した場合)

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
既存のリスト、レポートは再度設定する必要がある
