### PR TITLE
#1031 [不具合]リッチテキストで登録したテキストが詳細画面での表示がおかしくなる修正

### DIFF
--- a/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewBlockView.tpl
@@ -127,7 +127,12 @@
 												{if $fieldDataType eq 'multipicklist'}
 													<input type="hidden" class="fieldBasicData" data-name='{$FIELD_MODEL->get('name')}[]' data-type="{$fieldDataType}" data-displayvalue='{$FIELD_DISPLAY_VALUE}' data-value="{$FIELD_VALUE}" />
 												{else}
-													<input type="hidden" class="fieldBasicData" data-name='{$FIELD_MODEL->get('name')}' data-type="{$fieldDataType}" data-displayvalue='{$FIELD_DISPLAY_VALUE}' data-value="{$FIELD_VALUE}" />
+													{if $fieldDataType eq 'text'}
+														{* value エスケープ処理 *}
+														<input type="hidden" class="fieldBasicData" data-name='{$FIELD_MODEL->get('name')}' data-type="{$fieldDataType}" data-displayvalue='{$FIELD_DISPLAY_VALUE|escape:'html'}' data-value="{$FIELD_VALUE|escape:'html'}" />
+													{else}
+														<input type="hidden" class="fieldBasicData" data-name='{$FIELD_MODEL->get('name')}' data-type="{$fieldDataType}" data-displayvalue='{$FIELD_DISPLAY_VALUE}' data-value="{$FIELD_VALUE}" />
+													{/if}
 												{/if}
 											</span>
 											<span class="action pull-right"><a href="#" onclick="return false;" class="editAction fa fa-pencil"></a></span>

--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1403,6 +1403,11 @@ Vtiger.Class("Vtiger_Detail_Js",{
 								thisInstance.handlePickListDependencyMap(sourcePicklistname);
 								thisInstance.sourcePicklistname = false;
 							}
+
+							if(fieldType == 'text'){
+								// リッチテキスト再表示のため、リロード
+								window.location.reload();
+							}
 						});
 					}
 				};

--- a/layouts/v7/modules/Vtiger/resources/Field.js
+++ b/layouts/v7/modules/Vtiger/resources/Field.js
@@ -589,10 +589,21 @@ Vtiger_Field_Js('Vtiger_Text_Field_Js',{},{
 	 * @return - input text field
 	 */
 	getUi : function() {
-		var html = '<textarea class="input-xxlarge form-control inputElement" name="'+ this.getName() +'" value="'+ this.getValue() + '" >'+ this.getValue() + '</textarea>';
+		// value エスケープ処理
+		var textValue = this.htmlEscape(this.getValue());
+		var html = '<textarea class="input-xxlarge form-control inputElement" name="'+ this.getName() +'" value="'+ textValue + '" >'+ textValue + '</textarea>';
 		var element = jQuery(html);
 		element.css({'cssText': 'height:250px; max-width: initial;'});
 		return this.addValidationToElement(element);
+	},
+
+	htmlEscape : function(str) {
+	return str
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
 	}
 });
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1031

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ドキュメントのメモ（リッチテキスト）にtableを使って表を作って保存すると、詳細画面で表示が崩れる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 詳細画面のテキスト表示にて、value値にhtmlコードが入り、不具合を起こしている

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. エスケープ処理をした値をテキストのvalue値にセット
2. 詳細画面のペンシルアイコンをクリックして、クイック更新を行った後、リロード処理を実行

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット 2024-06-12 171206](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75661775/64f0ef71-d0ef-46ab-8559-e327128b70e0)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->