### PR TITLE
#1038 項目設定画面において「必須」などをクイック変更した場合にデフォルト値が消える問題などの対応

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -952,10 +952,6 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 
 				data.name = nameAttr;
 				data.value = defaultValueUi.val();
-				//チェックボックス項目から、または選択肢(複数)からの変更の場合、デフォルト値に何も表示されないようにする
-				if(nameAttr == 'fieldDefaultValue' && (typeBeforeChange == 'Boolean' || typeBeforeChange == 'Multipicklist')){
-					data.value = "";
-				}
 				if (currentTarget.val() == "MultiSelectCombo") {
 					if (data.value != null && data.value.length > 0) {
 						data.value = data.value.join('|##|');

--- a/modules/Settings/LayoutEditor/actions/Field.php
+++ b/modules/Settings/LayoutEditor/actions/Field.php
@@ -81,6 +81,7 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         $summaryField = $request->get('summaryfield',null);
         $massEditable = $request->get('masseditable',null);
         $headerField = $request->get('headerfield',null);
+        $fieldDefaultValue = $request->get('fieldDefaultValue', null);
 
 		if (!$fieldLabel) {
 			$fieldInstance->set('label', $fieldLabel);
@@ -108,12 +109,15 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
             $fieldInstance->set('masseditable', $massEditable);
         }
         
-        if($uitype == 33){
-            $defaultValue = decode_html(implode(' |##| ', $request->get('fieldDefaultValue')));
-        }else{
-            $defaultValue = decode_html($request->get('fieldDefaultValue'));
+        if(isset($fieldDefaultValue) && $fieldDefaultValue !== null) {
+            $fieldDataType = $fieldInstance->getFieldDataType();
+            if($fieldDataType == 'multipicklist'){
+                $defaultValue = decode_html(implode(' |##| ', $request->get('fieldDefaultValue')));
+            }else{
+                $defaultValue = decode_html($request->get('fieldDefaultValue'));
+            }
+            $fieldInstance->set('defaultvalue', $defaultValue);
         }
-		$fieldInstance->set('defaultvalue', $defaultValue);
 		$response = new Vtiger_Response();
         try{
             $fieldInstance->save();
@@ -122,6 +126,7 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
 			$fieldInfo = $fieldInstance->getFieldInfo();
 			$fieldInfo['id'] = $fieldInstance->getId();
 
+            $defaultValue = $fieldInstance->getDefaultFieldValue();
 			$fieldInfo['fieldDefaultValueRaw'] = $defaultValue;
 			if (isset($defaultValue)) {
 				if ($defaultValue && $fieldInfo['type'] == 'date') {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1038 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目設定の一覧画面（項目単体の編集モーダルではなく、項目一覧が表示されている画面）から「必須」「クイック作成」などを変更すると、設定されているデフォルト値が消えてしまう
1. 複数選択肢項目の編集モーダルを開いた際、デフォルト値が設定されている場合にデフォルト値が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「必須」「クイック作成」などをクイック編集する際、デフォルト値が空として送られている
2. 複数選択肢項目のデフォルト値が編集モーダルを開いたタイミングで削除されてしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. デフォルト値が保存時にリクエストパラメータとして送られてきていない場合はデフォルト値を上書きしないように修正
※「空」で保存した場合はリクエストパラメータとして「空」が送られるため、削除可能
2. 複数選択肢項目のデフォルト値が編集モーダルを開いたタイミングで削除しないよう修正

## 影響範囲  / Affected Area
項目設定

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->