### PR TITLE
#1046 クイック作成→詳細入力時に複数選択項目で1つ選択の場合に引き継がれない

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -471,6 +471,13 @@ Vtiger.Class('Vtiger_Index_Js', {
 		// formDataの中身をhiddenのinputにしてeditFormに入れる
 		for(var key in formData) {
 			var value = formData[key];
+			// 複数選択肢の場合のみ
+			if ( jQuery('select[name="'+key+'"]').length && key.includes("[]") ) {
+				key = key.replace("[]", "");
+				if(Array.isArray(value)) {
+					value = value.join(" |##| ");
+				}
+			}
 			var input = document.createElement('input');
 			input.type = 'hidden';
 			input.name = key;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1046

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. クイック作成で選択した複数選択の項目が詳細入力遷移時に引き継がれない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 複数選択肢の値を配列のままRequesutに格納しているため詳細表示の項目で表示できていなかった


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 複数選択項目のkeyから[](角括弧)を除外
2. 値が配列だった場合、|##|で区切った文字列に変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- その他複数選択肢項目があった場合に影響がないか

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
