### PR TITLE
PDFテンプレートで原価項目が出力されない問題の修正

### DIFF
--- a/include/InventoryPDFController.php
+++ b/include/InventoryPDFController.php
@@ -780,6 +780,9 @@ class Vtiger_InventoryPDFController {
 		else if($name == 'discount_percent'){
 			$name = "discount_itempercent";
 		}
+		else if($name == 'purchasecost'){
+			$name = "purchase_cost";
+		}
 		return $name;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1002 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
* PDFテンプレートで原価項目（$quotes-purchase_cost$）が正常に表示されない。

テスト環境（v7.4.0）では原価の値が0と出力されるのではなく、何らかの別の値が表示されてしまうことを確認しました。
一方でv7.3.9およびv7.3.8では所望の値が表示されておりました。
もし、不具合の内容に関して私の認識に誤りがございましたら、ご指摘いただけますと幸いです。

##  原因 / Cause
<!-- バグの原因を記述 -->
* PDFテンプレートで入力された項目名（$quotes-purchase_cost$）とgetMergeInventoryBlock()で置換される項目名（$quotes-purchasecost$、ハイフン無し）が一致していなかったため、項目が置換されるべき場所で置換されていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* プライベート関数convertFieldName()内でフィールド名を変更（purchasecost -> purchase_cost）し、getMergeInventoryBlock()内で置換されるように変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* PDFテンプレート
    ![image](https://github.com/user-attachments/assets/ded88f0e-52e5-4a67-aa91-956cc91bbdee)
* 修正前の見積書（製品A: 単価￥2,000 原価￥500、製品B: 単価￥1,000 原価￥100）
    ![image](https://github.com/user-attachments/assets/59c9c704-b5d8-4626-917b-7b6e7a02fc93)
* 修正後の見積書
    ![image](https://github.com/user-attachments/assets/90a131c2-79fb-485e-9b23-aaca8175c5f5)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
PDFテンプレート関係

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->