### PR TITLE
Fix/#1010 uitype10でUsersモジュールが紐づいている場合はリスト作成時に「自分」を選択できるようにする

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1197,10 +1197,14 @@ class QueryGenerator {
 				$value = '0';
 			}
 			
-			if ($operator === "own") {
+			if ($operator === "own" && !$field->getUIType() !== 10) {
 				$currentUser = Users_Record_Model::getCurrentUserModel();
 				$currentUserName = decode_html($currentUser->getName());
 				$sql[] = "= '$currentUserName'";
+			}else if($operator === "own" && $field->getUIType() === 10) {
+				$currentUser = Users_Record_Model::getCurrentUserModel();
+				$currentUserId = $currentUser->id;
+				$sql[] = "= '$currentUserId'";
 			}else{
 				$sql[] = "$sqlOperator $value";
 			}

--- a/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
+++ b/layouts/v7/modules/Vtiger/resources/AdvanceFilter.js
@@ -229,7 +229,8 @@ jQuery.Class("Vtiger_AdvanceFilter_Js",{
 		}
 
 		// owner以外の場合「自分」を非表示
-		if(fieldType != 'owner' && (fieldSpecificType == 'V' || fieldSpecificType == 'I')){
+		if(fieldType != 'owner' && (fieldSpecificType == 'V' || fieldSpecificType == 'I')
+				&& !(fieldInfo.referencemodules instanceof Array && fieldInfo.referencemodules.includes('Users'))){
 			conditionList = conditionList.filter(key => key != 'own');
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1010

##  不具合の内容 / Bug
1.  uitype=10の場合はリストの条件に「自分」を選択することが出来ない

##  原因 / Cause
1. uitype=10の場合はリストの条件で「自分」の選択肢を削除していた
2. uitype=10の場合は検索条件が氏名ではなくvtiger_users.idにする必要があるため、ownの条件の場合の処理に問題がある

##  変更内容 / Details of Change
1. uitype=10の場合はリストの条件で「自分」の選択肢を削除されないように修正
2. uitype=10の場合は検索条件が氏名ではなくvtiger_users.idにする必要があるため、ownの条件の場合の処理を修正

## 影響範囲  / Affected Area
- リスト作成画面
- リスト検索
- レポート条件設定

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
ワークフローは未対応