### PR TITLE
#933 一覧画面上でダブルクリック編集時にチェックボックスが空欄になる不具合を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -785,7 +785,7 @@ Vtiger.Class("Vtiger_List_Js", {
 
 			var value = jQuery.trim(valueElement.text());
 			//adding string,text,url,currency in customhandling list as string will be textlengthchecked
-			var customHandlingFields = ['owner', 'ownergroup', 'picklist', 'multipicklist', 'reference', 'string', 'url', 'currency', 'text', 'email'];
+			var customHandlingFields = ['owner', 'ownergroup', 'picklist', 'multipicklist', 'reference', 'string', 'url', 'currency', 'text', 'email','boolean'];
 			if (jQuery.inArray(fieldType, customHandlingFields) !== -1) {
 				value = tdElement.data('rawvalue');
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #933 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
一覧画面上でのダブルクリック編集時にチェックボックス項目について既存の値が「はい」だったとしても「いいえ」として編集状態になる。この為、意図せずチェックが外れてしまうことがある。

##  原因 / Cause
<!-- バグの原因を記述 -->
ダブルクリック編集時のチェックボックス項目に0,1ではなく，’はい’，’いいえ’が入力されていたため


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. fieldTypeがbooleanのときにvalueが0,1で取得するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
一覧画面
![スクリーンショット 2023-12-17 161815](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/2ad6093e-cf69-424e-a67e-8709a4cb9559)
ダブルクリック時
![スクリーンショット 2023-12-17 161834](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/b1ccdbf3-4be2-447b-9a94-a6a1c294dd40)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
一覧画面でダブルクリック編集をした時

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->