### PR TITLE
refs #1054 ドキュメント添付の際、ドキュメントレコードは作成されるがファイルアップロードが出来ない問題の対応

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -183,7 +183,7 @@ class CRMEntity {
 		}
 
 		// Check 1
-		$save_file = 'true';
+		$save_file = true;
 		//only images are allowed for Image Attachmenttype
 		$mimeType = vtlib_mime_content_type($file_details['tmp_name']);
 		$mimeTypeContents = explode('/', $mimeType);
@@ -192,12 +192,12 @@ class CRMEntity {
 			$save_file = validateImageFile($file_details);
 		}
                 $log->debug("File Validation status in Check1 save_file => $save_file");
-		if ($save_file == 'false') {
+		if ($save_file == false) {
 			return false;
 		}
 
 		// Check 2
-		$save_file = 'true';
+		$save_file = true;
 		//only images are allowed for these modules
 		if ($module == 'Contacts' || $module == 'Products') {
 			$save_file = validateImageFile($file_details);
@@ -219,7 +219,7 @@ class CRMEntity {
 		$upload_status = copy($filetmp_name, $upload_file_path . $current_id . "_" . $encryptFileName);
 		// temporary file will be deleted at the end of request
                 $log->debug("Upload status of file => $upload_status");
-		if ($save_file == 'true' && $upload_status == 'true') {
+		if ($save_file == true && $upload_status == true) {
 			if($attachmentType != 'Image' && $this->mode == 'edit') {
 				//Only one Attachment per entity delete previous attachments
 				$res = $adb->pquery('SELECT vtiger_seattachmentsrel.attachmentsid FROM vtiger_seattachmentsrel 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1054 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 掲題の通り

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ファイルアップロードの際、validateImageFile()にてバリデーションを行っているが、その実体であるvtiger_Functions::validateImage()の戻り値の型がPHP8.0対応においてboolean型に変更されていた
2. そのため、問題がないとtrue == 'false'という比較になり、比較結果はtrueになるため、バリデーションエラーとして動作してしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ファイルのバリデーション結果を格納している変数をbooleanで扱うよう変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/04fe731e-361e-4be4-9e66-47def3f4147f)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ファイルアップロード機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->