### PR TITLE
#906 チケットのクイック作成時に改行を改行コードを使わなくても行えるようにする

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -602,6 +602,9 @@ Vtiger.Class('Vtiger_Index_Js', {
 					return false;
 				}
 				var formData = jQuery(form).serializeFormData();
+				if(formData['module']=="HelpDesk"){
+					formData['description']=formData['description'].replace(/\n/g,'<br>');
+				}
 				app.request.post({data:formData}).then(function(err,data){
 					app.helper.hideProgress();
 					if(err === null) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #906 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. チケットのクイック作成時に詳細内容を入力する際に，改行コードを使用しないと改行されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 表示に`<br>`が使われていなかった．

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 保存する際に，改行を改行コードに変換した．
2. チケットを詳細入力から保存したときには，詳細内容の入力にCKEditorを用いているため改行が<br>として保存される．この修正以前に詳細入力から保存されたチケットとの互換性を踏まえて，保存する際に改行を改行コードに変換している．


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
チケットモジュールにてクイック作成を行うとき

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
改行コードの保存を統一したほうが良いかもしれない．
チケット(CKEditorを使用しているモジュール)は改行コードを保存している
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/2c5b76ed-5343-428c-8c10-ada448986024)

活動(CKEditorを使っていないモジュール)は改行コードを保存しない
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/95267222/7a471a77-4b93-4c6a-b4a2-83d82b04ad08)

