### PR TITLE
#905 ブックマークを一覧画面から削除できない不具合を修正

### DIFF
--- a/modules/Portal/actions/DeleteAjax.php
+++ b/modules/Portal/actions/DeleteAjax.php
@@ -18,7 +18,7 @@ class Portal_DeleteAjax_Action extends Vtiger_DeleteAjax_Action {
     public function process(Vtiger_Request $request) {
         $recordId = $request->get('record');
         $module = $request->getModule();
-        Portal_Module_Model::deleteRecord($recordId);
+        Portal_Module_Model::deletePortalRecord($recordId);
         
         $response = new Vtiger_Response();
 		$response->setResult(array('message'=>  vtranslate('LBL_RECORD_DELETED_SUCCESSFULLY', $module)));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #905 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ブックマークの一覧画面にて，チェックボックスで選択してゴミ箱マークからは削除できるが，個々のドロップダウンから削除を選択してもブックマークが削除されなかった．

##  原因 / Cause
<!-- バグの原因を記述 -->
ドロップダウンから削除を行う時に存在しない関数を使用していた．

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
存在する関数を指定した

## スクリーンショット / Screenshot
ドロップダウンから削除できるように修正
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット 2024-01-23 165139](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/0d956dc4-39e8-4d4e-b1f4-8a515abd3b3c)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ブックマークのドロップダウン削除

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->