### PR TITLE
カレンダーのリストにて「ステータス」でソートをかけたまま「ステータス」を非表示にするとレコードが表示されない

### DIFF
--- a/modules/Calendar/models/ListView.php
+++ b/modules/Calendar/models/ListView.php
@@ -183,7 +183,9 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 		$queryGenerator = $this->get('query_generator');
 		$listViewContoller = $this->get('listview_controller');
 		$listViewFields = array('visibility','assigned_user_id');
-		$queryGenerator->setFields(array_unique(array_merge($queryGenerator->getFields(), $listViewFields)));
+		
+		$querySetFields = $queryGenerator->getFields();
+		$queryGenerator->setFields(array_unique(array_merge($querySetFields, $listViewFields)));
 		
         $searchParams = $this->get('search_params');
         if(empty($searchParams)) {
@@ -204,6 +206,10 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 		}
         
         $orderBy = $this->getForSql('orderby');
+		if(is_countable($querySetFields) && !in_array($orderBy, $querySetFields, true)) {
+			$orderBy = '';
+		}
+		
 		$sortOrder = $this->getForSql('sortorder');
         if(empty($sortOrder)) {
             $sortOrder = 'DESC';


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #922

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダーの一覧リスト画面にて「ステータス」項目でソートをかけた状態にして、「ステータス」項目を非表示にするとレコードが表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
内部でのステータス項目の取り扱い上、2カラムの結果を統合し別名が付けられているため、「ステータス」項目を非表示にした場合、別名のカラムが見つからずレコードの取得に失敗していた。
1. DBのカラムとして、status(TODOのステータス)とeventstatus(活動のステータス)が存在している。
2. リスト画面でレコードを取得する場合、statusとeventstatusは1カラムに統合され、別名が付いた状態で結果として返ってくる。
3. リストでステータスのソートを実行したまま、ステータス項目の列を削除した場合、統合された別名のカラムが存在しないため、レコードの取得に失敗する。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
クエリ生成処理に渡す対象のフィールド名が、取得対象のフィールドに含まれているかチェックし、含まれていない場合は、デフォルトの更新日時でソートされるように修正。

## 影響範囲  / Affected Area
カレンダーのリスト表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った