### PR TITLE
#1066 [不具合]ユーザーにフォローされているデータを編集できない

### DIFF
--- a/modules/Vtiger/handlers/FollowRecordHandler.php
+++ b/modules/Vtiger/handlers/FollowRecordHandler.php
@@ -93,7 +93,7 @@ class FollowRecordHandler extends VTEventHandler {
 	}
 
 	public function getChangedFieldString($fieldModels, $changedValues, $userRecordModel) {
-		$userEntity = $userRecordModel->entity;
+		$userEntity = $userRecordModel->getEntity();
 
 		$changedFieldString = '';
 		foreach ($fieldModels as $fieldName => $fieldModel) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1066

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ユーザーにフォローされているデータを
編集して保存ボタンを押すとエラーが発生する

##  原因 / Cause
<!-- バグの原因を記述 -->
 FollowRecordHandler#getChangedFieldString の中で
 Users_Record_Model の変数 protected $entity の取得方法にミスがあり、以下のエラーが発生していた。
```
Fatal error
: Uncaught Error: Cannot access protected property Users_Record_Model::$entity ...
```

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Users_Record_Model#getEntity() を利用するように変更

## 影響範囲  / Affected Area
フォローされている各レコード

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った