### PR TITLE
#897 関連のコメントを開いたときに子コメントがすべて表示されるようにする修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -196,6 +196,8 @@ $languageStrings = array(
 	'LBL_NO_COMMENTS' => 'コメントはありません。',
 	'LBL_REPLIES' => '返信',
 	'LBL_REPLY_ALL' => '全員に返信',
+	'LBL_HIDDEN' => '非表示',
+	'LBL_DISPLAY' => '表示',
 
 	//Translation for all modules
 	'Dashboards' => 'ダッシュボード',

--- a/layouts/v7/modules/Vtiger/Comment.tpl
+++ b/layouts/v7/modules/Vtiger/Comment.tpl
@@ -86,24 +86,24 @@
 												{if $COMMENTS_MODULE_MODEL->isPermitted('EditView')}&nbsp;&nbsp;&nbsp;{/if}
 												<span class="viewThreadBlock" data-child-comments-count="{$CHILD_COMMENTS_COUNT}">
 													<a href="javascript:void(0)" class="cursorPointer viewThread" style="color: blue;">
-														<span class="childCommentsCount">{$CHILD_COMMENTS_COUNT}</span>&nbsp;{if $CHILD_COMMENTS_COUNT eq 1}{vtranslate('LBL_REPLY',$MODULE_NAME)}{else}{vtranslate('LBL_REPLIES',$MODULE_NAME)}{/if}&nbsp;
+														{vtranslate('LBL_HIDDEN',$MODULE_NAME)}&nbsp;
 													</a>
 												</span>
 												<span class="hideThreadBlock" data-child-comments-count="{$CHILD_COMMENTS_COUNT}" style="display:none;">
 													<a href="javascript:void(0)" class="cursorPointer hideThread" style="color: blue;">
-														<span class="childCommentsCount">{$CHILD_COMMENTS_COUNT}</span>&nbsp;{if $CHILD_COMMENTS_COUNT eq 1}{vtranslate('LBL_REPLY',$MODULE_NAME)}{else}{vtranslate('LBL_REPLIES',$MODULE_NAME)}{/if}&nbsp;
+														{vtranslate('LBL_DISPLAY',$MODULE_NAME)}&nbsp;
 													</a>
 												</span>
 											{elseif $CHILD_COMMENTS_MODEL neq null and ($CHILDS_ROOT_PARENT_ID eq $PARENT_COMMENT_ID)}
 												{if $COMMENTS_MODULE_MODEL->isPermitted('EditView')}&nbsp;&nbsp;&nbsp;{/if}
 												<span class="viewThreadBlock" data-child-comments-count="{$CHILD_COMMENTS_COUNT}" style="display:none;">
 													<a href="javascript:void(0)" class="cursorPointer viewThread" style="color: blue;">
-														<span class="childCommentsCount">{$CHILD_COMMENTS_COUNT}</span>&nbsp;{if $CHILD_COMMENTS_COUNT eq 1}{vtranslate('LBL_REPLY',$MODULE_NAME)}{else}{vtranslate('LBL_REPLIES',$MODULE_NAME)}{/if}&nbsp;
+														{vtranslate('LBL_HIDDEN',$MODULE_NAME)}&nbsp;
 													</a>
 												</span>
 												<span class="hideThreadBlock" data-child-comments-count="{$CHILD_COMMENTS_COUNT}">
 													<a href="javascript:void(0)" class="cursorPointer hideThread" style="color: blue;">
-														<span class="childCommentsCount">{$CHILD_COMMENTS_COUNT}</span>&nbsp;{if $CHILD_COMMENTS_COUNT eq 1}{vtranslate('LBL_REPLY',$MODULE_NAME)}{else}{vtranslate('LBL_REPLIES',$MODULE_NAME)}{/if}&nbsp;
+														{vtranslate('LBL_DISPLAY',$MODULE_NAME)}&nbsp;
 													</a>
 												</span>
 											{/if}

--- a/layouts/v7/modules/Vtiger/CommentsList.tpl
+++ b/layouts/v7/modules/Vtiger/CommentsList.tpl
@@ -29,11 +29,15 @@
 				{assign var=PARENT_COMMENT_ID value=$COMMENT->getId()}
 				<li class="commentDetails">
 					{include file='Comment.tpl'|@vtemplate_path COMMENT=$COMMENT COMMENT_MODULE_MODEL=$COMMENTS_MODULE_MODEL}
-
-					{if $CHILDS_ROOT_PARENT_MODEL}
+				
+					{if $COMMENT->getChildComments()}
+						{assign var=CHILD_COMMENT value=$COMMENT->getChildComments()}
+						{include file='CommentsList.tpl'|@vtemplate_path PARENT_COMMENTS=$CHILD_COMMENT}
+					{/if}
+					{if $CHILDS_ROOT_PARENT_MODEL} 
 						{if $CHILDS_ROOT_PARENT_MODEL->getId() eq $PARENT_COMMENT_ID}		
 							{assign var=CHILD_COMMENTS_MODEL value=$CHILDS_ROOT_PARENT_MODEL->getChildComments()}
-							{include file='CommentsListIteration.tpl'|@vtemplate_path CHILD_COMMENTS_MODEL=$CHILD_COMMENTS_MODEL}
+														{include file='CommentsListIteration.tpl'|@vtemplate_path CHILD_COMMENTS_MODEL=$CHILD_COMMENTS_MODEL}
 						{/if}
 					{/if}
 				</li>	

--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -2736,7 +2736,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 		var detailContentsHolder = this.getContentHolder();
 		var self = this;
 		this.registerSendSmsSubmitEvent();
-		detailContentsHolder.on('click','.viewThread', function(e){
+		detailContentsHolder.on('click','.hideThread', function(e){
 			var currentTarget = jQuery(e.currentTarget);
 			var currentTargetParent = currentTarget.parent();
 			var commentActionsBlock = currentTarget.closest('.commentActions');
@@ -2744,25 +2744,20 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			var ulElements = currentCommentBlock.find('ul');
 			if(ulElements.length > 0){
 				ulElements.show();
-				commentActionsBlock.find('.hideThreadBlock').show();
+				commentActionsBlock.find('.viewThreadBlock').show();
 				currentTargetParent.hide();
 				return;
 			}
 			var commentId = currentTarget.closest('.commentDiv').find('.commentInfoHeader').data('commentid');
-			self.getChildComments(commentId).then(function(data){
-				jQuery(data).appendTo(jQuery(e.currentTarget).closest('.commentDetails'));
-				commentActionsBlock.find('.hideThreadBlock').show();
-				currentTargetParent.hide();
-			});
 		});
-		detailContentsHolder.on('click','.hideThread', function(e){
+		detailContentsHolder.on('click','.viewThread', function(e){
 			var currentTarget = jQuery(e.currentTarget);
 			var currentTargetParent = currentTarget.parent();
 			var commentActionsBlock = currentTarget.closest('.commentActions');
 			var currentCommentBlock = currentTarget.closest('.commentDetails');
 			currentCommentBlock.find('ul').hide();
 			currentTargetParent.hide();
-			commentActionsBlock.find('.viewThreadBlock').show();
+			commentActionsBlock.find('.hideThreadBlock').show();
 		});
 		detailContentsHolder.on('click','.detailViewThread',function(e){
 			var recentCommentsTab = self.getTabByLabel(self.detailViewRecentCommentsTabLabel);
@@ -2858,11 +2853,6 @@ Vtiger.Class("Vtiger_Detail_Js",{
 									var newChildCommentCount = currentChildCommentsCount + 1;
 									commentInfoBlock.find('.childCommentsCount').text(newChildCommentCount);
 									var parentCommentId = commentInfoBlock.find('.commentInfoHeader').data('commentid');
-									self.getChildComments(parentCommentId).then(function(responsedata){
-										jQuery(responsedata).appendTo(commentBlock);
-										commentInfoBlock.find('.viewThreadBlock').hide();
-										commentInfoBlock.find('.hideThreadBlock').show();
-									});
 								}else {
 									jQuery(html).appendTo(commentBlock);
 								}

--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -2853,6 +2853,11 @@ Vtiger.Class("Vtiger_Detail_Js",{
 									var newChildCommentCount = currentChildCommentsCount + 1;
 									commentInfoBlock.find('.childCommentsCount').text(newChildCommentCount);
 									var parentCommentId = commentInfoBlock.find('.commentInfoHeader').data('commentid');
+									self.getChildComments(parentCommentId).then(function(responsedata){
+										jQuery(responsedata).appendTo(commentBlock);
+										commentInfoBlock.find('.viewThreadBlock').hide();
+										commentInfoBlock.find('.hideThreadBlock').show();
+									});
 								}else {
 									jQuery(html).appendTo(commentBlock);
 								}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #897 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連のコメントを開いた際に子コメントが表示されていなくて、子コメントに気づきにくい。



##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. コメントに子コメントがある場合はCommentsList.tplを再帰的に読み込みなおすようにした。
2. 表示、非表示ボタンを追加した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/caf27295-3a14-4bb5-b947-9197ad35be7e)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
コメントを表示する範囲すべて

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->