### PR TITLE
リストごとに列幅を保存できるように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2462,9 +2462,12 @@ Vtiger.Class("Vtiger_List_Js", {
 						return false;
 					}
 					var ele = jQuery(e.currentTarget);
+					var cvid = thisInstance.getCurrentCvId();
 					var sourceFieldEle = ele.parent('.item');
 					var targetFieldEle = availFieldsListContainer.find('.item[data-cv-columnname="' + sourceFieldEle.attr('data-cv-columnname') + '"]');
 					targetFieldEle.removeClass('hide');
+					// 項目を削除したときに保存している列幅も削除
+					window.localStorage.removeItem(cvid + '-' + sourceFieldEle.attr('data-field-id'));
 					sourceFieldEle.remove();
 				});
 
@@ -2820,18 +2823,19 @@ Vtiger.Class("Vtiger_List_Js", {
 			'wheelPropagation': true
 		});
 
-		//テーブルからカラム名を取得，各カラムの幅を保存するために一意のidを生成
+		// 現在有効になっているcvidとテーブルのfieldidから，リストごとに各カラムの幅を保存するための一意のidを生成
 		var module = app.getModuleName();
+		var cvId = this.getCurrentCvId();
 		$table.attr('data-resizable-column-id', module);
 		tableContainer.find("tr").each(function(){
 			var $tr = $(this);
 			$tr.find("th").each(function(){
 				var $header = $(this);
-				var $columnname = $header.find('a').data('columnname');
+				var $fieldid = $header.find('a').data('field-id');
 				var $columnid = '';
 				var $tableactions = $header.find('.table-actions');
-				if ($columnname) {
-					$columnid += module + '-' + $columnname;
+				if ($fieldid) {
+					$columnid += cvId + '-' + $fieldid;
 				} else if ($tableactions) {
 					$columnid += module + '-actions';
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1017 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
リストを切り替えた場合、他のリストの設定が反映されている？のか列の幅がおかしくなる
リストによって表示したい幅が異なるため、使いづらい。

##  原因 / Cause
<!-- バグの原因を記述 -->
列幅を保存するときに「モジュール名-項目名」という形式で保存していたため，リストを変更しても他のリストの列幅が適用されていた．


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
列幅を保存するときに「cvid-fieldid」という形式で保存するように修正
一覧画面から項目を削除するときにローカルストレージから該当項目の列幅も削除するように修正


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->