### PR TITLE
ディスプレイサイズが推奨の解像度の範囲内にも関わらず文字が見切れる箇所の修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -654,7 +654,7 @@ ul#productsImageContainer > li a{
 
 /* レコード編集画面のpadding-leftを可変ではなく固定にする */
 @media (min-width: 992px) {
-  .main-container > .viewContent > .content-area {
+  .editViewPageDiv.viewContent > .content-area {
     padding-left: 57px;
   }
 }

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -651,3 +651,10 @@ ul#productsImageContainer > li a{
   flex-wrap: nowrap;
   align-items: center;
 }
+
+/* レコード編集画面のpadding-leftを可変ではなく固定にする */
+@media (min-width: 992px) {
+  .main-container > .viewContent > .content-area {
+    padding-left: 57px;
+  }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1015 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 編集画面にてタイトル文字列が見切れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. padding-leftが3%の相対指定であるため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. サイドバーがあるときは57pxに固定する
  57pxは詳細画面のcontent-areaと同値 #309 

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
- 1366×768の解像度
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/aeafcf20-ce7a-48c0-81ff-6aa1927df2e2)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* レコード編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->