### PR TITLE
他人の作成した活動を変更する際に確認メッセージを出す。(モバイルデバイスを用いているかの識別とシステム変数未対応)

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1609,6 +1609,7 @@ $jsLanguageStrings = array(
 	'INVALID_NUMBER_OF' => '無効な数字：',
 	'INVALID_NUMBER' => '無効な数字',
 	'JS_LBL_ARE_YOU_SURE_YOU_WANT_TO_DELETE' => '削除しますか？',
+	'JS_EDIT_OTHERS_EVENT_CONFIRMATION' => '他人の活動に変更を加えますか？',
 
 	'OVERWRITE_EXISTING_MSG1' => '既存住所を選択した住所の詳細 ( ',
 	'OVERWRITE_EXISTING_MSG2' => ') で上書きしますか？',

--- a/modules/Calendar/actions/SaveFollowupAjax.php
+++ b/modules/Calendar/actions/SaveFollowupAjax.php
@@ -28,6 +28,7 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
     function __construct() {
         $this->exposeMethod('createFollowupEvent');
         $this->exposeMethod('markAsHeldCompleted');
+        $this->exposeMethod('checkNotificationOthersEvents');
     }
     
     public function process(Vtiger_Request $request) {  
@@ -173,6 +174,26 @@ class Calendar_SaveFollowupAjax_Action extends Calendar_SaveAjax_Action {
 				$_REQUEST['repeatMonth_daytype'] = $recurringInfo['repeatMonth_daytype'];
 				$_REQUEST['repeatMonth_day'] = $recurringInfo['repeatMonth_day'];
 			}
+		}
+	}
+
+	function checkNotificationOthersEvents(Vtiger_Request $request){
+		global $adb, $current_user;
+		$response = new Vtiger_Response();
+
+		$record = $request->get('record');
+		$query = "SELECT smcreatorid FROM vtiger_crmentity WHERE crmid = ?";
+
+		$check_activity = array($record);
+		$result = $adb->pquery($query, $check_activity);
+		$currentUserId = $current_user->id;
+		$creatorId = $adb->query_result($result,0,"smcreatorid");
+		if($currentUserId != $creatorId){			
+			$response->setResult(array("own"=>FALSE));
+			$response->emit();
+		}else if ($currentUserId == $creatorId){
+			$response->setResult(array("own"=>TRUE));
+			$response->emit();
 		}
 	}
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #952 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー

##  原因 / Cause
<!-- バグの原因を記述 -->
1. モバイルデバイスを利用している際に、画面が小さい為、カレンダー画面で誤って他人のスケジュールを編集や削除してしまうことがある。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 他人の活動を編集する際に、確認メッセージを出すようにする。
2. 確認メッセージを出す機能のOn/Offを、システム変数で設定できるようにする。(途中)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
他人の活動を編集する際に、画像のようなメッセージを出す。
![image](https://github.com/user-attachments/assets/dafab3c9-078a-42da-aaf6-473890974f91)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
活動の編集/削除の範囲。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
システム変数にて制御を行えるように修正しています。
