### PR TITLE
一覧画面の列幅可変機能の修正

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1145,6 +1145,7 @@ $languageStrings = array(
 	'LBL_SWITCH_TO_OLD'=>'過去のバージョンに戻す',
 	'LBL_SLA_INFORMATION' => 'SLA情報',
 	'LBL_CUSTOM_FIELD_LIMIT' => 'カスタムフィールドの登録数上限に達しています',
+	'LBL_RESET_COLUMN_WIDTHS' => "列幅をリセット",
 
 	//configure columns
 	'LBL_UPDATE_LIST' => 'リストの更新',

--- a/layouts/v7/lib/jquery/resizableColumns/css/jquery.resizableColumns.css
+++ b/layouts/v7/lib/jquery/resizableColumns/css/jquery.resizableColumns.css
@@ -20,3 +20,7 @@ table.rc-table-resizing thead > th > a {
 .rc-handle:hover {
   background-color:rgb(166, 190, 241);
 }
+/* 検索欄の列幅を調整できないように変更 */
+.rc-handle:first-child {
+  display:none;
+}

--- a/layouts/v7/lib/jquery/resizableColumns/js/jquery.resizableColumns.js
+++ b/layouts/v7/lib/jquery/resizableColumns/js/jquery.resizableColumns.js
@@ -68,6 +68,7 @@ var ResizableColumns = (function () {
 		this.ns = '.rc' + this.count++;
 
 		this.originalTableLayout = $table.css('table-layout');
+		this.originalTableWidth = $table.width();
 		this.options = $.extend({}, ResizableColumns.defaults, options);
 
 		this.$window = $(window);
@@ -76,6 +77,7 @@ var ResizableColumns = (function () {
 
 		this.refreshHeaders();
 		this.restoreColumnWidths();
+		this.adjustDummyColumnWidth();
 		this.syncHandleWidths();
 
 		this.bindEvents(this.$window, 'resize', this.syncHandleWidths.bind(this));
@@ -229,6 +231,31 @@ var ResizableColumns = (function () {
 			});
 		}
 	}, {
+		key: 'adjustDummyColumnWidth',
+
+		/**
+  adjust the dummyColumn width to match all other column widths and container width
+  	@method adjustDummyColumnWidth
+  **/
+		value: function adjustDummyColumnWidth() {
+			var _this6 = this;
+			var containerWidth = this.originalTableWidth
+			var $dummyColumn = this.$tableHeaders.eq(-1);
+			var dummyWidth = this.parseWidth($dummyColumn[0]);
+
+			var sumWithoutDummy = -dummyWidth;
+
+			this.$tableHeaders.each(function (_, el) {
+				sumWithoutDummy += _this6.parseWidth(el);
+			});
+			
+			if (sumWithoutDummy < containerWidth) { 
+				_this6.setWidth($dummyColumn, containerWidth-sumWithoutDummy); 
+			} else {
+				_this6.setWidth($dummyColumn, 20); 
+			}
+		}
+	}, {
 		key: 'onPointerDown',
 
 		/**
@@ -258,22 +285,26 @@ var ResizableColumns = (function () {
 			var gripIndex = $currentGrip.index();
 			var $leftColumn = this.$tableHeaders.eq(gripIndex).not(_constants.SELECTOR_UNRESIZABLE);
 			var $rightColumn = this.$tableHeaders.eq(gripIndex + 1).not(_constants.SELECTOR_UNRESIZABLE);
+			var $dummyColumn = this.$tableHeaders.eq(-1);
 
 			var leftWidth = this.parseWidth($leftColumn[0]);
 			var rightWidth = this.parseWidth($rightColumn[0]);
+			var dummyWidth = this.parseWidth($dummyColumn[0]);
 
 			this.operation = {
-				$leftColumn: $leftColumn, $rightColumn: $rightColumn, $currentGrip: $currentGrip,
+				$leftColumn: $leftColumn, $rightColumn: $rightColumn, $dummyColumn: $dummyColumn, $currentGrip: $currentGrip,
 
 				startX: this.getPointerX(event),
 
 				widths: {
 					left: leftWidth,
-					right: rightWidth
+					right: rightWidth,
+					dummy: dummyWidth
 				},
 				newWidths: {
 					left: leftWidth,
-					right: rightWidth
+					right: rightWidth,
+					dummy: dummyWidth
 				}
 			};
 
@@ -284,7 +315,7 @@ var ResizableColumns = (function () {
 
 			$leftColumn.add($rightColumn).add($currentGrip).addClass(_constants.CLASS_COLUMN_RESIZING);
 
-			this.triggerEvent(_constants.EVENT_RESIZE_START, [$leftColumn, $rightColumn, leftWidth, rightWidth], event);
+			this.triggerEvent(_constants.EVENT_RESIZE_START, [$leftColumn, $rightColumn, $dummyColumn, leftWidth, rightWidth, dummyWidth], event);
 
 			event.preventDefault();
 		}
@@ -312,8 +343,10 @@ var ResizableColumns = (function () {
 
 			var leftColumn = op.$leftColumn[0];
 			var rightColumn = op.$rightColumn[0];
+			var dummyColumn = op.$dummyColumn[0];
 			var widthLeft = undefined,
-			    widthRight = undefined;
+			    widthRight = undefined,
+				widthDummy = undefined;
 
 			// if (difference > 0) {
 			// 	widthLeft = this.constrainWidth(op.widths.left + (op.widths.right - op.newWidths.right));
@@ -323,8 +356,8 @@ var ResizableColumns = (function () {
 			// 	widthRight = this.constrainWidth(op.widths.right + (op.widths.left - op.newWidths.left));
 			// }
 			widthLeft = this.constrainWidth(op.widths.left + difference);
-			// widthRight = this.constrainWidth(op.widths.right);
-			widthRight = this.constrainWidth(op.widths.right - difference);
+			widthRight = this.constrainWidth(op.widths.right);
+			widthDummy = this.constrainWidth(op.widths.dummy - difference);
 
 			if (leftColumn) {
 				this.setWidth(leftColumn, widthLeft);
@@ -332,11 +365,15 @@ var ResizableColumns = (function () {
 			if (rightColumn) {
 				this.setWidth(rightColumn, widthRight);
 			}
+			if (dummyColumn) { 
+				this.setWidth(dummyColumn, widthDummy);
+			}
 
 			op.newWidths.left = widthLeft;
 			op.newWidths.right = widthRight;
+			op.newWidths.dummy = widthDummy;
 
-			return this.triggerEvent(_constants.EVENT_RESIZE, [op.$leftColumn, op.$rightColumn, widthLeft, widthRight], event);
+			return this.triggerEvent(_constants.EVENT_RESIZE, [op.$leftColumn, op.$rightColumn, op.$dummyColumn ,widthLeft, widthRight, widthDummy], event);
 		}
 	}, {
 		key: 'onPointerUp',
@@ -358,12 +395,13 @@ var ResizableColumns = (function () {
 
 			op.$leftColumn.add(op.$rightColumn).add(op.$currentGrip).removeClass(_constants.CLASS_COLUMN_RESIZING);
 
+			this.adjustDummyColumnWidth();
 			this.syncHandleWidths();
 			this.saveColumnWidths();
 
 			this.operation = null;
 
-			return this.triggerEvent(_constants.EVENT_RESIZE_STOP, [op.$leftColumn, op.$rightColumn, op.newWidths.left, op.newWidths.right], event);
+			return this.triggerEvent(_constants.EVENT_RESIZE_STOP, [op.$leftColumn, op.$rightColumn, op.$dummyColumn, op.newWidths.left, op.newWidths.right, op.newWidths.dummy], event);
 		}
 	}, {
 		key: 'destroy',

--- a/layouts/v7/lib/jquery/resizableColumns/js/jquery.resizableColumns.js
+++ b/layouts/v7/lib/jquery/resizableColumns/js/jquery.resizableColumns.js
@@ -80,6 +80,8 @@ var ResizableColumns = (function () {
 		this.adjustDummyColumnWidth();
 		this.syncHandleWidths();
 
+		this.bindEvents(this.$window, 'resize', this.refreshContainerSize.bind(this));
+		this.bindEvents(this.$window, 'resize', this.adjustDummyColumnWidth.bind(this));
 		this.bindEvents(this.$window, 'resize', this.syncHandleWidths.bind(this));
 
 		if (this.options.start) {
@@ -134,7 +136,7 @@ var ResizableColumns = (function () {
 			}
 
 			this.$handleContainer = $('<div class=\'' + _constants.CLASS_HANDLE_CONTAINER + '\' />');
-			// this.$table.before(this.$handleContainer);
+			this.$table.before(this.$handleContainer);
 			this.options.handleContainer ? this.options.handleContainer.before(this.$handleContainer) : this.$table.before(this.$handleContainer);
 
 			this.$tableHeaders.each(function (i, el) {
@@ -239,7 +241,7 @@ var ResizableColumns = (function () {
   **/
 		value: function adjustDummyColumnWidth() {
 			var _this6 = this;
-			var containerWidth = this.originalTableWidth
+			var containerWidth = this.originalTableWidth;
 			var $dummyColumn = this.$tableHeaders.eq(-1);
 			var dummyWidth = this.parseWidth($dummyColumn[0]);
 
@@ -255,7 +257,18 @@ var ResizableColumns = (function () {
 				_this6.setWidth($dummyColumn, 20); 
 			}
 		}
-	}, {
+	},{
+		key: 'refreshContainerSize',
+
+		/**
+  refresh original container size 
+  	@method refreshContainerSize
+  **/
+		value: function refreshContainerSize() {
+			var tableContainer = this.$table.closest('.table-container');
+			this.originalTableWidth = tableContainer.width();
+		}
+	},{
 		key: 'onPointerDown',
 
 		/**
@@ -398,6 +411,8 @@ var ResizableColumns = (function () {
 			this.adjustDummyColumnWidth();
 			this.syncHandleWidths();
 			this.saveColumnWidths();
+			var tableContainer = this.$table.closest('.table-container');
+			tableContainer.perfectScrollbar('update');
 
 			this.operation = null;
 

--- a/layouts/v7/modules/Vtiger/ListViewActions.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewActions.tpl
@@ -115,6 +115,11 @@
                                     {/if}  
                                 {/if}
                             {/foreach}
+                            <li>
+                                <a id="resetColumnWidths" >
+                                    {vtranslate('LBL_RESET_COLUMN_WIDTHS',$MODULE)}
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 {/if}

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2821,9 +2821,11 @@ Vtiger.Class("Vtiger_List_Js", {
 			'height': height,
 			'width': width
 		});
-		tableContainer.perfectScrollbar('update');
-		// $table.floatThead('reflow');
+		$table.resizableColumns('refreshContainerSize');
+		$table.resizableColumns('adjustDummyColumnWidth');
 		$table.resizableColumns('syncHandleWidths');
+		// $table.floatThead('reflow');
+		tableContainer.perfectScrollbar('update');
 	},
 	registerFloatingThead: function () {
 		if (typeof $.fn.perfectScrollbar !== 'function' || typeof $.fn.floatThead !== 'function') {
@@ -2854,9 +2856,6 @@ Vtiger.Class("Vtiger_List_Js", {
 			'width': width
 		});
 
-		tableContainer.perfectScrollbar({
-			'wheelPropagation': true
-		});
 
 		// 現在有効になっているcvidとテーブルのfieldidから，リストごとに各カラムの幅を保存するための一意のidを生成
 		var module = app.getModuleName();
@@ -2885,6 +2884,14 @@ Vtiger.Class("Vtiger_List_Js", {
 
 		$table.resizableColumns({
 			store:store
+		});
+
+		tableContainer.perfectScrollbar({
+			'wheelPropagation': true
+		});
+
+		window.addEventListener('resize',function(){
+			tableContainer.perfectScrollbar('update');
 		});
 
 		// 列の固定処理
@@ -2921,7 +2928,9 @@ Vtiger.Class("Vtiger_List_Js", {
 				leftPos += $column.width();//どちらかゼロ
 			}
 		});
-
+		$table.resizableColumns('refreshContainerSize');
+		$table.resizableColumns('adjustDummyColumnWidth');
+		$table.resizableColumns('syncHandleWidths');
 
 		// $table.floatThead({
 		// 	scrollContainer: function ($table) {

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -325,6 +325,29 @@ Vtiger.Class("Vtiger_List_Js", {
 			thisInstance.loadFilter(cvId, {'mode': 'removeSorting'});
 		});
 	},
+	registerResetColumnWidths: function () {
+		var thisInstance = this;
+		var cvid = thisInstance.getCurrentCvId();
+		jQuery('.btn-group.listViewActionsContainer').find('#resetColumnWidths').on('click', function(e) {
+			var substring = cvid + '-'
+			keysToRemove = [];
+
+			// ローカルストレージ内のcvidを含むkeyを取得
+			for (let i = 0; i < localStorage.length; i++) {
+				const key = localStorage.key(i);
+				
+				if (key.includes(substring)) {
+					keysToRemove.push(key);
+				}
+			}
+			
+			// 該当するすべてのkeyを削除
+			keysToRemove.forEach(key => {
+				localStorage.removeItem(key);
+			});
+			thisInstance.loadListViewRecords();
+		});
+	},
 	performMassDeleteRecords: function (url) {
 		var listInstance = this;
 		var params = {};
@@ -2366,9 +2389,11 @@ Vtiger.Class("Vtiger_List_Js", {
 		jQuery('.btn-group.listViewActionsContainer').find('li').addClass('hide');
 		var selectFreeRecords = jQuery('.btn-group.listViewActionsContainer').find('li.selectFreeRecords');
 		selectFreeRecords.removeClass('hide');
-		if (selectFreeRecords.length == 0) {
-			jQuery('.btn-group.listViewActionsContainer').find('.dropdown-toggle').attr('disabled', "disabled");
-		}
+		var resetColumns = jQuery('.btn-group.listViewActionsContainer').find('#resetColumnWidths');
+		resetColumns.parent().removeClass('hide');
+		// if (selectFreeRecords.length == 0) {
+		// 	jQuery('.btn-group.listViewActionsContainer').find('.dropdown-toggle').attr('disabled', "disabled");
+		// }
 	},
 	/*
 	 * Function to register the click event of email field
@@ -2580,6 +2605,7 @@ Vtiger.Class("Vtiger_List_Js", {
 				vtUtils.applyFieldElementsView(searchRow);
 				self.filterClick = false;
 			}
+			self.registerResetColumnWidths();
 			self.registerDummyColumn();
 			self.registerFloatingThead();
 		});
@@ -2590,6 +2616,7 @@ Vtiger.Class("Vtiger_List_Js", {
 		this._super();
 		this.registerListViewSort();
 		this.registerRemoveListViewSort();
+		this.registerResetColumnWidths();
 		this.registerRowClickEvent();
 		this.registerRowDoubleClickEvent();
 		this.registerListViewBasicActions();

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2822,7 +2822,8 @@ Vtiger.Class("Vtiger_List_Js", {
 			'width': width
 		});
 		tableContainer.perfectScrollbar('update');
-		$table.floatThead('reflow');
+		// $table.floatThead('reflow');
+		$table.resizableColumns('syncHandleWidths');
 	},
 	registerFloatingThead: function () {
 		if (typeof $.fn.perfectScrollbar !== 'function' || typeof $.fn.floatThead !== 'function') {

--- a/layouts/v7/skins/contact/style.css
+++ b/layouts/v7/skins/contact/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/inventory/style.css
+++ b/layouts/v7/skins/inventory/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -6700,7 +6700,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6812,9 +6812,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/marketing_and_sales/style.css
+++ b/layouts/v7/skins/marketing_and_sales/style.css
@@ -6637,7 +6637,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6749,9 +6749,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/project/style.css
+++ b/layouts/v7/skins/project/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/sales/style.css
+++ b/layouts/v7/skins/sales/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/support/style.css
+++ b/layouts/v7/skins/support/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/tools/style.css
+++ b/layouts/v7/skins/tools/style.css
@@ -6644,7 +6644,7 @@ a.cp-modules:hover {
   padding-left: 230px;
 }
 .listViewPageDiv .ps-scrollbar-x-rail {
-  opacity: 1 !important;
+  /* opacity: 1 !important; */
   z-index: 1000;
 }
 li.select2-search-choice div {
@@ -6756,9 +6756,9 @@ li.select2-search-choice div {
 .main-container-Reports .full-width {
   padding-left: 0px !important;
 }
-.listViewPageDiv .ps-scrollbar-x-rail {
+/* .listViewPageDiv .ps-scrollbar-x-rail {
   opacity: 1 !important;
-}
+} */
 li.select2-search-choice div {
   white-space: nowrap;
 }

--- a/layouts/v7/skins/vtiger/style.less
+++ b/layouts/v7/skins/vtiger/style.less
@@ -7397,7 +7397,9 @@ a.cp-modules:hover{
 .ps-container>.ps-scrollbar-y-rail {
     z-index: 1002;
 }
-
+.ps-container>.ps-scrollbar-x-rail {
+    z-index: 1002;
+}
 #relationBlock .recordScroll{
     max-height:150px;
 }

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -35,6 +35,12 @@
   .listViewEntries:last-child {
     border-bottom: 0px;
   }
+  .dummy {
+    right: 0;
+    z-index: 1;
+    /* border-top: 1px solid #ddd; */
+    background: #fff;
+  }
 }
 /*
  * モーダルウインドウの背景を黒ベースに変更
@@ -650,4 +656,9 @@ ul#productsImageContainer > li a{
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
+}
+/* rc-handleと重ならないように調整 */
+.fa-remove {
+  position: relative;
+  right: 15px;
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1028 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 列を狭めると右端の項目が必ず大きくなってしまい，スクロールバーを消すことができない．
2. リストを切り替えた場合，他のリストの設定が反映されている？のか列の幅がおかしくなる．
3. 列幅をリセットできる機能がない．

##  原因 / Cause
<!-- バグの原因を記述 -->
2. 列幅を保存するときに「モジュール名-項目名」という形式で保存していたため，リストを変更しても他のリストの列幅が適用されていた．

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 右端項目の列幅を調整できるように，ダミーカラムを右端に追加．
2. 列幅を保存するときに「cvid-fieldid」という形式で保存するように修正．一覧画面から項目を削除するときにローカルストレージから該当項目の列幅も削除するように修正
3. 一覧画面の「その他」に「列幅をリセット」を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
ダミーカラムを追加後の一覧画面
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/107910164/7d4f9385-6b7f-46b1-96be-0d4c110da2d0)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->