### PR TITLE
#677 カレンダーから活動の編集ポップアップが開かなくなることがある不具合の修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1564,8 +1564,13 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	registerEditEventModalEvents: function (modalContainer, isRecurring) {
 		this.validateAndUpdateEvent(modalContainer, isRecurring);
 	},
+	showEditModalOperation: false,
 	showEditModal: function (moduleName, record, isRecurring, isDuplicate) {
 		var thisInstance = this;
+		if (thisInstance.showEditModalOperation) {
+			return;
+		}
+		thisInstance.showEditModalOperation = true;
 		var quickCreateNode = jQuery('#quickCreateModules').find('[data-name="' + moduleName + '"]');
 		if (quickCreateNode.length <= 0) {
 			app.helper.showAlertNotification({
@@ -1582,6 +1587,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 
 			if (moduleName === 'Events') {
 				app.event.one('post.QuickCreateForm.show', function (e, form) {
+					thisInstance.showEditModalOperation = false;
 					thisInstance.registerEditEventModalEvents(form.closest('.modal'), isRecurring);
 				});
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #677 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
* 活動を複数回クリックすると編集ポップアップが開かなくなる

##  原因 / Cause
<!-- バグの原因を記述 -->
* 活動がクリック連打されることでAjaxの処理が重複している

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* 編集画面が表示されるまではshowEditModalの処理が実行されないように修正

カレンダーの任意のエリアをクリック連打しても不具合が発生しない理由は, performingDayClickOperationによりshowCreateModalが実行されないように制限されていたため.
本件の場合も同様にshowEditModalOperationによりshowEditModalが実行されないように制限を施した. 

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->