### PR TITLE
#1063 [不具合]顧客企業の活動一覧データが表示されない

### DIFF
--- a/modules/Accounts/models/Module.php
+++ b/modules/Accounts/models/Module.php
@@ -165,9 +165,6 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 			"SELECT distinct
 				vtiger_crmentity.crmid
 				, crmentity2.crmid AS parent_id
-				, vtiger_crmentity.smownerid
-				, vtiger_crmentity.setype
-				, vtiger_crmentity.description
 				, vtiger_activity.* 
 			FROM
 				vtiger_activity 
@@ -229,9 +226,6 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 			"SELECT distinct
 				vtiger_crmentity.crmid
 				, crmentity2.crmid AS parent_id
-				, vtiger_crmentity.smownerid
-				, vtiger_crmentity.setype
-				, vtiger_crmentity.description
 				, vtiger_activity.* 
 			FROM
 				vtiger_activity 
@@ -300,9 +294,6 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 				"SELECT distinct
 					vtiger_crmentity.crmid
 					, null AS parent_id
-					, vtiger_crmentity.smownerid
-					, vtiger_crmentity.setype
-					, vtiger_crmentity.description
 					, vtiger_activity.* 
 				FROM
 					vtiger_activity 
@@ -323,9 +314,6 @@ class Accounts_Module_Model extends Vtiger_Module_Model {
 				"SELECT distinct
 					vtiger_crmentity.crmid
 					, null AS parent_id
-					, vtiger_crmentity.smownerid
-					, vtiger_crmentity.setype
-					, vtiger_crmentity.description
 					, vtiger_activity.* 
 				FROM
 					vtiger_activity 


### PR DESCRIPTION
##  関連Issue / Related Issue

- fix #1063

##  不具合の内容 / Bug

顧客企業の活動一覧のデータが表示されない

##  原因 / Cause

以下のカラム名を重複した状態で取得しようとしてエラーが発生していた
1.  vtiger_crmentity.description とvtiger_activity.description
2.  vtiger_crmentity.smownerid と vtiger_activity.smownerid

##  変更内容 / Details of Change

活動一覧表示に不要なカラムをSELECT文から削除
1. vtiger_crmentity.smownerid
2. vtiger_crmentity.setype
3. vtiger_crmentity.description

## 影響範囲  / Affected Area

- 顧客企業 活動一覧

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
