### PR TITLE
見積・発注・受注・請求で、住所のコピー元がなくても住所のコピーの選択肢が表示される不具合の修正

### DIFF
--- a/layouts/v7/modules/Inventory/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/Inventory/partials/EditViewContents.tpl
@@ -34,7 +34,7 @@
                                 <label  name="togglingHeader">{vtranslate('LBL_BILLING_ADDRESS_FROM', $MODULE)}</label>
                             </td>
                             <td class="fieldValue" name="copyAddress1">
-                                <div class="radio">
+                                <div class="radio{if $CHECK_ACCOUNTID eq false} hidden{/if}">
                                     <label>
                                         <input type="radio" name="copyAddressFromRight" class="accountAddress" data-copy-address="billing" checked="checked">
                                         &nbsp;{vtranslate('SINGLE_Accounts', $MODULE)}
@@ -68,7 +68,7 @@
                                 <label  name="togglingHeader">{vtranslate('LBL_SHIPPING_ADDRESS_FROM', $MODULE)}</label>
                             </td>
                             <td class="fieldValue" name="copyAddress2">
-                                <div class="radio">
+                                <div class="radio{if $CHECK_ACCOUNTID eq false} hidden{/if}">
                                     <label>
                                         <input type="radio" name="copyAddressFromLeft" class="accountAddress" data-copy-address="shipping" checked="checked">
                                         &nbsp;{vtranslate('SINGLE_Accounts', $MODULE)}

--- a/layouts/v7/modules/PurchaseOrder/uitypes/Text.tpl
+++ b/layouts/v7/modules/PurchaseOrder/uitypes/Text.tpl
@@ -35,7 +35,7 @@
 				{foreach from=$pickList key=keys item=value}
 					{if $keys eq 'vendor' or $keys eq 'contact' or $keys eq 'account'}
 						{$modl = ucfirst($keys|cat:"s")}
-						{if  vtlib_isModuleActive($modl)}
+						{if  vtlib_isModuleActive($modl) and array_key_exists($keys|cat:'_id', $RECORD_STRUCTURE['LBL_PO_INFORMATION'])}
 							<option value="{$keys}">{vtranslate($value,$MODULE)}</option>
 						{/if}
 					{else}
@@ -51,7 +51,7 @@
 					{foreach from=$pickList key=keys item=value}
 					{if $keys eq 'vendor' or $keys eq 'contact' or $keys eq 'account'}
 						{$modl = ucfirst($keys|cat:"s")}
-						{if  vtlib_isModuleActive($modl)}
+						{if  vtlib_isModuleActive($modl) and array_key_exists($keys|cat:'_id', $RECORD_STRUCTURE['LBL_PO_INFORMATION'])}
 							<option value="{$keys}">{vtranslate($value,$MODULE)}</option>
 						{/if}
 					{else}

--- a/modules/Inventory/views/Edit.php
+++ b/modules/Inventory/views/Edit.php
@@ -170,6 +170,17 @@ Class Inventory_Edit_View extends Vtiger_Edit_View {
 		$viewer->assign('CURRENTDATE', date('Y-n-j'));
 		$viewer->assign('USER_MODEL', Users_Record_Model::getCurrentUserModel());
 
+		// 顧客企業が非表示項目である場合, コピーする住所の選択肢から削除する
+		$inventoryModules = array(
+			'Invoice' => 'LBL_INVOICE_INFORMATION',
+			'SalesOrder' => 'LBL_SO_INFORMATION',
+			// 'PurchaseOrder' => 'LBL_PO_INFORMATION', // POはテンプレート側で対応
+			'Quotes' => 'LBL_QUOTE_INFORMATION'
+		);
+		if ($inventoryModules[$moduleName] && $recordStructure[$inventoryModules[$moduleName]]) {
+			$viewer->assign('CHECK_ACCOUNTID', array_key_exists("account_id", $recordStructure[$inventoryModules[$moduleName]]));
+		}
+
 		$taxRegions = $recordModel->getRegionsList();
 		$defaultRegionInfo = $taxRegions[0];
 		unset($taxRegions[0]);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1014 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
* 見積・発注・受注・請求で、住所のコピー元がなくても住所のコピーの選択肢が表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
* 項目の有無にかかわらず選択肢が表示されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
* 発注モジュールは顧客企業（account_id）・発注先（vendor_id）・顧客担当者（contact_id）の3項目の表示/非表示を制御
* 発注以外のモジュールは顧客企業の表示/非表示を制御できるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* 修正前：発注モジュール
![image](https://github.com/user-attachments/assets/5af6b1b6-2b72-43fd-8df7-798070eb9753)
* 修正後：発注モジュール -> 非表示項目とした顧客企業住所・顧客担当者住所が削除されている
![image](https://github.com/user-attachments/assets/10e506ba-da72-4018-a76c-9f17f2f92ee8)
* 修正前：見積モジュール
![image](https://github.com/user-attachments/assets/8c97e5f0-44a7-444a-8195-c63b87dd48c5)
* 修正後：見積モジュール -> 非表示項目とした顧客企業住所が削除されている
![image](https://github.com/user-attachments/assets/a78d43bb-ae84-4da7-b06d-4a6d635bae3b)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* Inventoryモジュール（見積・発注・受注・請求）の編集画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->