### PR TITLE
カレンダーリスト画面でステータス項目によりソートを行うとレコードが1件も表示されない

### DIFF
--- a/include/QueryGenerator/EnhancedQueryGenerator.php
+++ b/include/QueryGenerator/EnhancedQueryGenerator.php
@@ -269,12 +269,7 @@ class EnhancedQueryGenerator extends QueryGenerator {
 					$sql = $this->getSQLColumn($timeField);
 				} else if ($field == 'taskstatus' || $field == 'eventstatus') {
 					//In calendar list view, Status value = Planned is not displaying
-					$sql = "CASE WHEN (vtiger_activity.status not like '') THEN vtiger_activity.status ELSE vtiger_activity.eventstatus END AS ";
-					if ($field == 'taskstatus') {
-						$sql .= "status";
-					} else {
-						$sql .= $field;
-					}
+					$sql = "CASE WHEN (vtiger_activity.status not like '') THEN vtiger_activity.status ELSE vtiger_activity.eventstatus END AS status";
 				}
 				$columns[] = $sql;
 			}

--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -411,12 +411,7 @@ class QueryGenerator {
 					$sql = $this->getSQLColumn($timeField);
 				} else if ($field == 'taskstatus' || $field == 'eventstatus') {
 					//In calendar list view, Status value = Planned is not displaying
-					$sql = "CASE WHEN (vtiger_activity.status not like '') THEN vtiger_activity.status ELSE vtiger_activity.eventstatus END AS ";
-					if ( $field == 'taskstatus') {
-						$sql .= "status";
-					} else {
-						$sql .= $field;
-					}
+					$sql = "CASE WHEN (vtiger_activity.status not like '') THEN vtiger_activity.status ELSE vtiger_activity.eventstatus END AS status";
 				}
 				$columns[] = $sql;
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #921

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダーのリスト画面にて、ステータス(活動の基本情報ブロック内のステータス)項目でレコードのソートを変更するとレコードが表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
一覧リストに表示する際にレコードを取得するクエリのソート句にて、存在しないカラム名を指定してしまう場合があり、正常に結果が取得されずレコードが0件となっていた。
1.  一覧リスト表示の際は、statusカラム(TODOのステータス)とeventstatusカラム(活動のステータス)をまとめて別名を付け、statusカラムとして取得を行っている。
2. カレンダーのリストには2つの「ステータス」フィールドが存在しており、ラベル名は同じ「ステータス」だが、内部ではtaskstatusとeventstatusに分かれている。
3. 取得クエリを組み立てる処理の中で、taskstatusフィールドでソート条件を指定した場合は、クエリ内のソートカラムの名称がstatusとなるが、eventstatusフィールドでソート条件をしていた場合は、クエリ内のソートカラムの名称がeventstatusになってしまう。
4. その結果、クエリ内に存在しないeventstatusカラム利用してソートをかけようとしたため、クエリの実行が正常に実行されず、レコードの取得に失敗していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
一覧リストに表示する際にレコードを取得するクエリの生成処理のソート句処理部分にて、正しいカラム名が指定されるように修正。

1. include\QueryGenerator\QueryGenerator.php 
2. include\QueryGenerator\EnhancedQueryGenerator.php 

## 影響範囲  / Affected Area
カレンダーのリスト表示機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った