### PR TITLE
繰り返しスケジュールを保存すると、エラーになる不具合の修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -471,6 +471,19 @@ function insertIntoRecurringTable(& $recurObj)
 			return ;
 		}
 
+		// 初回$activityarrayが配列化されていないとin_arrayでExceptionが発生するので初期化する
+		if (empty($activityarray)) {
+			$activityarray = array();
+		}
+
+		if (empty($this->workflow_skip_field_array)){
+			$this->workflow_skip_field_array = array();
+		}
+
+		if (empty($activityarray[$this->workflow_task_id])) {
+			$activityarray[$this->workflow_task_id] = array();
+		}
+
 		// 編集の場合
 		if($this->mode == 'edit'){
 			// 参加者のActivityを更新または削除


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PHP8移行、繰り返しスケジュールを作成すると、ワークフロー周りをスキップする処理でエラーになる不具合

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 配列が初期化されていないため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 初期化を実施した

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
繰り返しスケジュール＋招待者がいる場合の活動の保存すべて

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->