### PR TITLE
カレンダーリストに「ステータス」が2列表示できてしまう不具合の修正

### DIFF
--- a/modules/Calendar/models/FilterRecordStructure.php
+++ b/modules/Calendar/models/FilterRecordStructure.php
@@ -20,6 +20,7 @@ class Calendar_FilterRecordStructure_Model extends Vtiger_FilterRecordStructure_
 		}
 
 		$values = array();
+		$taskstatusFieldModel = null;
 		$recordModel = $this->getRecord();
 		$recordExists = !empty($recordModel);
 		$baseModuleModel = $moduleModel = $this->getModule();
@@ -30,8 +31,12 @@ class Calendar_FilterRecordStructure_Model extends Vtiger_FilterRecordStructure_
 			if ($fieldModelList) {
 				$values[vtranslate($blockLabel, $baseModuleName)] = array();
 				foreach ($fieldModelList as $fieldName => $fieldModel) {
-					if ($fieldModel->isViewableInFilterView()) {
+					if ($fieldModel->isViewableInFilterView() && $fieldName !== 'eventstatus') {
 						$newFieldModel = clone $fieldModel;
+						if($fieldName === 'taskstatus') {
+							$taskstatusFieldModel = clone $fieldModel;
+						}
+						
 						if ($recordExists) {
 							$newFieldModel->set('fieldvalue', $recordModel->get($fieldName));
 						}
@@ -50,7 +55,12 @@ class Calendar_FilterRecordStructure_Model extends Vtiger_FilterRecordStructure_
                 $values[vtranslate($blockLabel, 'Events')] = array();
                 foreach ($fieldModelList as $fieldName => $fieldModel) {
                     if ($fieldModel->isViewableInFilterView()) {
-                        $newFieldModel = clone $fieldModel;
+						if($fieldName === 'eventstatus' && $taskstatusFieldModel) {
+							$newFieldModel = $taskstatusFieldModel;
+						}else {
+							$newFieldModel = clone $fieldModel;
+						}
+						
                         if ($recordExists) {
                             $newFieldModel->set('fieldvalue', $recordModel->get($fieldName));
                         }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #923

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダーのリスト画面にてステータス項目を2列表示することができる。

##  原因 / Cause
<!-- バグの原因を記述 -->
TODOと活動にそれぞれ「ステータス」項目があり、リストに表示する際は２つのステータス項目を統合して表示を行うが、項目に選択画面ではそのことが考慮されていないため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
２つの項目のうち、リスト表示する場合はtaskstatus項目にeventstatus項目の値を統合して表示することから、eventstatus項目を選択するステータスの選択肢が表示されないように修正

## 影響範囲  / Affected Area
カレンダーのリスト表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った