### PR TITLE
PDFテンプレートモジュールにモジュール無効化やプロファイル設定で制限をかけてもアクセスができる不具合の修正

### DIFF
--- a/include/utils/UserInfoUtil.php
+++ b/include/utils/UserInfoUtil.php
@@ -582,7 +582,11 @@ function isPermitted($module,$actionname,$record_id='')
 			$permission = "yes";
 		}
 	}else {
-		$permission = "no";
+		if($module === 'PDFTemplates' && $profileTabsPermission[$tabid] === 0) {
+			$permission = "yes";
+		}else {
+			$permission = "no";
+		}
 	}
 
 	$log->debug("Exiting isPermitted method ...");

--- a/modules/PDFTemplates/views/Detail.php
+++ b/modules/PDFTemplates/views/Detail.php
@@ -10,19 +10,16 @@
 
 class PDFTemplates_Detail_View extends Vtiger_Index_View {
 
-    public function requiresPermission(\Vtiger_Request $request) {
-		return array();
-	}
-    
-    public function checkPermission($request) {
+	public function checkPermission($request) {
         $moduleName = $request->getModule();
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-        if(!$moduleModel->isActive()){
-            return false;
-        }
-        return true;
+		if($moduleModel->isActive()) {
+			return parent::checkPermission($request);
+		}
+		
+		throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
     }
-    
+
 	function preProcess(Vtiger_Request $request, $display=true) {
 		parent::preProcess($request, false);
 

--- a/modules/PDFTemplates/views/Edit.php
+++ b/modules/PDFTemplates/views/Edit.php
@@ -10,19 +10,16 @@
 
 Class PDFTemplates_Edit_View extends Vtiger_Index_View {
 
-	public function requiresPermission(\Vtiger_Request $request) {
-		return array();
-	}
-    
-    public function checkPermission($request) {
+	public function checkPermission($request) {
         $moduleName = $request->getModule();
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-        if(!$moduleModel->isActive()){
-            return false;
-        }
-        return true;
+		if($moduleModel->isActive()) {
+			return parent::checkPermission($request);
+		}
+		
+		throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
     }
-    
+
     public function preProcess(Vtiger_Request $request, $display = true) {
 		$record = $request->get('record');
 		if (!empty($record)) {

--- a/modules/PDFTemplates/views/List.php
+++ b/modules/PDFTemplates/views/List.php
@@ -14,19 +14,16 @@ class PDFTemplates_List_View extends Vtiger_Index_View {
 		parent::__construct();
 	}
 
-    public function requiresPermission(\Vtiger_Request $request) {
-		return array();
-	}
-    
-    public function checkPermission($request) {
+	public function checkPermission($request) {
         $moduleName = $request->getModule();
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-        if(!$moduleModel->isActive()){
-            return false;
-        }
-        return true;
+		if($moduleModel->isActive()) {
+			return parent::checkPermission($request);
+		}
+		
+		throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
     }
-    
+
 	function preProcess(Vtiger_Request $request, $display = true) {
 		parent::preProcess($request, false);
 

--- a/modules/PDFTemplates/views/Popup.php
+++ b/modules/PDFTemplates/views/Popup.php
@@ -10,18 +10,16 @@
 
 class PDFTemplates_Popup_View extends Vtiger_Popup_View {
 
-	public function requiresPermission(\Vtiger_Request $request) {
-		return array();
-	}
-
-    public function checkPermission($request) {
+	public function checkPermission($request) {
         $moduleName = $request->getModule();
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-        if(!$moduleModel->isActive()){
-            return false;
-        }
-        return true;
+		if($moduleModel->isActive()) {
+			return parent::checkPermission($request);
+		}
+		
+		throw new AppException(vtranslate('LBL_PERMISSION_DENIED'));
     }
+
 	/*
 	 * Function to initialize the required data in smarty to display the List View Contents
 	 */


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #983

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
PDFテンプレートモジュールにモジュール自体を無効化しても、プロファイル設定で制限をかけても、PDFTemplateのURLを知っていればアクセスができてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
モジュール無効化が効かない
- PDFテンプレートの有効無効判定は行われていたが、適切にエラースローが行われていなかったため

プロファイル制限が効かない
- パーミッション判定の処理が適切に行われていなかったため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
モジュール無効化が効かない
- PDFテンプレートの有効無効判定後、適切にエラーがスローされるように修正

プロファイル制限が効かない
1. パーミッション判定処理にてPDFテンプレートの判定行われるように修正
2.  PDFテンプレートモジュールの各Viewファイルで権限判定が行われるように修正

## 影響範囲  / Affected Area
PDFテンプレート機能全体

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った