### PR TITLE
「担当」項目で「グループ」を選択した際に該当ユーザーにメールが飛ぶように修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -152,7 +152,14 @@ class Activity extends CRMEntity {
 				$this->invitee_array[] = $smownerid;
 			}
 			if(!in_array($request_assigned_user_id, $this->invitee_array)){
-				$this->invitee_array[] = $request_assigned_user_id;
+				require_once 'include/utils/GetGroupUsers.php';
+				$userGroups = new GetGroupUsers();
+				$userGroups->getAllUsersInGroup($request_assigned_user_id);
+				if(!empty($userGroups->group_users)){ // 担当がグループである場合
+					$this->invitee_array = array_unique(array_merge($this->invitee_array, $userGroups->group_users));
+				}else{
+					$this->invitee_array[] = $request_assigned_user_id;
+				}
 			}
 		} else if(empty($this->invitee_array) && count($_REQUEST['selectedusers']) > 0){// 概要欄や関連からの遷移の場合
 			$this->invitee_array = $_REQUEST['selectedusers'];
@@ -162,7 +169,14 @@ class Activity extends CRMEntity {
 				$this->invitee_array[] = $smownerid;
 			}
 			if(!in_array($request_assigned_user_id, $this->invitee_array)){
-				$this->invitee_array[] = $request_assigned_user_id;
+				require_once 'include/utils/GetGroupUsers.php';
+				$userGroups = new GetGroupUsers();
+				$userGroups->getAllUsersInGroup($request_assigned_user_id);
+				if(!empty($userGroups->group_users)){ // 担当がグループである場合
+					$this->invitee_array = array_unique(array_merge($this->invitee_array, $userGroups->group_users));
+				}else{
+					$this->invitee_array[] = $request_assigned_user_id;
+				}
 			}
 		} else {// リクエストに入っていない場合はDBから取得を試みる
 			$this->loadInvitees();

--- a/modules/Events/models/Module.php
+++ b/modules/Events/models/Module.php
@@ -27,9 +27,25 @@ class Events_Module_Model extends Calendar_Module_Model {
 	 */
 	public function saveRecord(Vtiger_Record_Model $recordModel) {
         $recordModel = parent::saveRecord($recordModel);
-        
+
         //code added to send mail to the vtiger_invitees
         $selectUsers = $recordModel->get('selectedusers');
+		if(empty($selectUsers)){
+			$selectUsers = array();
+		}
+
+		// 担当にも招待・更新メールが送信されるようにする
+		require_once 'include/utils/GetGroupUsers.php';
+		$assigneduserId = $recordModel->get('assigned_user_id');
+		$userGroups = new GetGroupUsers();
+		$userGroups->getAllUsersInGroup($assigneduserId);
+		if(!empty($userGroups->group_users)){ // 担当がグループである場合
+			$assigneduserId = $userGroups->group_users;
+		}else{
+			$assigneduserId = array($assigneduserId);
+		}
+		$selectUsers = array_unique(array_merge($selectUsers, $assigneduserId));
+		
         if(!empty($selectUsers))
         {
             $invities = implode(';',$selectUsers);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #957 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動の担当（ユーザー・グループ）に招待メールが送信されない
2. 担当にグループが設定され、参加者も設定されている場合に活動が作成できない

    ![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/bad51923-dd7d-4db2-8bb4-4014c6d0c0be)

##  原因 / Cause
<!-- バグの原因を記述 -->
### 不具合1 
* 活動新規作成時、参加者欄に選択されたユーザーに対して招待メールが送信される。担当には送信されない。
* 再編集時、担当が参加者の欄に選択される為、保存時に招待（更新）メールが送信される
  * 担当がグループである場合、参加者の欄にグループが無いためメールが送信されない

### 不具合2
* 担当にグループが選択される場合にも、グループIDがユーザーIDと同様に処理されていた
  * modules/Calendar/Activity.php
  #680 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 担当にユーザーもしくはグループが選択されている場合に招待メールが送信されるように修正
2. グループIDをユーザーIDに分割する処理を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* 活動作成

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->