### PR TITLE
活動を一覧画面からまとめて削除しようとするとundefinedエラーが生じる不具合の修正

### DIFF
--- a/modules/Calendar/actions/MassDelete.php
+++ b/modules/Calendar/actions/MassDelete.php
@@ -22,7 +22,7 @@ class Calendar_MassDelete_Action extends Vtiger_MassDelete_Action {
         }
 		$cvId = $request->get('viewname');
 		foreach($recordIds as $recordId) {
-			if(Users_Privileges_Model::isPermitted($moduleName, 'Delete', $recordId)) {
+			if(isRecordExists($recordId) && Users_Privileges_Model::isPermitted($moduleName, 'Delete', $recordId)) {
 				$recordModel = Vtiger_Record_Model::getInstanceById($recordId, $moduleModel);
 				$parentRecurringId = $recordModel->getParentRecurringRecord();
 				$adb->pquery('DELETE FROM vtiger_activity_recurring_info WHERE activityid=? AND recurrenceid=?', array($parentRecurringId, $recordId));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1070 
- #1068 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
活動を一覧画面からまとめて削除しようとするとundefinedエラーが生じる.

##  原因 / Cause
<!-- バグの原因を記述 -->
参加者を含むレコードは親レコードが削除されると子レコードも削除される.
そのため, すでに削除済みの子レコードに対して再度deleteを実行しようとしていた.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
delete前にisRecordExists($recordId)を用いてレコードの存在判定を行う. 
なお, 参加者を含む活動作成時にFatalErrorが発生する場合には #1069 を適用してください. 

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
活動のまとめて削除機能関連(MassDelete)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->