### PR TITLE
thinkingreed-inc#980 リードのメールアドレス(予備)のラベルが間違っている

### DIFF
--- a/languages/ja_jp/Leads.php
+++ b/languages/ja_jp/Leads.php
@@ -26,7 +26,7 @@ $languageStrings = array(
 	'Lead Status' => 'ステータス',
 	'No Of Employees' => '従業員数',
 	'Phone' => '電話番号',
-	'Secondary Email' => '電話番号(予備)',
+	'Secondary Email' => 'メールアドレス(予備)',
 	'Email' => 'メールアドレス',
 
 	//Added for Existing Picklist Entries


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #980

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  リードのフィールドである「メールアドレス(予備)」が「電話番号(予備)」と表示されている
※内部名称がsecondaryemail、デフォルトのuitypeがメールアドレスであることから判断

##  原因 / Cause
<!-- バグの原因を記述 -->
1. リードの「Secondary Email」への日本語翻訳が間違っていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「Secondary Email」の翻訳を「メールアドレス(予備)」に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
![image](https://github.com/user-attachments/assets/fa5d8531-74b1-4220-8ab3-748e6ed15563)


変更語
![image](https://github.com/user-attachments/assets/a735eab8-fbcc-4c77-bad8-f5e1499cb343)


## 影響範囲  / Affected Area
リードのフィールド表記のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
概要、詳細、編集ページで正常になっていることを確認済み
