### PR TITLE
fixed #931 [不具合]レポート：ドキュメントを主モジュールにして作成した場合、関連モジュールを選択しても関連モジュールのデータが…

### DIFF
--- a/modules/Documents/Documents.php
+++ b/modules/Documents/Documents.php
@@ -414,8 +414,8 @@ class Documents extends CRMEntity {
 	 * returns the array with table names and fieldnames storing relations between module and this module
 	 */
 	function setRelationTables($secmodule){
-		$rel_tables = array();
-		return $rel_tables[$secmodule];
+		// どのモジュールと紐づいてもvtiger_senotesrelで紐づけられている
+		return array("vtiger_senotesrel"=>array("notesid","crmid"),"".$this->table_name."" => "".$this->table_index."");
 	}
 
 	// Function to unlink all the dependent entities of the given Entity by Id


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #919

##  不具合の内容 / Bug
1. ドキュメントを作成
1. 上記を紐づけた案件を作成
1. レポートを作成 - 主モジュール：ドキュメント　関連モジュール：案件
1. 案件の内容を表示するように設定
1. レポートに案件の内容が表示されない 

##  原因 / Cause
1. テーブルの紐づけが正しく設定されていなかったため

##  変更内容 / Details of Change
1. Documentsの関連テーブルを設定

## スクリーンショット / Screenshot
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/65175138/22cf3b44-096e-4818-b953-f0dbb4966786)


## 影響範囲  / Affected Area
- ドキュメントを使用したレポート

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
　特になし