### PR TITLE
[WIP] #881 Androidで検索ができない不具合の修正

### DIFF
--- a/layouts/v7/lib/jquery/floatThead/jquery.floatThead.js
+++ b/layouts/v7/lib/jquery/floatThead/jquery.floatThead.js
@@ -511,6 +511,14 @@
                 $tableCells.eq(i).css('width', '');
               }
             }
+
+            // 検索欄にフォーカスが設定されている場合, reflow()処理を中断する. 
+            // スマホ画面での入力中やウィンドウサイズの変更時にフォーカスが失われてしまうため. 
+            var activeElement = document.activeElement;
+            if(activeElement && jQuery(activeElement).hasClass('reflowInterrupted')) {
+              return;
+            }
+
             unfloat();
             var widths = [];
             for(i=0; i < numCols; i++){

--- a/layouts/v7/modules/Vtiger/uitypes/FieldSearchView.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/FieldSearchView.tpl
@@ -12,6 +12,6 @@
 {strip}
     {assign var="FIELD_INFO" value=Zend_Json::encode($FIELD_MODEL->getFieldInfo())}
     <div class="">
-        <input type="text" name="{$FIELD_MODEL->get('name')}" class="listSearchContributor inputElement" value="{$SEARCH_INFO['searchValue']}" data-field-type="{$FIELD_MODEL->getFieldDataType()}" data-fieldinfo='{$FIELD_INFO|escape}'/>
+        <input type="text" name="{$FIELD_MODEL->get('name')}" class="listSearchContributor inputElement reflowInterrupted" value="{$SEARCH_INFO['searchValue']}" data-field-type="{$FIELD_MODEL->getFieldDataType()}" data-fieldinfo='{$FIELD_INFO|escape}'/>
     </div>
 {/strip}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #881 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Android画面にてリストの検索欄をタップした際、フォーカスが外れてしまうため入力できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. floatThead('reflow')が呼び出されることで入力のフォーカスが失われている. 
   他にも, ウィンドウサイズが変更された場合に同様の不具合が発生する. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. reflow前にフォーカスが設定されている要素を取得. 検索欄であった場合reflow()を中断する.

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/d8e73844-89f6-4506-bf0f-84e1c4b80ff3)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* リスト(新しくreflowInterruptedクラスが付与された要素)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
* 担当などの項目についても同様の修正が必要 [WIP]
