### PR TITLE
#1012 [不具合] ワークフロー 定期的に実行 を使用する際に 日付項目に対して 空ではない 条件を指定すると正しく動作しない

### DIFF
--- a/modules/com_vtiger_workflow/WorkFlowScheduler.php
+++ b/modules/com_vtiger_workflow/WorkFlowScheduler.php
@@ -172,7 +172,7 @@ class WorkFlowScheduler {
 			"starts with" => 's',
 			"ends with" => 'ew',
 			"is not" => 'n',
-			"is not empty" => 'n',
+			"is not empty" => 'ny',
 			'before' => 'l',
 			'after' => 'g',
 			'between' => 'bw',


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1012

##  不具合の内容 / Bug
1. ワークフロー 定期的に実行 を使用する際に 日付項目に対して 空ではない 条件を指定すると正しく動作しない

##  原因 / Cause
1. 空でないに対して日付項目で != "" のSQL が発行されエラーになっていた

##  変更内容 / Details of Change
1. 日付項目に対しては!= ""が入らないように修正

## 影響範囲  / Affected Area
- ワークフロー 定期的に実行 + 空ではない 条件を指定時

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [×] 自らテストを行った
- [×] 不必要な変更が無い
- [×] 影響範囲の検討を行った

