### PR TITLE
[WIP]#970 レポートのヘッダーを固定する修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -651,3 +651,28 @@ ul#productsImageContainer > li a{
   flex-wrap: nowrap;
   align-items: center;
 }
+
+/* レポートのヘッダーを固定する */
+#reportDetails.contents-bottomscroll {
+	max-height: 70vh;
+}
+#reportDetails table tr.blockHeader th{
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  
+  border-color: inherit;
+  background-color: inherit;
+  background-image: inherit;
+  background-repeat: inherit;
+}
+#reportDetails table tr.blockHeader th::before {
+  /* stickyにより枠線が消えてしまうため疑似要素に枠線を追加 */
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: -1px;
+  left: 0;
+  border-top: 2px solid white;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #970 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポートのヘッダーをスクロール時に固定したい。
レポートの横スクロールが必要な時一番したまで行かなければならない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. テーブルにmax-heightを設定し、stickyで項目の行が固定されるように修正
[WIP] スクロールバーのスタイル変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* レポート項目の行が固定されている様子
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/aa99fd45-f2ac-4112-ae28-7e50da29456b)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->