### PR TITLE
レポートにて関連の参照先を選択できるように修正

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -2320,8 +2320,9 @@ class CRMEntity {
 						$rel_obj = CRMEntity::getInstance($rel_mod);
 						vtlib_setup_modulevars($rel_mod, $rel_obj);
 
-						$rel_tab_name = $rel_obj->table_name;
-						$rel_tab_index = $rel_obj->table_index;
+						$entityTableFieldNames = getEntityFieldNames($rel_mod);
+						$rel_tab_name = $entityTableFieldNames['tablename'];
+						$rel_tab_index = $entityTableFieldNames['entityidfield'];
 
 						$rel_tab_name_rel_module_table_alias = $rel_tab_name . "Rel$module$field_id";
 
@@ -2368,7 +2369,7 @@ class CRMEntity {
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
 
-	function generateReportsSecQuery($module, $secmodule,$queryPlanner) {
+	function generateReportsSecQuery($module, $secmodule,$queryPlanner, $reportid = false) {
 		global $adb;
 		$secondary = CRMEntity::getInstance($secmodule);
 
@@ -2379,10 +2380,14 @@ class CRMEntity {
 		$modulecftable = $secondary->customFieldTable[0];
 		$modulecfindex = $secondary->customFieldTable[1];
 
+		$cfquery = '';
+		foreach($this->tab_name_index as $modulecftable => $modulecfindex) {
+			if($modulecftable == 'vtiger_crmentity' || $modulecftable == $tablename) {
+				continue;
+			}
 		if (isset($modulecftable) && $queryPlanner->requireTable($modulecftable)) {
 			$cfquery = "left join $modulecftable as $modulecftable on $modulecftable.$modulecfindex=$tablename.$tableindex";
-		} else {
-			$cfquery = '';
+			}
 		}
 
 		$relquery = '';
@@ -2416,7 +2421,16 @@ class CRMEntity {
 					$matrix->addDependency($tab_name, $crmentityRelSecModuleTable);
 
 					if ($queryPlanner->requireTable($crmentityRelSecModuleTable, $matrix)) {
-						$relquery .= " left join vtiger_crmentity as $crmentityRelSecModuleTable on $crmentityRelSecModuleTable.crmid = $tab_name.$field_name and $crmentityRelSecModuleTable.deleted=0";
+						// Usersを関連にした場合、vtiger_crmentityをJoinするとレコードがないため、vtiger_usersを一度JOINする
+						if($rel_mod == "Users"){
+							// vtiger_crmentityの代わりとして動かすため、
+							//   - vtiger_users.id as `crmid` として振る舞わせる
+							//   - deleted = 0となっていた箇所は、vtiger_users.status = 'Active'で判定する
+							// [TODO] Usersの場合、通常のレコードとは異なり過去のユーザーも見せたいのであれば、この判定は無く必要がある
+							$relquery.= " LEFT JOIN (select u.*, u.id as `crmid` from vtiger_users u) AS $crmentityRelSecModuleTable ON $crmentityRelSecModuleTable.id = $tab_name.$field_name AND vtiger_crmentityRel$secmodule$field_id.status='Active'";
+						}else{
+							$relquery .= " left join vtiger_crmentity as $crmentityRelSecModuleTable on $crmentityRelSecModuleTable.crmid = $tab_name.$field_name and $crmentityRelSecModuleTable.deleted=0";
+						}
 					}
 					for ($j = 0; $j < $adb->num_rows($ui10_modules_query); $j++) {
 						$rel_mod = $adb->query_result($ui10_modules_query, $j, 'relmodule');
@@ -2439,11 +2453,11 @@ class CRMEntity {
 		$matrix->setDependency("vtiger_crmentity$secmodule", array("vtiger_groups$secmodule", "vtiger_users$secmodule", "vtiger_lastModifiedBy$secmodule"));
 		$matrix->addDependency($tablename, "vtiger_crmentity$secmodule");
 
-		if (!$queryPlanner->requireTable($tablename, $matrix) && !$queryPlanner->requireTable($modulecftable)) {
-			return '';
-		}
+		// if (!$queryPlanner->requireTable($tablename, $matrix) && !$queryPlanner->requireTable($modulecftable)) {
+		// 	return '';
+		// }
 
-		$query = $this->getRelationQuery($module, $secmodule, "$tablename", "$tableindex", $queryPlanner);
+		$query = $this->getRelationQuery($module, $secmodule, "$tablename", "$tableindex", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentity$secmodule", $matrix)) {
 			// $query .= " left join vtiger_crmentity as vtiger_crmentity$secmodule on vtiger_crmentity$secmodule.crmid = $tablename.$tableindex AND vtiger_crmentity$secmodule.deleted=0";
@@ -2543,7 +2557,12 @@ class CRMEntity {
 							$rel_obj = CRMEntity::getInstance($rel_mod);
 							vtlib_setup_modulevars($rel_mod, $rel_obj);
 
-							$rel_tab_name = $rel_obj->table_name;
+							$rel_module_entityname_query = $adb->pquery("SELECT tablename FROM vtiger_entityname WHERE modulename=?", array($rel_mod));
+							if ($adb->num_rows($rel_module_entityname_query) > 0) {
+								for ($j = 0; $j < $adb->num_rows($rel_module_entityname_query); $j++) {
+									$rel_tab_name = $adb->query_result($rel_module_entityname_query, $j, 'tablename');
+								}
+							}
 							$rel_tab_index = $rel_obj->table_index;
 
 							$rel_tab_name_rel_module_table_alias = $rel_tab_name . "Rel$module$field_id";
@@ -2598,8 +2617,31 @@ class CRMEntity {
 	 * returns the query string formed on relating the primary module and secondary module
 	 */
 
-	function getRelationQuery($module, $secmodule, $table_name, $column_name, $queryPlanner) {
-		$tab = getRelationTables($module, $secmodule);
+	function getRelationQuery($module, $secmodule, $table_name, $column_name, $queryPlanner, $reportid = false) {
+		global $adb;
+
+		// selected join column
+		$joinColumn = $queryPlanner->getReportJoinColumn();
+		$joinTypes = explode(",", $joinColumn);
+		foreach($joinTypes as $tmpKey) {
+			if(strpos($tmpKey, $secmodule.'::') === 0) {
+				$joinKey = $tmpKey;
+				break;
+			}
+		}
+		$reportModel = new Reports_Record_Model();
+		$tabs = $reportModel->getRelationTables($module, $secmodule);
+		foreach($tabs as $tmpKey => $tmpTab) {
+			if(strpos($tmpKey, $joinKey) === 0) {
+				$tab = $tmpTab;
+				break;
+			}
+		}
+
+		// default
+		if(empty($tab)) {
+			$tab = getRelationTables($module, $secmodule);
+		}
 
 		foreach ($tab as $key => $value) {
 			$tables[] = $key;
@@ -2611,14 +2653,38 @@ class CRMEntity {
 		$secfieldname = $fields[0][1];
 		$tmpname = $pritablename . 'tmp' . $secmodule;
 		$condition = "";
-		if (!empty($tables[1]) && !empty($fields[1])) {
+
+		// 選択している関連項目が親か子かを判断する
+		$join_column_result = $adb->query("select join_column from vtiger_reportmodules where reportmodulesid=$reportid");
+		$join_column = $adb->query_result($join_column_result, 0, 'join_column');
+		$join_column_array = explode(",", $join_column);
+		foreach ($join_column_array as $key => $value) {
+			if(!$value) continue;
+			$valuearray = explode("::", $value);
+			$join_column_array[$valuearray[0]] = $valuearray;
+		}
+
+		$ischild_selectedjoin = false;
+		if($join_column_array[$secmodule] != "" && (count($join_column_array[$secmodule]) == 0 || $join_column_array[$secmodule][1] != $module)){
+			// 関連先の項目を指定していて、子の場合
+			$ischild_selectedjoin = true;
+		}
+
+		$ischild_firstjoincolum = false;
+		if(!empty($tables[1]) && !empty($fields[1]) && (strpos($tables[1], $tables[0]) === false) && (strpos($tables[0], $tables[1]) === false)){
+			// 関連先の1つ目の選択肢が子の場合
+			$ischild_firstjoincolum = true;
+		}
+
+		if ($ischild_selectedjoin || $ischild_firstjoincolum) {
+			//子の場合
 			$condvalue = $tables[1] . "." . $fields[1];
 			$condition = "$table_name.$prifieldname=$condvalue";
 		} else {
+			//親の場合
 			$condvalue = $table_name . "." . $column_name;
 			$condition = "$pritablename.$secfieldname=$condvalue";
 		}
-
 		$selectColumns = "$table_name.*";
 
 		// Look forward for temporary table usage as defined by the QueryPlanner
@@ -2653,10 +2719,8 @@ class CRMEntity {
 			if($secmodule == "Emails") {
 				$tableName .='Emails';
 			}
-			$condition = "($tableName.$column_name={$tmpname}.{$secfieldname} " .
-					"OR $tableName.$column_name={$tmpname}.{$prifieldname})";
-			$query = " left join vtiger_crmentityrel as $tmpname ON (($condvalue={$tmpname}.{$secfieldname} " .
-					"OR $condvalue={$tmpname}.{$prifieldname})) AND ({$tmpname}.module='{$secmodule}' OR {$tmpname}.relmodule='{$secmodule}') ";
+			$condition = " $tableName.$column_name={$tmpname}.{$prifieldname} ";
+			$query = " left join (SELECT crmid as crmid,module as module FROM vtiger_crmentityrel UNION SELECT relcrmid as crmid,relmodule as module FROM vtiger_crmentityrel) as $tmpname ON $condvalue={$tmpname}.{$prifieldname} AND {$tmpname}.module='{$secmodule}'";
 		} elseif (strripos($pritablename, 'rel') === (strlen($pritablename) - 3)) {
 			$instance = self::getInstance($module);
 			$sectableindex = $instance->tab_name_index[$sectablename];

--- a/include/utils/VTCacheUtils.php
+++ b/include/utils/VTCacheUtils.php
@@ -356,7 +356,7 @@ class VTCacheUtils {
 		return false;
 	}
 	static function updateReport_Info($userid, $reportid, $primarymodule, $secondarymodules, $reporttype,
-	$reportname, $description, $folderid, $owner) {
+	$reportname, $description, $folderid, $owner, $joinColumn) {
 		if(!isset(self::$_reportmodule_infoperuser_cache[$userid])) {
 			self::$_reportmodule_infoperuser_cache[$userid] = array();
 		}
@@ -369,7 +369,8 @@ class VTCacheUtils {
 				'reportname'      => $reportname,
 				'description'     => $description,
 				'folderid'        => $folderid,
-				'owner'           => $owner
+				'owner'           => $owner,
+				'join_column'     => $joinColumn
 			);
 		}
 	}

--- a/languages/ja_jp/Reports.php
+++ b/languages/ja_jp/Reports.php
@@ -88,6 +88,9 @@ $languageStrings = array(
 	'LBL_AVERAGE' => '平均',
 	'LBL_LOWEST_VALUE' => '最小値',
 	'LBL_HIGHEST_VALUE' => '最大値',
+	'LBL_HIGHEST_VALUE' => '最大値',
+	'LBL_RELATED_FIELD' => '関連の参照先',
+	'LBL_AUTO_SELECT' => '自動選択',
 
 	//Step3 Strings
 	'LBL_GENERATE_REPORT' => '保存とレポートの生成',

--- a/layouts/v7/modules/Reports/step2.tpl
+++ b/layouts/v7/modules/Reports/step2.tpl
@@ -38,6 +38,7 @@
         <input type="hidden" name="specificemails" value={ZEND_JSON::encode($REPORT_MODEL->get('specificemails'))}>
         <input type="hidden" name="schtypeid" value="{$REPORT_MODEL->get('schtypeid')}">
         <input type="hidden" name="fileformat" value="{$REPORT_MODEL->get('fileformat')}">
+        <input type="hidden" name="joinColumn" value={$REPORT_MODEL->getJoinColumn()}>
 
         <input type="hidden" class="step" value="2" />
         <div class="" style="border:1px solid #ccc;padding:4%;">
@@ -64,6 +65,32 @@
                     {/foreach}
                 </select>
             </div>
+            {if !empty($SECONDARY_MODULES)}
+            <div class="form-group">
+                <div class="row">
+                    {foreach $SECONDARY_MODULES as $SECONDARY_MODULE_NAME}
+                    <label class="col-lg-6">{vtranslate('LBL_RELATED_FIELD',$MODULE)} : {vtranslate($SECONDARY_MODULE_NAME, $SECONDARY_MODULE_NAME)}</label>
+                    {/foreach}
+                </div>
+                <div class="">
+                    {assign var=JOIN_COLUMN value=explode(",", $REPORT_MODEL->getJoinColumn())}
+                    {foreach $SECONDARY_MODULES as $SECONDARY_MODULE_NAME}
+                    <div class="col-lg-6">
+                        <select class="select2" name="joinfield_{$SECONDARY_MODULE_NAME}">
+                            <option value="">{vtranslate("LBL_AUTO_SELECT", $MODULE)}
+                            {assign var=RELATION_TABLES value=$REPORT_MODEL->getRelationTables($PRIMARY_MODULE_NAME, $SECONDARY_MODULE_NAME)}
+                            {foreach key=JOIN_KEY item=JOIN_VALUE from=$RELATION_TABLES}
+                            {assign var=KEY_VALUE value=explode("::", $JOIN_KEY)}
+                            {assign var=JOIN_KEYNAME value="`$KEY_VALUE[0]`::`$KEY_VALUE[1]`::`$KEY_VALUE[2]`"}
+                            {if $KEY_VALUE[2] eq "default"}{continue}{/if}
+                            <option value="{$JOIN_KEYNAME}" {foreach key=JOIN_COLUMN_KEY item=JOIN_COLUMN_VALUE from=$JOIN_COLUMN}{if $JOIN_KEYNAME eq $JOIN_COLUMN_VALUE}selected{/if}{/foreach}>{vtranslate($KEY_VALUE[3], $KEY_VALUE[1])}
+                            {/foreach}
+                        </select>
+                    </div>
+                    {/foreach}
+                </div>
+            </div>
+            {/if}
             <div class="form-group">
                 <div class="row">
                     <label class="col-lg-6">{vtranslate('LBL_GROUP_BY',$MODULE)}</label>

--- a/layouts/v7/modules/Reports/step3.tpl
+++ b/layouts/v7/modules/Reports/step3.tpl
@@ -38,6 +38,7 @@
         <input type="hidden" name="specificemails" value={ZEND_JSON::encode($REPORT_MODEL->get('specificemails'))}>
         <input type="hidden" name="schtypeid" value="{$REPORT_MODEL->get('schtypeid')}">
         <input type="hidden" name="fileformat" value="{$REPORT_MODEL->get('fileformat')}">
+        <input type="hidden" name="joinColumn" value={$REPORT_MODEL->get('joinColumn')}>
 
         <input type="hidden" name="date_filters" data-value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($DATE_FILTERS))}' />
         {assign var=RECORD_STRUCTURE value=array()}

--- a/modules/Accounts/Accounts.php
+++ b/modules/Accounts/Accounts.php
@@ -1061,7 +1061,7 @@ class Accounts extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityAccounts', array('vtiger_groupsAccounts', 'vtiger_usersAccounts', 'vtiger_lastModifiedByAccounts'));
@@ -1087,7 +1087,7 @@ class Accounts extends CRMEntity {
             $query = "";
         }
 
-		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_account","accountid", $queryPlanner);
+		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_account","accountid", $queryPlanner, $reportid);
 
         if($module == "Calendar"){
             $query .= " OR vtiger_account.accountid = vtiger_tmpcontactdetails.accountid " ;

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -1147,7 +1147,7 @@ function insertIntoRecurringTable(& $recurObj)
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityCalendar',array('vtiger_groupsCalendar','vtiger_usersCalendar','vtiger_lastModifiedByCalendar'));
 		$matrix->setDependency('vtiger_cntactivityrel',array('vtiger_contactdetailsCalendar'));
@@ -1164,7 +1164,7 @@ function insertIntoRecurringTable(& $recurObj)
 								'vtiger_seactivityrel','vtiger_activity_reminder','vtiger_recurringevents'));
 
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_activity","activityid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_activity","activityid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityCalendar",$matrix)){
 			$query .=" left join vtiger_crmentity as vtiger_crmentityCalendar on vtiger_crmentityCalendar.crmid=vtiger_activity.activityid and vtiger_crmentityCalendar.deleted=0";

--- a/modules/Campaigns/Campaigns.php
+++ b/modules/Campaigns/Campaigns.php
@@ -560,7 +560,7 @@ class Campaigns extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
         $matrix->setDependency('vtiger_crmentityCampaigns',array('vtiger_groupsCampaigns','vtiger_usersCampaignss','vtiger_lastModifiedByCampaigns','vtiger_campaignscf'));
         
@@ -570,7 +570,7 @@ class Campaigns extends CRMEntity {
 
         $matrix->setDependency('vtiger_campaign', array('vtiger_crmentityCampaigns','vtiger_productsCampaigns'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_campaign","campaignid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_campaign","campaignid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityCampaigns",$matrix)){
 			$query .=" left join vtiger_crmentity as vtiger_crmentityCampaigns on vtiger_crmentityCampaigns.crmid=vtiger_campaign.campaignid and vtiger_crmentityCampaigns.deleted=0";

--- a/modules/Contacts/Contacts.php
+++ b/modules/Contacts/Contacts.php
@@ -1298,7 +1298,7 @@ function get_contactsforol($user_name)
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityContacts',array('vtiger_groupsContacts','vtiger_usersContacts','vtiger_lastModifiedByContacts'));
 		
@@ -1309,7 +1309,7 @@ function get_contactsforol($user_name)
         $matrix->setDependency('vtiger_contactdetails', array('vtiger_crmentityContacts','vtiger_contactaddress',
 								'vtiger_customerdetails','vtiger_contactsubdetails','vtiger_contactscf'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_contactdetails","contactid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_contactdetails","contactid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityContacts",$matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityContacts on vtiger_crmentityContacts.crmid = vtiger_contactdetails.contactid  and vtiger_crmentityContacts.deleted=0";

--- a/modules/Documents/Documents.php
+++ b/modules/Documents/Documents.php
@@ -371,7 +371,7 @@ class Documents extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false) {
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency("vtiger_crmentityDocuments",array("vtiger_groupsDocuments","vtiger_usersDocuments","vtiger_lastModifiedByDocuments"));
@@ -381,7 +381,7 @@ class Documents extends CRMEntity {
 		}
 		$matrix->setDependency("vtiger_notes",array("vtiger_crmentityDocuments","vtiger_attachmentsfolder"));
 		// TODO Support query planner
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_notes","notesid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_notes","notesid", $queryPlanner, $reportid);
 		$query .= " left join vtiger_notescf on vtiger_notes.notesid = vtiger_notescf.notesid";
 		if ($queryPlanner->requireTable("vtiger_crmentityDocuments",$matrix)){
 			$query .=" left join vtiger_crmentity as vtiger_crmentityDocuments on vtiger_crmentityDocuments.crmid=vtiger_notes.notesid and vtiger_crmentityDocuments.deleted=0";

--- a/modules/Emails/Emails.php
+++ b/modules/Emails/Emails.php
@@ -584,7 +584,7 @@ class Emails extends CRMEntity {
 	* @param - $secmodule secondary module name
 	* returns the query string formed on fetching the related data for report for secondary module
 	*/
-	function generateReportsSecQuery($module, $secmodule, $queryPlanner){
+	function generateReportsSecQuery($module, $secmodule, $queryPlanner, $reportid = false){
 		$focus = CRMEntity::getInstance($module);
 		$matrix = $queryPlanner->newDependencyMatrix();
 
@@ -596,7 +596,7 @@ class Emails extends CRMEntity {
 
 		$matrix->setDependency("vtiger_activity",array("vtiger_crmentityEmails","vtiger_email_track"));
 
-		$query = $this->getRelationQuery($module, $secmodule, "vtiger_activity","activityid", $queryPlanner);
+		$query = $this->getRelationQuery($module, $secmodule, "vtiger_activity","activityid", $queryPlanner, $reportid);
 		if ($queryPlanner->requireTable("vtiger_crmentityEmails")){
 			$query .= " LEFT JOIN vtiger_crmentity AS vtiger_crmentityEmails ON vtiger_crmentityEmails.crmid=vtiger_activityEmails.activityid and vtiger_crmentityEmails.deleted = 0";
 		}

--- a/modules/HelpDesk/HelpDesk.php
+++ b/modules/HelpDesk/HelpDesk.php
@@ -590,7 +590,7 @@ case when (vtiger_users.user_name not like '') then $userNameSql else vtiger_gro
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule, $queryPlanner, $reportid = false) {
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency("vtiger_crmentityHelpDesk",array("vtiger_groupsHelpDesk","vtiger_usersHelpDesk","vtiger_lastModifiedByHelpDesk"));
 		$matrix->setDependency("vtiger_crmentityRelHelpDesk",array("vtiger_accountRelHelpDesk","vtiger_contactdetailsRelHelpDesk"));
@@ -602,7 +602,7 @@ case when (vtiger_users.user_name not like '') then $userNameSql else vtiger_gro
         $matrix->setDependency("vtiger_troubletickets",array("vtiger_crmentityHelpDesk","vtiger_ticketcf","vtiger_crmentityRelHelpDesk","vtiger_productsRel"));
 		
 		// TODO Support query planner
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_troubletickets","ticketid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_troubletickets","ticketid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityHelpDesk",$matrix)){
 		    $query .=" left join vtiger_crmentity as vtiger_crmentityHelpDesk on vtiger_crmentityHelpDesk.crmid=vtiger_troubletickets.ticketid and vtiger_crmentityHelpDesk.deleted=0";

--- a/modules/Invoice/Invoice.php
+++ b/modules/Invoice/Invoice.php
@@ -357,7 +357,7 @@ class Invoice extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 
 		// Define the dependency matrix ahead
 		$matrix = $queryPlanner->newDependencyMatrix();
@@ -372,7 +372,7 @@ class Invoice extends CRMEntity {
 				'vtiger_invoicecf', 'vtiger_salesorderInvoice', 'vtiger_invoicebillads',
 				'vtiger_invoiceshipads', 'vtiger_inventoryproductrelInvoice', 'vtiger_contactdetailsInvoice', 'vtiger_accountInvoice'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_invoice","invoiceid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_invoice","invoiceid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable('vtiger_crmentityInvoice', $matrix)) {
 			$query .= " left join vtiger_crmentity as vtiger_crmentityInvoice on vtiger_crmentityInvoice.crmid=vtiger_invoice.invoiceid and vtiger_crmentityInvoice.deleted=0";

--- a/modules/Leads/Leads.php
+++ b/modules/Leads/Leads.php
@@ -561,7 +561,7 @@ class Leads extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule, $queryPlanner, $reportid = false) {
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityLeads',array('vtiger_groupsLeads','vtiger_usersLeads','vtiger_lastModifiedByLeads'));
 
@@ -572,7 +572,7 @@ class Leads extends CRMEntity {
 
 		$matrix->setDependency('vtiger_leaddetails',array('vtiger_crmentityLeads', 'vtiger_leadaddress','vtiger_leadsubdetails','vtiger_leadscf','vtiger_email_trackLeads'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_leaddetails","leadid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_leaddetails","leadid", $queryPlanner, $reportid);
 		if ($queryPlanner->requireTable("vtiger_crmentityLeads",$matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityLeads on vtiger_crmentityLeads.crmid = vtiger_leaddetails.leadid and vtiger_crmentityLeads.deleted=0";
 		}

--- a/modules/Migration/schema/739_to_740.php
+++ b/modules/Migration/schema/739_to_740.php
@@ -52,4 +52,7 @@ if (defined('VTIGER_UPGRADE')) {
 
     // vtiger_crmentityテーブルの内容をモジュール毎のメインテーブルにコピーする
     require_once 'setup/scripts/75_Update_CRMEntity.php';
+
+    // レポートの関連の参照元を格納するカラムの追加
+    $db->pquery("alter table vtiger_reportmodules add column join_column text", array());
 }

--- a/modules/Migration/schema/739_to_740.php
+++ b/modules/Migration/schema/739_to_740.php
@@ -57,11 +57,13 @@ if (defined('VTIGER_UPGRADE')) {
     $db->pquery("alter table vtiger_reportmodules add column join_column text", array());
 
     // Reports_Record_Model::getRelationTables()にて, vtiger_fieldmodulerelを参照しているため足りないフィールドを追加
-    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(279,'Faq','Products')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(72,'Contacts','Accounts')", array());
     $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(129,'Campaigns','Products')", array());
     $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(159,'HelpDesk','Products')", array());
-    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(330,'Quotes','Accounts')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(279,'Faq','Products')", array());
     $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(316,'Quotes','Potentials')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(319,'Quotes','Contacts')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(330,'Quotes','Accounts')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(356,'PurchaseOrder','Contacts')", array());
     $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(452,'Invoice','Accounts')", array());
-    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(72,'Contacts','Accounts')", array());
 }

--- a/modules/Migration/schema/739_to_740.php
+++ b/modules/Migration/schema/739_to_740.php
@@ -55,4 +55,13 @@ if (defined('VTIGER_UPGRADE')) {
 
     // レポートの関連の参照元を格納するカラムの追加
     $db->pquery("alter table vtiger_reportmodules add column join_column text", array());
+
+    // Reports_Record_Model::getRelationTables()にて, vtiger_fieldmodulerelを参照しているため足りないフィールドを追加
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(279,'Faq','Products')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(129,'Campaigns','Products')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(159,'HelpDesk','Products')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(330,'Quotes','Accounts')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(316,'Quotes','Potentials')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(452,'Invoice','Accounts')", array());
+    $db->pquery("INSERT INTO vtiger_fieldmodulerel(fieldid, module, relmodule) VALUES(72,'Contacts','Accounts')", array());
 }

--- a/modules/ModComments/ModCommentsCore.php
+++ b/modules/ModComments/ModCommentsCore.php
@@ -356,7 +356,7 @@ class ModCommentsCore extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
 
 		$matrix->setDependency('vtiger_crmentityModComments',array('vtiger_groupsModComments','vtiger_usersModComments', 'vtiger_contactdetailsRelModComments', 'vtiger_modcommentsRelModComments'));
@@ -366,7 +366,7 @@ class ModCommentsCore extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_modcomments', array('vtiger_crmentityModComments'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_modcomments","modcommentsid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_modcomments","modcommentsid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityModComments",$matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityModComments on vtiger_crmentityModComments.crmid=vtiger_modcomments.modcommentsid and vtiger_crmentityModComments.deleted=0";

--- a/modules/Potentials/Potentials.php
+++ b/modules/Potentials/Potentials.php
@@ -645,7 +645,7 @@ class Potentials extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityPotentials',array('vtiger_groupsPotentials','vtiger_usersPotentials','vtiger_lastModifiedByPotentials'));
 
@@ -655,7 +655,7 @@ class Potentials extends CRMEntity {
         $matrix->setDependency('vtiger_potential', array('vtiger_crmentityPotentials','vtiger_accountPotentials',
 											'vtiger_contactdetailsPotentials','vtiger_campaignPotentials','vtiger_potentialscf'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_potential","potentialid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_potential","potentialid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityPotentials",$matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityPotentials on vtiger_crmentityPotentials.crmid=vtiger_potential.potentialid and vtiger_crmentityPotentials.deleted=0";

--- a/modules/PriceBooks/PriceBooks.php
+++ b/modules/PriceBooks/PriceBooks.php
@@ -289,7 +289,7 @@ class PriceBooks extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false) {
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 
@@ -299,7 +299,7 @@ class PriceBooks extends CRMEntity {
 		}
         $matrix->setDependency("vtiger_pricebook",array("vtiger_crmentityPriceBooks","vtiger_currency_infoPriceBooks"));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_pricebook","pricebookid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_pricebook","pricebookid", $queryPlanner, $reportid);
 		// TODO Support query planner
 		if ($queryPlanner->requireTable('vtiger_pricebookcf')) {
 			$query .= " left join vtiger_pricebookcf on vtiger_pricebook.pricebookid = vtiger_pricebookcf.pricebookid";

--- a/modules/Products/Products.php
+++ b/modules/Products/Products.php
@@ -1180,7 +1180,7 @@ class Products extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false) {
 		global $current_user;
 		$matrix = $queryPlanner->newDependencyMatrix();
 
@@ -1191,7 +1191,7 @@ class Products extends CRMEntity {
 		}
 		$matrix->setDependency("vtiger_products",array("innerProduct","vtiger_crmentityProducts","vtiger_productcf","vtiger_vendorRelProducts"));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_products","productid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_products","productid", $queryPlanner, $reportid);
 		if ($queryPlanner->requireTable("innerProduct")){
 			$query .= " LEFT JOIN (
 					SELECT vtiger_products.productid,

--- a/modules/ProjectMilestone/ProjectMilestone.php
+++ b/modules/ProjectMilestone/ProjectMilestone.php
@@ -403,7 +403,7 @@ class ProjectMilestone extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module, $secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module, $secmodule, $queryPlanner, $reportid = false) {
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityProjectMilestone', array('vtiger_groupsProjectMilestone', 'vtiger_usersProjectMilestone', 'vtiger_lastModifiedByProjectMilestone'));
 
@@ -412,7 +412,7 @@ class ProjectMilestone extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_projectmilestone', array('vtiger_crmentityProjectMilestone'));
 
-		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projectmilestone","projectmilestoneid", $queryPlanner);
+		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projectmilestone","projectmilestoneid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable('vtiger_crmentityProjectMilestone', $matrix)) {
 			$query .= " LEFT JOIN vtiger_crmentity AS vtiger_crmentityProjectMilestone ON vtiger_crmentityProjectMilestone.crmid=vtiger_projectmilestone.projectmilestoneid and vtiger_crmentityProjectMilestone.deleted=0";

--- a/modules/ProjectTask/ProjectTask.php
+++ b/modules/ProjectTask/ProjectTask.php
@@ -431,7 +431,7 @@ class ProjectTask extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityProjectTask', array('vtiger_groupsProjectTask', 'vtiger_usersProjectTask', 'vtiger_lastModifiedByProjectTask'));
@@ -441,7 +441,7 @@ class ProjectTask extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_projecttask', array('vtiger_crmentityProjectTask'));
 
-		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projecttask","projecttaskid", $queryPlanner);
+		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projecttask","projecttaskid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable('vtiger_crmentityProjectTask', $matrix)) {
 			$query .= " left join vtiger_crmentity as vtiger_crmentityProjectTask on vtiger_crmentityProjectTask.crmid=vtiger_projecttask.projecttaskid and vtiger_crmentityProjectTask.deleted=0";

--- a/modules/Quotes/Quotes.php
+++ b/modules/Quotes/Quotes.php
@@ -356,7 +356,7 @@ class Quotes extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityQuotes', array('vtiger_usersQuotes', 'vtiger_groupsQuotes', 'vtiger_lastModifiedByQuotes'));
 		$matrix->setDependency('vtiger_inventoryproductrelQuotes', array('vtiger_productsQuotes', 'vtiger_serviceQuotes'));
@@ -369,7 +369,7 @@ class Quotes extends CRMEntity {
 				'vtiger_inventoryproductrelQuotes', 'vtiger_contactdetailsQuotes', 'vtiger_accountQuotes',
 				'vtiger_invoice_recurring_info','vtiger_quotesQuotes','vtiger_usersRel1'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_quotes","quoteid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_quotes","quoteid", $queryPlanner, $reportid);
 		if ($queryPlanner->requireTable("vtiger_crmentityQuotes", $matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityQuotes on vtiger_crmentityQuotes.crmid=vtiger_quotes.quoteid and vtiger_crmentityQuotes.deleted=0";
 		}

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -370,6 +370,19 @@ class ReportRun extends CRMEntity {
 			return $this->_columnslist;
 		}
 
+		// レポートのカラムに関連項目が選択されていない場合cfテーブルがjoinされないため、
+		// $columnslistrowのループにてcfテーブルが必要であるか判定を行う. 
+		$joincftableflag = false; // 判定フラグ
+		$joinColumn = $this->queryPlanner->getReportJoinColumn();
+		$joinTypes = explode(",", $joinColumn);
+		$secmodulelists_joincftable = [];
+		foreach ($joinTypes as $tmpKey) {
+			list($secmodule, $primodule, $column) = split("::", $tmpKey);
+			if (stripos($column, 'cf_') !== false) {
+				$secmodulelists_joincftable[] = $secmodule;
+			}
+		}
+
 		global $adb;
 		global $modules;
 		global $log, $current_user, $current_language;
@@ -449,8 +462,19 @@ class ReportRun extends CRMEntity {
 					$columnslist[$fieldcolname] = $querycolumns;
 				}
 
+				if (in_array($module, $secmodulelists_joincftable)) {
+					$joincftableflag = true;
+				}
+
 				$this->queryPlanner->addTable($targetTableName);
 			}
+		}
+
+		// cfテーブルを追加する
+		if ($joincftableflag) {
+			$focus = CRMEntity::getInstance($this->primarymodule);
+			$customFieldTable = $focus->customFieldTable;
+			$this->queryPlanner->addTable($customFieldTable[0]);
 		}
 
 		if ($outputformat == "HTML" || $outputformat == "PDF" || $outputformat == "PRINT") {

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -370,19 +370,6 @@ class ReportRun extends CRMEntity {
 			return $this->_columnslist;
 		}
 
-		// レポートのカラムに関連項目が選択されていない場合cfテーブルがjoinされないため、
-		// $columnslistrowのループにてcfテーブルが必要であるか判定を行う. 
-		$joincftableflag = false; // 判定フラグ
-		$joinColumn = $this->queryPlanner->getReportJoinColumn();
-		$joinTypes = explode(",", $joinColumn);
-		$secmodulelists_joincftable = [];
-		foreach ($joinTypes as $tmpKey) {
-			list($secmodule, $primodule, $column) = split("::", $tmpKey);
-			if (stripos($column, 'cf_') !== false) {
-				$secmodulelists_joincftable[] = $secmodule;
-			}
-		}
-
 		global $adb;
 		global $modules;
 		global $log, $current_user, $current_language;
@@ -462,20 +449,15 @@ class ReportRun extends CRMEntity {
 					$columnslist[$fieldcolname] = $querycolumns;
 				}
 
-				if (in_array($module, $secmodulelists_joincftable)) {
-					$joincftableflag = true;
-				}
-
 				$this->queryPlanner->addTable($targetTableName);
 			}
 		}
 
 		// cfテーブルを追加する
-		if ($joincftableflag) {
-			$focus = CRMEntity::getInstance($this->primarymodule);
-			$customFieldTable = $focus->customFieldTable;
-			$this->queryPlanner->addTable($customFieldTable[0]);
-		}
+		// [TODO] 関連の参照先として選択されていなければ不要
+		$focus = CRMEntity::getInstance($this->primarymodule);
+		$customFieldTable = $focus->customFieldTable;
+		$this->queryPlanner->addTable($customFieldTable[0]);
 
 		if ($outputformat == "HTML" || $outputformat == "PDF" || $outputformat == "PRINT") {
 			if($this->primarymodule == 'ModComments') {

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -85,6 +85,7 @@ class ReportRunQueryPlanner {
 	protected static $tempTableCounter = 0;
 	protected $registeredCleanup = false;
 	var $reportRun = false;
+	protected $reportJoinColumn = false;
 
 	function addTable($table) {
 		if (!empty($table))
@@ -277,6 +278,12 @@ class ReportRunQueryPlanner {
 		return $advfiltersql;
 	}
 
+	function setReportJoinColumn($reportJoinColumn) {
+		$this->reportJoinColumn = $reportJoinColumn;
+	}
+	function getReportJoinColumn() {
+		return $this->reportJoinColumn;
+	}
 }
 
 class ReportRun extends CRMEntity {
@@ -335,6 +342,7 @@ class ReportRun extends CRMEntity {
             $this->reportname = $oReport->reportname;
             $this->queryPlanner = new ReportRunQueryPlanner();
             $this->queryPlanner->reportRun = $this;
+			$this->queryPlanner->setReportJoinColumn($oReport->joinColumn);
         }
 	function ReportRun($reportid) {
             self::__construct($reportid);
@@ -2128,7 +2136,7 @@ class ReportRun extends CRMEntity {
 				// Case handling: Force table requirement ahead of time.
 				$this->queryPlanner->addTable('vtiger_crmentity' . $value);
 
-				$focQuery = $foc->generateReportsSecQuery($module, $value, $this->queryPlanner);
+				$focQuery = $foc->generateReportsSecQuery($module, $value, $this->queryPlanner, $this->reportid);
 				
 				if ($focQuery) {
 					if (php7_count($secondarymodule) > 1) {

--- a/modules/Reports/Reports.php
+++ b/modules/Reports/Reports.php
@@ -168,7 +168,8 @@ class Reports extends CRMEntity{
                                         $current_user->id, $reportid, $reportmodulesrow["primarymodule"],
                                         $reportmodulesrow["secondarymodules"], $reportmodulesrow["reporttype"],
                                         $reportmodulesrow["reportname"], $reportmodulesrow["description"],
-                                        $reportmodulesrow["folderid"], $reportmodulesrow["owner"]
+                                        $reportmodulesrow["folderid"], $reportmodulesrow["owner"],
+                                        $reportmodulesrow["join_column"]
                                 );
                         }
 
@@ -183,6 +184,7 @@ class Reports extends CRMEntity{
                         $this->reportname = decode_html($cachedInfo["reportname"]);
                         $this->reportdescription = decode_html($cachedInfo["description"]);
                         $this->folderid = $cachedInfo["folderid"];
+						$this->joinColumn = $cachedInfo["join_column"];
                         if($is_admin==true || in_array($cachedInfo["owner"],$subordinate_users) || $cachedInfo["owner"]==$current_user->id)
                                 $this->is_editable = 'true';
                         else

--- a/modules/Reports/actions/Save.php
+++ b/modules/Reports/actions/Save.php
@@ -62,6 +62,25 @@ class Reports_Save_Action extends Vtiger_Save_Action {
 		$reportModel->set('advancedGroupFilterConditions', $request->get('advanced_group_condition'));
 		$reportModel->set('members', $request->get('members'));
 
+		// 自動選択の場合、１番目の選択肢項目をjoincolumnに設定する。
+		$joinColumn = $request->get('joinColumn');
+		$joinColumnArray = explode(",", $joinColumn);
+		$joinkeynames = array();
+		foreach ($request->get('secondary_modules') as $key => $secondaryModule) {
+			if ($joinColumnArray[$key]) {
+				$joinkeynames[] = $joinColumnArray[$key];
+			} else {
+				$relationTables = $reportModel->getRelationTables($request->get('primary_module'), $secondaryModule);
+				foreach ($relationTables as $joinkey => $relationTable) {
+					$keyvalue = explode("::", $joinkey);
+					$joinkeyname = $keyvalue[0] . "::" . $keyvalue[1] . "::" . $keyvalue[2];
+					$joinkeynames[] = $joinkeyname;
+					break;
+				}
+			}
+		}
+		$reportModel->setJoinColumn(implode(",", $joinkeynames));
+
 		$reportModel->save();
 
 		//Scheduled Reports

--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -188,6 +188,14 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 	}
 
 	/**
+	 * Function returns Join Columns of the Report
+	 * @return <String>
+	 */
+	function getJoinColumn() {
+		return $this->report->joinColumn;
+	}
+
+	/**
 	 * Function sets the Primary Module of the Report
 	 * @param <String> $module
 	 */
@@ -201,6 +209,14 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 	 */
 	function setSecondaryModule($modules) {
 		$this->report->secmodule = $modules;
+	}
+
+	/**
+	 * Function sets the Primary and Secondary join column for the Report
+	 * @param <String> $joinColumn, secondary_module_name@join_key separated with comma(,), and join_key is $this->getRelationTables().
+	 */
+	function setJoinColumn($joinColumn) {
+		$this->report->joinColumn = $joinColumn;
 	}
 
 	/**
@@ -470,8 +486,8 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 
 
 			$secondaryModule = $this->getSecondaryModules();
-			$db->pquery('INSERT INTO vtiger_reportmodules(reportmodulesid, primarymodule, secondarymodules) VALUES(?,?,?)',
-					array($reportId, $this->getPrimaryModule(), $secondaryModule));
+			$db->pquery('INSERT INTO vtiger_reportmodules(reportmodulesid, primarymodule, secondarymodules, join_column) VALUES(?,?,?,?)',
+					array($reportId, $this->getPrimaryModule(), $secondaryModule, $this->getJoinColumn()));
 
 			$this->saveSelectedFields();
 
@@ -496,8 +512,8 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 			$this->saveSharingInformation();
 
 
-			$db->pquery('UPDATE vtiger_reportmodules SET primarymodule = ?,secondarymodules = ? WHERE reportmodulesid = ?',
-					array($this->getPrimaryModule(), $this->getSecondaryModules(), $reportId));
+			$db->pquery('UPDATE vtiger_reportmodules SET primarymodule = ?,secondarymodules = ?, join_column = ? WHERE reportmodulesid = ?',
+					array($this->getPrimaryModule(), $this->getSecondaryModules(), $this->getJoinColumn(), $reportId));
 
 			$db->pquery('UPDATE vtiger_report SET reportname = ?, description = ?, reporttype = ?, folderid = ?,sharingtype = ? WHERE
 				reportid = ?', array(decode_html($this->get('reportname')), decode_html($this->get('description')),
@@ -1382,5 +1398,86 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 		}
 
 		return false;
+	}
+
+	public function getRelationTables($primaryModuleName, $secondaryModuleName) {
+		global $adb;
+		$primary_obj = CRMEntity::getInstance($primaryModuleName);
+		$secondary_obj = CRMEntity::getInstance($secondaryModuleName);
+
+		$array = array();
+
+		$ui10_query = $adb->pquery("SELECT
+										vtiger_field.tabid AS tabid,
+										vtiger_field.tablename AS tablename,
+										vtiger_field.columnname AS columnname,
+										vtiger_field.fieldname AS fieldname,
+										vtiger_field.fieldlabel AS fieldlabel,
+										vtiger_fieldmodulerel.module AS module
+									FROM
+										vtiger_field
+										INNER JOIN vtiger_fieldmodulerel ON vtiger_fieldmodulerel.fieldid = vtiger_field.fieldid
+									WHERE
+										vtiger_field.presence <> 1
+										AND (
+											( 
+												vtiger_fieldmodulerel.module = ? 
+												AND vtiger_fieldmodulerel.relmodule = ?
+											) 
+											OR ( 
+												vtiger_fieldmodulerel.module = ? 
+												AND vtiger_fieldmodulerel.relmodule = ?
+											)
+										)
+									ORDER BY vtiger_field.fieldid", array(
+											$primaryModuleName,
+											$secondaryModuleName,
+											$secondaryModuleName,
+											$primaryModuleName
+										));
+
+		$cnt = $adb->num_rows($ui10_query);
+		for($i = 0; $i<$cnt; $i++) {
+			$reltables = array();
+			$ui10_tablename = $adb->query_result($ui10_query,$i,'tablename');
+			$ui10_columnname = $adb->query_result($ui10_query,$i,'columnname');
+			$ui10_tabid = $adb->query_result($ui10_query,$i,'tabid');
+			$ui10_fieldname = $adb->query_result($ui10_query,$i,'fieldname');
+			$ui10_module = $adb->query_result($ui10_query,$i,'module');
+			$ui10_fieldlabel = $adb->query_result($ui10_query,$i,'fieldlabel');
+
+			if($primary_obj->table_name == $ui10_tablename){
+				$reltables = array($ui10_tablename=>array("".$primary_obj->table_index."","$ui10_columnname"));
+			} else if($secondary_obj->table_name == $ui10_tablename){
+				$reltables = array($ui10_tablename=>array("$ui10_columnname","".$secondary_obj->table_index.""),"".$primary_obj->table_name."" => "".$primary_obj->table_index."");
+			} else {
+				if(isset($secondary_obj->tab_name_index[$ui10_tablename])){
+					$rel_field = $secondary_obj->tab_name_index[$ui10_tablename];
+					$reltables = array($ui10_tablename=>array("$ui10_columnname","$rel_field"),"".$primary_obj->table_name."" => "".$primary_obj->table_index."");
+				} else {
+					$rel_field = $primary_obj->tab_name_index[$ui10_tablename];
+					$reltables = array($ui10_tablename=>array("$rel_field","$ui10_columnname"),"".$primary_obj->table_name."" => "".$primary_obj->table_index."");
+				}
+			}
+			$array[$secondaryModuleName.'::'.$ui10_module.'::'.$ui10_fieldname.'::'.$ui10_fieldlabel] = $reltables;
+		}
+
+		if($cnt == 0) {
+			if(method_exists($primary_obj,'setRelationTables')){
+				$reltables = $primary_obj->setRelationTables($secondaryModuleName);
+				$array[$secondaryModuleName.'::'.$primaryModuleName."::default::LBL_DEFAULT"] = $reltables;
+			} else {
+				$reltables = '';
+			}
+		}
+
+		if(is_array($reltables) && !empty($reltables)){
+			$rel_array = $reltables;
+		} else {
+			$rel_array = array("vtiger_crmentityrel"=>array("crmid","relcrmid"),"".$primary_obj->table_name."" => "".$primary_obj->table_index."");
+			$array[$secondaryModuleName.'::'.$primaryModuleName."::default::LBL_DEFAULT"] = $rel_array;
+		}
+
+		return $array;	
 	}
 }

--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -1446,8 +1446,8 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 			$ui10_module = $adb->query_result($ui10_query,$i,'module');
 			$ui10_fieldlabel = $adb->query_result($ui10_query,$i,'fieldlabel');
 
-			if($primary_obj->table_name == $ui10_tablename){
-				$reltables = array($ui10_tablename=>array("".$primary_obj->table_index."","$ui10_columnname"));
+			if(in_array($ui10_tablename, $primary_obj->tab_name)){
+				$reltables = array($ui10_tablename=>array("".$ui10_tablename."","$ui10_columnname"));
 			} else if($secondary_obj->table_name == $ui10_tablename){
 				$reltables = array($ui10_tablename=>array("$ui10_columnname","".$secondary_obj->table_index.""),"".$primary_obj->table_name."" => "".$primary_obj->table_index."");
 			} else {

--- a/modules/Reports/models/Report.php
+++ b/modules/Reports/models/Report.php
@@ -89,7 +89,8 @@ class Vtiger_Report_Model extends Reports {
 							$userId, $reportId, $reportModulesRow["primarymodule"],
 							$reportModulesRow["secondarymodules"], $reportModulesRow["reporttype"],
 							$reportModulesRow["reportname"], $reportModulesRow["description"],
-							$reportModulesRow["folderid"], $reportModulesRow["owner"]
+							$reportModulesRow["folderid"], $reportModulesRow["owner"],
+							$reportModulesRow["join_column"]
 					);
 				}
 
@@ -120,6 +121,7 @@ class Vtiger_Report_Model extends Reports {
 				$this->reportname = decode_html($cachedInfo["reportname"]);
 				$this->reportdescription = decode_html($cachedInfo["description"]);
 				$this->folderid = $cachedInfo["folderid"];
+				$this->joinColumn = $cachedInfo["join_column"];
 				if($currentUser->isAdminUser() == true || in_array($cachedInfo["owner"], $subOrdinateUsers) || $cachedInfo["owner"]==$userId) {
 					$this->is_editable = true;
 				}else{

--- a/modules/Reports/views/Edit.php
+++ b/modules/Reports/views/Edit.php
@@ -239,6 +239,7 @@ Class Reports_Edit_View extends Vtiger_Edit_View {
 			$viewer->assign('SELECTED_ADVANCED_FILTER_FIELDS', $reportModel->transformToNewAdvancedFilter());
 		}
 		$data = $request->getAll();
+		$joinColumn = array();
 		foreach ($data as $name => $value) {
 			if($name == 'schdayoftheweek' || $name == 'schdayofthemonth' || $name == 'schannualdates' || $name == 'recipients' || $name == 'members') {
 				$value = Zend_Json::decode($value);
@@ -246,8 +247,12 @@ Class Reports_Edit_View extends Vtiger_Edit_View {
 					$value = array($value);
 				}
 			}
+			if(strpos($name, "joinfield_") !== false) {
+				$joinColumn[] = $value;
+			}
 			$reportModel->set($name, $value);
 		}
+		$reportModel->set("joinColumn", implode(",", $joinColumn));
 		$primaryModule = $request->get('primary_module');
 		$secondaryModules = $request->get('secondary_modules');
 		$reportModel->setPrimaryModule($primaryModule);

--- a/modules/ServiceContracts/ServiceContracts.php
+++ b/modules/ServiceContracts/ServiceContracts.php
@@ -225,7 +225,7 @@ class ServiceContracts extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false) {
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityServiceContracts',array('vtiger_groupsServiceContracts','vtiger_usersServiceContracts'));
@@ -234,7 +234,7 @@ class ServiceContracts extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_servicecontracts',array('vtiger_servicecontractscf','vtiger_crmentityServiceContracts'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_servicecontracts","servicecontractsid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_servicecontracts","servicecontractsid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable("vtiger_crmentityServiceContracts",$matrix)){
 			$query .= " left join vtiger_crmentity as vtiger_crmentityServiceContracts on vtiger_crmentityServiceContracts.crmid = vtiger_servicecontracts.servicecontractsid  and vtiger_crmentityServiceContracts.deleted=0";

--- a/modules/Services/Services.php
+++ b/modules/Services/Services.php
@@ -1013,7 +1013,7 @@ class Services extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule, $queryPlanner, $reportid = false) {
 		global $current_user;
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityServices',array('vtiger_usersServices','vtiger_groupsServices','vtiger_lastModifiedByServices'));
@@ -1022,7 +1022,7 @@ class Services extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_service',array('actual_unit_price','vtiger_currency_info','vtiger_productcurrencyrel','vtiger_servicecf','vtiger_crmentityServices'));
 
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_service","serviceid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_service","serviceid", $queryPlanner, $reportid);
 		if ($queryPlanner->requireTable("innerService")){
 			$query .= " LEFT JOIN (
 			SELECT vtiger_service.serviceid,

--- a/modules/Vendors/Vendors.php
+++ b/modules/Vendors/Vendors.php
@@ -411,7 +411,7 @@ class Vendors extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module,$secmodule, $queryPlanner, $reportid = false) {
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 
@@ -420,7 +420,7 @@ class Vendors extends CRMEntity {
 			return '';
 		}
         $matrix->setDependency("vtiger_vendor",array("vtiger_crmentityVendors","vtiger_vendorcf","vtiger_email_trackVendors"));
-		$query = $this->getRelationQuery($module,$secmodule,"vtiger_vendor","vendorid", $queryPlanner);
+		$query = $this->getRelationQuery($module,$secmodule,"vtiger_vendor","vendorid", $queryPlanner, $reportid);
 		// TODO Support query planner
 		if ($queryPlanner->requireTable("vtiger_crmentityVendors",$matrix)){
 		    $query .=" left join vtiger_crmentity as vtiger_crmentityVendors on vtiger_crmentityVendors.crmid=vtiger_vendor.vendorid and vtiger_crmentityVendors.deleted=0";

--- a/packages/vtiger/optional/Projects/ProjectMilestone/modules/ProjectMilestone/ProjectMilestone.php
+++ b/packages/vtiger/optional/Projects/ProjectMilestone/modules/ProjectMilestone/ProjectMilestone.php
@@ -403,7 +403,7 @@ class ProjectMilestone extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module, $secmodule, $queryPlanner) {
+	function generateReportsSecQuery($module, $secmodule, $queryPlanner, $reportid = false) {
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityProjectMilestone', array('vtiger_groupsProjectMilestone', 'vtiger_usersProjectMilestone', 'vtiger_lastModifiedByProjectMilestone'));
 
@@ -412,7 +412,7 @@ class ProjectMilestone extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_projectmilestone', array('vtiger_crmentityProjectMilestone'));
 
-		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projectmilestone","projectmilestoneid", $queryPlanner);
+		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projectmilestone","projectmilestoneid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable('vtiger_crmentityProjectMilestone', $matrix)) {
 			$query .= " LEFT JOIN vtiger_crmentity AS vtiger_crmentityProjectMilestone ON vtiger_crmentityProjectMilestone.crmid=vtiger_projectmilestone.projectmilestoneid and vtiger_crmentityProjectMilestone.deleted=0";

--- a/packages/vtiger/optional/Projects/ProjectTask/modules/ProjectTask/ProjectTask.php
+++ b/packages/vtiger/optional/Projects/ProjectTask/modules/ProjectTask/ProjectTask.php
@@ -431,7 +431,7 @@ class ProjectTask extends CRMEntity {
 	 * @param - $secmodule secondary module name
 	 * returns the query string formed on fetching the related data for report for secondary module
 	 */
-	function generateReportsSecQuery($module,$secmodule,$queryPlanner){
+	function generateReportsSecQuery($module,$secmodule,$queryPlanner, $reportid = false){
 
 		$matrix = $queryPlanner->newDependencyMatrix();
 		$matrix->setDependency('vtiger_crmentityProjectTask', array('vtiger_groupsProjectTask', 'vtiger_usersProjectTask', 'vtiger_lastModifiedByProjectTask'));
@@ -441,7 +441,7 @@ class ProjectTask extends CRMEntity {
 		}
 		$matrix->setDependency('vtiger_projecttask', array('vtiger_crmentityProjectTask'));
 
-		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projecttask","projecttaskid", $queryPlanner);
+		$query .= $this->getRelationQuery($module,$secmodule,"vtiger_projecttask","projecttaskid", $queryPlanner, $reportid);
 
 		if ($queryPlanner->requireTable('vtiger_crmentityProjectTask', $matrix)) {
 			$query .= " left join vtiger_crmentity as vtiger_crmentityProjectTask on vtiger_crmentityProjectTask.crmid=vtiger_projecttask.projecttaskid and vtiger_crmentityProjectTask.deleted=0";


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #554 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートの関連モジュールを選択した際に主モジュールまたは副モジュールのどの項目で関連付けされるのかわからない

##  変更内容 / Details of Change
### fork_from_hereの逆輸入
1. レポートstep2に「関連の参照先」を追加, vtiger_reportmodulesのjoin_columnに保存. 
2.  CRMEntity.php
    * generateReportsSecQuery()にcfテーブルをjoinするコードを追加
    * getRelationQuery()に選択した項目が親か？子か？を判断するコードを追加
3. vtiger_reportmodulesにjoin_columnを追加(739→740のマイグレーション)

### fork_from_hereからの変更点
1. レポートクエリにcfテーブルを追加する.
    * カラムに関連項目が選択されていない場合, cfテーブルがjoinされずクエリエラーとなってしまうため
2. vtiger_fieldmodulerelに足りないフィールドを追加(739→740のマイグレーション)
    * 見積の「ご担当者様」などの一部項目において、関連の参照先に表示されないバグがあったため
3. 顧客担当者に関連項目(cfテーブル)を作成すると、顧客担当者のレポートが表示されない
    * getRelationTablesにてcfテーブルを取得できていなかった
    * 顧客担当者のテーブルはvtiger_contactdetailsだが、cfテーブルはvtiger_contactscfであるため

### 仕様か？バグか？分からなかったため変更しなかった点
1. 見積の関連の参照先に、「① 見積→顧客担当者」ではなく「② 顧客担当者→見積」の関連項目が表示されてしまう
    * ①は見積の関連項目として顧客担当者を設定。②は顧客担当者の関連項目として見積を設定。
    * レポートにて、①は正常に表示されるが、②は何も表示されない。
    * getRelationTables()の条件式にて②が表示されるようになっている。
    * そもそも②が表示される必要があるか分からない

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
関連の参照先
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/b9f4abc0-8b70-4d58-bc0a-67a5f1f281d2)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->