### PR TITLE
#1008 [不具合]レポート 明細のあるモジュールと明細の元となるモジュールを関連モジュールにすると余計に結合される

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -2681,6 +2681,15 @@ class CRMEntity {
 				 */
 				$query = " left join $pritablename as $tmpname ON ($sectablename.$sectableindex=$tmpname.$prifieldname AND $tmpname.id in 
 						(select crmid from vtiger_crmentity where setype='$secmodule' and deleted=0))";
+			} else if($pritablename == 'vtiger_inventoryproductrel' && ($secmodule =="Products" || $secmodule =="Services") && ($module == "Invoice" || $module == "SalesOrder" || $module == "PurchaseOrder" || $module == "Quotes")) {
+				$matrix = $queryPlanner->newDependencyMatrix();
+				$matrix->setDependency('vtiger_inventoryproductreltmp'.$module, array('vtiger_productsQuotes', 'vtiger_serviceQuotes'));
+				if ($queryPlanner->requireTable("vtiger_inventoryproductreltmp".$module, $matrix)) {
+					$tmpname = $pritablename . 'tmp' . $module;
+					$condition = "$table_name.$column_name=$tmpname.$secfieldname";
+				} else {
+					$query = " LEFT JOIN $pritablename AS $tmpname ON ($sectablename.$sectableindex=$tmpname.$prifieldname)";
+				}
 			} else if($pritablename == 'vtiger_cntactivityrel') {
 				if($queryPlanner->requireTable('vtiger_cntactivityrel') && $secmodule == 'Contacts') {
 					$tmpname = 'vtiger_cntactivityrel';


### PR DESCRIPTION
修正

##  関連Issue / Related Issue
- fix #1008 

##  不具合の内容 / Bug
1.  レポート 明細のあるモジュールと明細の元となるモジュールを関連モジュールにすると余計に結合される

##  原因 / Cause
1.  明細と関連モジュールでそれぞれ結合していたため

##  変更内容 / Details of Change
1.  併せて結合するよう修正

## スクリーンショット / Screenshot
※ 1レコードに3つの明細がある状態
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/65175138/c7f473e8-d667-407d-bba6-988632cac863)


## 影響範囲  / Affected Area
レポートで主モジュールに明細があるモジュール、関連モジュールに明細の中身のモジュールを使用した場合

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
