### PR TITLE
#963 [要望]活動一覧のメール文章からHTMLを除外する

### DIFF
--- a/layouts/v7/modules/Vtiger/RelatedActivities.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedActivities.tpl
@@ -72,8 +72,13 @@
 										<td class="relatedActivitiesValue">{vtranslate($ACTIVITYTYPE,$MODULE_NAME)}</td>
 									</tr>
 									<tr class="relatedActivitiesEntries">
-										<td class="relatedActivitiesLabel" valign="top">{vtranslate('Description')}</td>
-										<td class="relatedActivitiesValue">{$DESCRIPTION|nl2br}</td>
+										{if $ACTIVITYTYPE eq 'Emails'}
+											<td class="relatedActivitiesLabel" valign="top">{vtranslate('Description')}</td>
+											<td class="relatedActivitiesValue">{$RECORD->getPlainTextDescription()}</td>
+										{else}
+											<td class="relatedActivitiesLabel" valign="top">{vtranslate('Description')}</td>
+											<td class="relatedActivitiesValue">{$DESCRIPTION|nl2br}</td>
+										{/if}
 									</tr>
 								</table>
 							</div>

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -284,4 +284,11 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 
 		return $isAllDay;
 	}
+
+	// HTMLタグを除外してDescriptionのデータを取得する
+	public function getPlainTextDescription(){
+		$html = html_entity_decode($this->get('description'), ENT_QUOTES, 'UTF-8');
+		$plainText = trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html)));
+		return nl2br($plainText);
+	}
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #963

##  変更内容 / Details of Change
1.  RelatedActivities.tplでEmailの文章の場合はHTMLタグを除外するように変更

## スクリーンショット / Screenshot
変更前
![image](https://github.com/user-attachments/assets/aee24fdf-68a8-4d1b-8d15-c39accc5393e)

変更後
![image](https://github.com/user-attachments/assets/d406716f-81fc-4d99-828b-b5b4dd923dc4)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
