### PR TITLE
一覧画面からTODOを追加、編集した後に詳細画面に遷移するように修正

### DIFF
--- a/modules/Calendar/actions/Save.php
+++ b/modules/Calendar/actions/Save.php
@@ -40,6 +40,9 @@ class Calendar_Save_Action extends Vtiger_Save_Action {
 			} else {
 				$loadUrl = 'index.php?module=Calendar&view=Calendar&calendarStartDate='. $recordModel->get('date_start');
 			}
+			if($parsedParams['referer'] == 'Detail') {
+				$loadUrl = 'index.php?module=Calendar&view=Detail&record='. $recordModel->get('id');
+			}
 
 			if ($request->get('fromQuickCreate')) {
 				$loadUrl = 'index.php'.$request->get('quickCreateReturnURL');

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -89,8 +89,9 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 	 * Function returns the URL for creating Task
 	 * @return <String>
 	 */
+	//一覧表示からTODOを追加後、詳細画面に遷移できるようにrefererを追加。
 	public function getCreateTaskRecordUrl() {
-		return 'index.php?module='.$this->get('name').'&view='.$this->getEditViewName().'&mode=Calendar';
+		return 'index.php?module='.$this->get('name').'&view='.$this->getEditViewName().'&referer=Detail&mode=Calendar';
 	}
 
 	/**

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -61,8 +61,9 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 	 * Function returns the URL for creating Events
 	 * @return <String>
 	 */
+	//一覧表示から活動を追加後、詳細画面に遷移できるようにrefererを追加。
 	public function getCreateEventRecordUrl() {
-		return 'index.php?module='.$this->get('name').'&view='.$this->getEditViewName().'&mode=Events';
+		return 'index.php?module='.$this->get('name').'&view='.$this->getEditViewName().'&referer=Detail&mode=Events';
 	}
 
 	/**

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -46,6 +46,12 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 		return 'Events';
 	}
 
+    //一覧表示からTODO編集を行った際に、詳細画面に戻ってこれるようにrefererを追加
+	public function getEditViewUrl() {
+		$module = $this->getModule();
+		return 'index.php?module=Calendar&view='.$module->getEditViewName().'&referer=Detail&record='.$this->getId();
+	}
+
 	/**
 	 * Function to get the Detail View url for the record
 	 * @return <String> - Record Detail View Url

--- a/modules/Events/models/Record.php
+++ b/modules/Events/models/Record.php
@@ -19,9 +19,10 @@ class Events_Record_Model extends Calendar_Record_Model {
 	 * Function to get the Edit View url for the record
 	 * @return <String> - Record Edit View Url
 	 */
+    //一覧表示から活動編集を行った際に、詳細画面に戻ってこれるようにrefererを追加
 	public function getEditViewUrl() {
 		$module = $this->getModule();
-		return 'index.php?module=Calendar&view='.$module->getEditViewName().'&record='.$this->getId();
+		return 'index.php?module=Calendar&view='.$module->getEditViewName().'&referer=Detail&record='.$this->getId();
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #681 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダーの 一覧表示からTODOを追加、編集するとき、詳細画面に戻らずに個人カレンダー画面に戻ってしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
TODOを追加、編集したあとの遷移先のデフォルトが個人カレンダーになっていたため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
TODOを一覧画面から追加、編集するときにreferer=Detailを追加。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
TODO

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->