### PR TITLE
#1006 [不具合]レポートのCSVエクスポートにてInternalServerErrorが発生する問題の対応

### DIFF
--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -861,8 +861,8 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 //		$fileSize = @filesize($tempFileName) + 8;
 		header('Content-Encoding: UTF-8');
 		header('Content-type: text/csv; charset=UTF-8');
-		header('Transfer-Encoding: chuncked');
-//		header('Content-Length: '.$fileSize);
+//		header('Transfer-Encoding: chuncked');
+		header('Content-Length: '.@filesize($tempFileName));
 //		header('Content-disposition: attachment; filename="'.$fileName.'"');
 		header('Content-Disposition: attachment; filename="'.$fileName.'.csv";filename*=UTF-8\'ja\''.urlencode($fileName).".csv");
 		// UTF-8 Byte Order Mark - BOM (Source : http://stackoverflow.com/questions/4348802/how-can-i-output-a-utf-8-csv-in-php-that-excel-will-read-properly)


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1006

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートのCSVエクスポートにてInternalServerErrorが発生する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Apacheのセキュリティ強化により、Transfer-Encoding: chunckedの指定に厳格になったものと思われる

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. CSVエクスポートの際、Transfer-Encoding: chunckedのheaderを削除し、Content-Lengthを指定するよう修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/84055994/11b6a6dd-45c7-4945-b7a1-0176ac1fc588)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポートのCSVエクスポートのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->