### PR TITLE
#1003 [不具合] カレンダーで月をまたいで3か月以上の終日活動を登録すると、3か月先からカレンダーに活動が表示されない

### DIFF
--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -318,10 +318,6 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		}
 		$query.= " ((concat(date_start, '', time_start)  >= ? AND concat(due_date, '', time_end) < ? ) OR ( due_date >= ? ))";
 
-		$lastMonth = date('Y-m-d H:i:s', strtotime('-2 month', strtotime($dbStartDateTime)));
-		$nextMonth = date('Y-m-d H:i:s', strtotime('+2 month', strtotime($dbStartDateTime)));
-		$query.= " AND concat(date_start, '', time_start) >= '$lastMonth' AND concat(date_start, '', time_start) <= '$nextMonth'";
-
 		$params=array($dbStartDateTime,$dbEndDateTime,$dbStartDate);
 		if(empty($userid)){
 			$eventUserId  = $currentUser->getId();


### PR DESCRIPTION
　修正

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1003 [不具合] カレンダーで月をまたいで3か月以上の終日活動を登録すると、3か月先からカレンダーに活動が表示されない

##  不具合の内容 / Bug
1.  カレンダーで月をまたいで3か月以上の終日活動を登録すると、3か月先からカレンダーに活動が表示されない

##  原因 / Cause
1. 活動のみ範囲を絞っていた

##  変更内容 / Details of Change
1. 範囲を絞るのをやめた

## 影響範囲  / Affected Area
1. 長期間の終日予定のカレンダー部分

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->