### PR TITLE
#1033 ユーザー情報の項目「メールの署名」を詳細画面から変更できないよう修正

### DIFF
--- a/modules/Users/models/Field.php
+++ b/modules/Users/models/Field.php
@@ -66,7 +66,20 @@ class Users_Field_Model extends Vtiger_Field_Model {
 		if(!$this->isEditable() || $this->get('uitype') == 105 || $this->get('uitype') == 106 || $this->get('uitype') == 98 || $this->get('uitype') == 101) {
 			return false;
 		}
+
+		// リッチテキストは概要・詳細画面での編集不可
+		if ($this->isCkeditor() === true) {
+			return false;
+		}
+
 		return true;
+	}
+
+	public function isCkEditor() {
+		if($this->getName() == 'signature') {
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1033 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー情報の項目「メールの署名」を詳細画面の鉛筆マークから編集すると編集できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「メールの署名」項目はリッチテキスト項目であり、詳細画面から編集できないが制御がかかっておらず編集可能項目となっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. チケット、FAQなどと同様、リッチテキスト項目のため編集不可とするよう修正した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/e37e12d8-5ea9-4aa5-80d8-e0b95e032556)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー詳細「メールの署名」のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->