### PR TITLE
関連項目のドキュメントを作成した際、「プラス」ボタンから新規登録できるように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -922,6 +922,17 @@ Vtiger.Class('Vtiger_Index_Js', {
 			var prevSelectedReferenceModule = referenceModuleElement.val();
 			referenceModuleElement.val(popupReferenceModule);
 
+			// ドキュメントの作成ボタンの挙動は他モジュールと異なるためテンプレートを変更する
+			if(popupReferenceModule == 'Documents') { // 他モジュール->ドキュメント
+				var createReferenceRecordElement = closestTD.find('.createReferenceRecord');
+				createReferenceRecordElement.addClass('dropdown').removeClass('createReferenceRecord').css('padding', '0px');
+				createReferenceRecordElement.find('.fa-plus').css('pointer-events', 'auto').css('padding', '5px 8px').attr('data-toggle', 'dropdown');
+			} else if(prevSelectedReferenceModule == 'Documents') { // ドキュメント->他モジュール
+				var createReferenceRecordElement = closestTD.find('.dropdown');
+				createReferenceRecordElement.addClass('createReferenceRecord').removeClass('dropdown').removeAttr('style');
+				createReferenceRecordElement.find('.fa-plus').removeAttr('style').removeAttr('data-toggle').css('pointer-events', 'none');
+			}
+
 			//If Reference module is changed then we should clear the previous value
 			if(prevSelectedReferenceModule != popupReferenceModule) {
 				closestTD.find('.clearReferenceSelection').trigger('click');

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -54,8 +54,26 @@
                 <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_select" class="fa fa-search"></i>
             </span>
         {if (($REQ.view eq 'Edit') or ($MODULE_NAME eq 'Webforms')) && !in_array($REFERENCE_LIST[0],$QUICKCREATE_RESTRICTED_MODULES)}
+            {if $REFERENCE_LIST[0] eq 'Documents'}
+                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}">
+                <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
+                <ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
+                    <li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', 'Documents')}</li>
+                    <li id="VtigerAction">
+                        <a href="javascript:Documents_Index_Js.uploadTo('Vtiger')">
+                            <img style="  margin-top: -3px;margin-right: 10px;margin-left:3px; width:15px; height:15px;" title="F-RevoCRM" alt="F-RevoCRM" src="layouts/v7/skins//images/Vtiger.png">
+                            {vtranslate('LBL_TO_SERVICE', 'Documents', {vtranslate('LBL_VTIGER', 'Documents')})}
+                        </a>
+                    </li>
+                    <li class="dropdown-header"><i class="fa fa-link"></i> {vtranslate('LBL_LINK_EXTERNAL_DOCUMENT', 'Documents')}</li>
+                    <li id="shareDocument"><a href="javascript:Documents_Index_Js.createDocument('E')">&nbsp;<i class="fa fa-external-link"></i>&nbsp;&nbsp; {vtranslate('LBL_FROM_SERVICE', 'Documents', {vtranslate('LBL_FILE_URL', 'Documents')})}</a></li>
+					<li role="separator" class="divider"></li>
+                    <li id="createDocument"><a href="javascript:Documents_Index_Js.createDocument('W')"><i class="fa fa-file-text"></i> {vtranslate('LBL_CREATE_NEW', 'Documents', {vtranslate('SINGLE_Documents', 'Documents')})}</a></li>
+                </ul>
+            {else}
             <span class="input-group-addon createReferenceRecord cursorPointer clearfix" title="{vtranslate('LBL_CREATE', $MODULE)}">
             <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus"></i>
+            {/if}
         </span>
         {/if}
     </div>

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -60,7 +60,7 @@
                 <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" 
                     {if $REFERENCE_LIST[0] eq 'Documents'} data-toggle="dropdown" style="padding: 5px 8px;"
                     {else} style="pointer-events: none;" {/if}></i> {*ドキュメント以外でドロップダウンメニューが表示されないようにする*}
-                <ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
+                <ul class="dropdown-menu dropdown-menu-right quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
                     <li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', 'Documents')}</li>
                     <li id="VtigerAction">
                         <a href="javascript:Documents_Index_Js.uploadTo('Vtiger','{$RECORD_ID}','{$MODULE}','{$FIELD_NAME}')">

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -55,8 +55,8 @@
             </span>
         {if (($REQ.view eq 'Edit') or ($MODULE_NAME eq 'Webforms')) && !in_array($REFERENCE_LIST[0],$QUICKCREATE_RESTRICTED_MODULES)}
             {if $REFERENCE_LIST[0] eq 'Documents'}
-                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}" name="{$FIELD_NAME}">
-                <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
+                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}" name="{$FIELD_NAME}" style="padding: 0px;">
+                <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="padding: 5px 8px;"></i>
                 <ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
                     <li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', 'Documents')}</li>
                     <li id="VtigerAction">

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -54,9 +54,12 @@
                 <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_select" class="fa fa-search"></i>
             </span>
         {if (($REQ.view eq 'Edit') or ($MODULE_NAME eq 'Webforms')) && !in_array($REFERENCE_LIST[0],$QUICKCREATE_RESTRICTED_MODULES)}
-            {if $REFERENCE_LIST[0] eq 'Documents'}
-                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}" name="{$FIELD_NAME}" style="padding: 0px;">
-                <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="padding: 5px 8px;"></i>
+            {if in_array('Documents', $REFERENCE_LIST)}
+                <span class="input-group-addon {if $REFERENCE_LIST[0] eq 'Documents'} dropdown {else} createReferenceRecord {/if} cursorPointer clearfix" title="{vtranslate('LBL_CREATE', $MODULE)}" name="{$FIELD_NAME}"
+                    {if $REFERENCE_LIST[0] eq 'Documents'} style="padding: 0px;" {/if}>
+                <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" 
+                    {if $REFERENCE_LIST[0] eq 'Documents'} data-toggle="dropdown" style="padding: 5px 8px;"
+                    {else} style="pointer-events: none;" {/if}></i> {*ドキュメント以外でドロップダウンメニューが表示されないようにする*}
                 <ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
                     <li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', 'Documents')}</li>
                     <li id="VtigerAction">

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -55,20 +55,20 @@
             </span>
         {if (($REQ.view eq 'Edit') or ($MODULE_NAME eq 'Webforms')) && !in_array($REFERENCE_LIST[0],$QUICKCREATE_RESTRICTED_MODULES)}
             {if $REFERENCE_LIST[0] eq 'Documents'}
-                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}">
+                <span class="input-group-addon cursorPointer clearfix dropdown" title="{vtranslate('LBL_CREATE', $MODULE)}" name="{$FIELD_NAME}">
                 <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></i>
                 <ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_Documents">
                     <li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', 'Documents')}</li>
                     <li id="VtigerAction">
-                        <a href="javascript:Documents_Index_Js.uploadTo('Vtiger')">
+                        <a href="javascript:Documents_Index_Js.uploadTo('Vtiger','{$RECORD_ID}','{$MODULE}','{$FIELD_NAME}')">
                             <img style="  margin-top: -3px;margin-right: 10px;margin-left:3px; width:15px; height:15px;" title="F-RevoCRM" alt="F-RevoCRM" src="layouts/v7/skins//images/Vtiger.png">
                             {vtranslate('LBL_TO_SERVICE', 'Documents', {vtranslate('LBL_VTIGER', 'Documents')})}
                         </a>
                     </li>
                     <li class="dropdown-header"><i class="fa fa-link"></i> {vtranslate('LBL_LINK_EXTERNAL_DOCUMENT', 'Documents')}</li>
-                    <li id="shareDocument"><a href="javascript:Documents_Index_Js.createDocument('E')">&nbsp;<i class="fa fa-external-link"></i>&nbsp;&nbsp; {vtranslate('LBL_FROM_SERVICE', 'Documents', {vtranslate('LBL_FILE_URL', 'Documents')})}</a></li>
+                    <li id="shareDocument"><a href="javascript:Documents_Index_Js.createDocument('E','{$RECORD_ID}','{$MODULE}','{$FIELD_NAME}')">&nbsp;<i class="fa fa-external-link"></i>&nbsp;&nbsp; {vtranslate('LBL_FROM_SERVICE', 'Documents', {vtranslate('LBL_FILE_URL', 'Documents')})}</a></li>
 					<li role="separator" class="divider"></li>
-                    <li id="createDocument"><a href="javascript:Documents_Index_Js.createDocument('W')"><i class="fa fa-file-text"></i> {vtranslate('LBL_CREATE_NEW', 'Documents', {vtranslate('SINGLE_Documents', 'Documents')})}</a></li>
+                    <li id="createDocument"><a href="javascript:Documents_Index_Js.createDocument('W','{$RECORD_ID}','{$MODULE}','{$FIELD_NAME}')"><i class="fa fa-file-text"></i> {vtranslate('LBL_CREATE_NEW', 'Documents', {vtranslate('SINGLE_Documents', 'Documents')})}</a></li>
                 </ul>
             {else}
             <span class="input-group-addon createReferenceRecord cursorPointer clearfix" title="{vtranslate('LBL_CREATE', $MODULE)}">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #256 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連項目を作成し、モジュールで「ドキュメント」を選択すると、虫眼鏡画面での選択は可能だが、「＋」ボタンからの新規登録ができない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「＋」ボタンがクリックされたときの挙動について
    * 他モジュール：クイック作成がtrigger
    * ドキュメント：ドロップダウンメニューが展開 <- 「＋」ボタンが機能しない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. テンプレートにドロップダウンメニューを追加
2. 作成したドキュメントを関連に適用する
3. 複数のモジュールが登録されている関連項目では「＋」ボタンのテンプレートを変更する

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/aaccfb8e-93f5-49a4-92fc-76540bec8b06)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* レコード新規作成・編集画面の「＋」ボタン

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* 現在、外部ドキュメントの作成時にFatalErrorが発生しています。以下の修正を適用することで解決します
#973 
