### PR TITLE
項目設定でカレンダー、活動がモジュール一覧から出てこなくなったデグレの修正

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -123,7 +123,9 @@
 							<div class="controls col-sm-7">
 								<select class="col-sm-6 relationModule" name="relationmodule[]" multiple data-rule-required='true'>
 									{foreach key=RELATION_MODULE_NAME item=TRANS_RELATION_MODULE_NAME from=$FIELD_TYPE_INFO['Relation']['relationModules']}
-										<option value="{$RELATION_MODULE_NAME}">{$TRANS_RELATION_MODULE_NAME}</option>
+										{if $RELATION_MODULE_NAME neq 'Calendar' && $RELATION_MODULE_NAME neq 'Events'} {* 関連項目にカレンダー・活動は不要 *}
+											<option value="{$RELATION_MODULE_NAME}">{$TRANS_RELATION_MODULE_NAME}</option>
+										{/if}
 									{/foreach}
 								</select>
 								<p class="related_field_caution">{vtranslate('Users', 'Vtiger')}{vtranslate('LBL_CANT_SELECT_THE_OTHER_MODULE_WITH_USERS_FOR_RELFIELD', 'Vtiger')}</p>

--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -416,9 +416,6 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 		}
 		// Usersの追加
 		$modulesList["Users"] = vtranslate("Users", "Users");	
-		//関連項目に、活動・カレンダーはあまり必要ではないため選択肢から除外する。
-		unset($modulesList['Events']);
-		unset($modulesList['Calendar']);
 		return $modulesList;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #954 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目設定でカレンダー、活動がモジュール一覧から出てこなくなった

##  原因 / Cause
<!-- バグの原因を記述 -->
1. #638 
    * Module.phpの修正のみ影響
    * FieldCreate.tplの修正は、カスタム項目を関連として作成するとテキストになるバグに対する修正なので本件とは無関係

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. FieldCreate.tpにてカレンダー・活動を表示しないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* 項目設定の選択肢、カレンダーと活動を追加
    ![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/7f07cf01-05c5-4d48-b314-589eb415a492)
* 関連項目の選択肢、カレンダーと活動を削除
    ![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/099c73f3-94ee-48a5-804b-ea367ef228d3)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
ご指摘のあった#740については、
「活動」「カレンダー」を除外する**修正以前**に作成された関連項目を削除することを目的としています。
