### PR TITLE
Fix #1093 PHP8以上の環境で、REST APIがエラーになっていた不具合の修正

### DIFF
--- a/include/Webservices/ChangePassword.php
+++ b/include/Webservices/ChangePassword.php
@@ -1,0 +1,70 @@
+<?php
+
+/*+*******************************************************************************
+ *   The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ *   ("License"); You may not use this file except in compliance with the License
+ *   The Original Code is:  vtiger CRM Open Source
+ *   The Initial Developer of the Original Code is vtiger.
+ *   Portions created by vtiger are Copyright (C) vtiger.
+ *   All Rights Reserved.
+ * 
+ *********************************************************************************/
+
+/**
+ * @author Musavir Ahmed Khan<musavir at vtiger.com>
+ */
+
+/**
+ *
+ * @param WebserviceId $id
+ * @param String $oldPassword
+ * @param String $newPassword
+ * @param String $confirmPassword
+ * @param Users $user 
+ * 
+ */
+function vtws_changePassword($id, $oldPassword, $newPassword, $confirmPassword, $user) {
+	vtws_preserveGlobal('current_user',$user);
+	$idComponents = vtws_getIdComponents($id);
+	if($idComponents[1] == $user->id || is_admin($user)) {
+		$newUser = new Users();
+		$newUser->retrieve_entity_info($idComponents[1], 'Users');
+		if(!is_admin($user)) {
+			if(empty($oldPassword)) {
+				throw new WebServiceException(WebServiceErrorCode::$INVALIDOLDPASSWORD, 
+					vtws_getWebserviceTranslatedString('LBL_'.
+							WebServiceErrorCode::$INVALIDOLDPASSWORD));
+			}
+			if(!$user->verifyPassword($oldPassword)) {
+				throw new WebServiceException(WebServiceErrorCode::$INVALIDOLDPASSWORD, 
+					vtws_getWebserviceTranslatedString('LBL_'.
+							WebServiceErrorCode::$INVALIDOLDPASSWORD));
+			}
+		}
+		if(strcmp($newPassword, $confirmPassword) === 0) {
+			$db = PearDatabase::getInstance();
+			$db->dieOnError = true;
+			$db->startTransaction();
+			$success = $newUser->change_password($oldPassword, $newPassword, false);
+			$error = $db->hasFailedTransaction();
+			$db->completeTransaction();
+			if($error) {
+				throw new WebServiceException(WebServiceErrorCode::$DATABASEQUERYERROR, 
+					vtws_getWebserviceTranslatedString('LBL_'.
+							WebServiceErrorCode::$DATABASEQUERYERROR));
+			}
+			if(!$success) {
+				throw new WebServiceException(WebServiceErrorCode::$CHANGEPASSWORDFAILURE, 
+					vtws_getWebserviceTranslatedString('LBL_'.
+							WebServiceErrorCode::$CHANGEPASSWORDFAILURE));
+			}
+		} else {
+			throw new WebServiceException(WebServiceErrorCode::$CHANGEPASSWORDFAILURE, 
+					vtws_getWebserviceTranslatedString('LBL_'.
+							WebServiceErrorCode::$CHANGEPASSWORDFAILURE));
+		}
+		VTWS_PreserveGlobal::flush();
+		return array('message' => 'Changed password successfully');
+	}
+}
+?>

--- a/include/Webservices/DeleteUser.php
+++ b/include/Webservices/DeleteUser.php
@@ -1,0 +1,68 @@
+<?php
+/*+*******************************************************************************
+ *  The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is:  vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *
+ *********************************************************************************/
+ require_once("include/events/include.inc");
+/**
+ * @author MAK
+ */
+
+function vtws_deleteUser($id, $newOwnerId,$user){
+		global $log,$adb;
+		$webserviceObject = VtigerWebserviceObject::fromId($adb,$id);
+		$handlerPath = $webserviceObject->getHandlerPath();
+		$handlerClass = $webserviceObject->getHandlerClass();
+
+		require_once $handlerPath;
+
+		$handler = new $handlerClass($webserviceObject,$user,$adb,$log);
+		$meta = $handler->getMeta();
+		$entityName = $meta->getObjectEntityName($id);
+
+		$types = vtws_listtypes(null, $user);
+		if(!in_array($entityName,$types['types'])){
+			throw new WebServiceException(WebServiceErrorCode::$ACCESSDENIED,
+					"Permission to perform the operation is denied, EntityName = ".$entityName);
+		}
+
+		if($entityName !== $webserviceObject->getEntityName()){
+			throw new WebServiceException(WebServiceErrorCode::$INVALIDID,
+					"Id specified is incorrect");
+		}
+
+		if(!$meta->hasPermission(EntityMeta::$DELETE,$id)){
+			throw new WebServiceException(WebServiceErrorCode::$ACCESSDENIED,
+					"Permission to read given object is denied");
+		}
+
+		$idComponents = vtws_getIdComponents($id);
+		if(!$meta->exists($idComponents[1])){
+			throw new WebServiceException(WebServiceErrorCode::$RECORDNOTFOUND,
+					"Record you are trying to access is not found, idComponent = ".$idComponents);
+		}
+
+		if($meta->hasWriteAccess()!==true){
+			throw new WebServiceException(WebServiceErrorCode::$ACCESSDENIED,
+					"Permission to write is denied");
+		}
+
+		$newIdComponents = vtws_getIdComponents($newOwnerId);
+		if(empty($newIdComponents[1])) {
+			//force the default user to be the default admin user.
+			$newIdComponents[1] = 1;
+		}
+
+		$userObj = new Users();
+		$userObj->transformOwnerShipAndDelete($idComponents[1], $newIdComponents[1]);		
+
+		VTWS_PreserveGlobal::flush();
+		return  array("status"=>"successful");
+	}
+
+?>

--- a/include/Webservices/FileRetrieve.php
+++ b/include/Webservices/FileRetrieve.php
@@ -8,11 +8,11 @@
  * All Rights Reserved.
  *************************************************************************************/
 
-function vtws_file_retrieve($file_id, $user) {
+function vtws_file_retrieve($id, $user) {
 
     global $log, $adb;
 
-    $idComponents = vtws_getIdComponents($file_id);
+    $idComponents = vtws_getIdComponents($id);
     $attachmentId = $idComponents[1];
     
     $id = vtws_getAttachmentRecordId($attachmentId);

--- a/include/Webservices/GetUpdates.php
+++ b/include/Webservices/GetUpdates.php
@@ -13,14 +13,14 @@ require_once 'include/utils/CommonUtils.php';
 require_once('include/utils/GetUserGroups.php');
 require_once 'include/Webservices/DescribeObject.php';
 
-	function vtws_sync($mtime,$elementType,$syncType,$user){
+	function vtws_sync($modifiedTime,$elementType,$syncType,$user){
 		global $adb, $recordString,$modifiedTimeString;
         
 		$numRecordsLimit = 100;
 		$ignoreModules = array("Users");
 		$typed = true;
 		$dformat = "Y-m-d H:i:s";
-		$datetime = date($dformat, $mtime);
+		$datetime = date($dformat, $modifiedTime);
 		$setypeArray = array();
 		$setypeData = array();
 		$setypeHandler = array();
@@ -84,7 +84,7 @@ require_once 'include/Webservices/DescribeObject.php';
 
 		if(php7_count($accessableModules)<=0)
 		{
-				$output['lastModifiedTime'] = $mtime;
+				$output['lastModifiedTime'] = $modifiedTime;
 				$output['more'] = false;
 				return $output;
 		}
@@ -222,7 +222,7 @@ require_once 'include/Webservices/DescribeObject.php';
 			$output['more'] = false;
 		}
 		if(!$maxModifiedTime){
-			$modifiedtime = $mtime;
+			$modifiedtime = $modifiedTime;
 		}else{
 			$modifiedtime = vtws_getSeconds($maxModifiedTime);
 		}
@@ -244,9 +244,9 @@ require_once 'include/Webservices/DescribeObject.php';
 		return $output;
 	}
 	
-	function vtws_getSeconds($mtimeString){
+	function vtws_getSeconds($modifiedTimeString){
 		//TODO handle timezone and change time to gmt.
-		return strtotime($mtimeString);
+		return strtotime($modifiedTimeString);
 	}
 
 	function vtws_isRecordDeleted($recordDetails,$deleteColumnDetails,$deletedValues){

--- a/include/Webservices/LineItem/RetrieveInventory.php
+++ b/include/Webservices/LineItem/RetrieveInventory.php
@@ -14,7 +14,7 @@ require_once 'include/Webservices/Retrieve.php';
 /**
  * Retrieve inventory record with LineItems
  */
-function vtws_retrieve_inventory($id){
+function vtws_retrieve_inventory($id, $user){
 	global $current_user;
 
 	$record = vtws_retrieve($id, $current_user);

--- a/include/Webservices/Login.php
+++ b/include/Webservices/Login.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  *************************************************************************************/
 	
-	function vtws_login($username,$pwd){
+	function vtws_login($username,$accessKey){
 		
 		$user = new Users();
 		$userId = $user->retrieve_user_id($username);
@@ -18,13 +18,13 @@
 			throw new WebServiceException(WebServiceErrorCode::$INVALIDTOKEN,"Specified token is invalid or expired");
 		}
 		
-		$accessKey = vtws_getUserAccessKey($userId);
-		if($accessKey == null){
+		$localAccessKey = vtws_getUserAccessKey($userId);
+		if($localAccessKey == null){
 			throw new WebServiceException(WebServiceErrorCode::$ACCESSKEYUNDEFINED,"Access key for the user is undefined");
 		}
 		
-		$accessCrypt = md5($token.$accessKey);
-		if(strcmp($accessCrypt,$pwd)!==0){
+		$accessCrypt = md5($token.$localAccessKey);
+		if(strcmp($accessCrypt, $accessKey)!==0){
 			throw new WebServiceException(WebServiceErrorCode::$INVALIDUSERPWD,"Invalid username or password");
 		}
 		$user = $user->retrieveCurrentUserInfoFromFile($userId);
@@ -32,7 +32,6 @@
 			return $user;
 		}
 		// Finer exception message could be handy to enumeration attacks - so normalize it. 
-		//throw new WebServiceException(WebServiceErrorCode::$AUTHREQUIRED,'Given user is inactive');
 		throw new WebServiceException(WebServiceErrorCode::$INVALIDUSERPWD,"Invalid username or password");
 	}
 	

--- a/include/Webservices/Logout.php
+++ b/include/Webservices/Logout.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  *************************************************************************************/
 
-function vtws_logout($sessionId,$user){
+function vtws_logout($sessionName,$user){
         global $adb;
         $sql = "select type from vtiger_ws_operation where name=?";
         $result = $adb->pquery($sql,array("logout"));
@@ -18,14 +18,13 @@ function vtws_logout($sessionId,$user){
             throw new WebServiceException(WebServiceErrorCode::$OPERATIONNOTSUPPORTED, "Permission to perform the operation is denied");
         }
 	$sessionManager = new SessionManager();
-	$sid = $sessionManager->startSession($sessionId);
+	$sid = $sessionManager->startSession($sessionName);
 	
-	if(!isset($sessionId) || !$sessionManager->isValid()){
+	if(!isset($sessionName) || !$sessionManager->isValid()){
 		return $sessionManager->getError();
 	}
 
 	$sessionManager->destroy();
-//	$sessionManager->setExpire(1);
 	return array("message"=>"successfull");
 
 }

--- a/include/Webservices/OperationManager.php
+++ b/include/Webservices/OperationManager.php
@@ -125,9 +125,7 @@
 			$sanitizedInput = array();
 			foreach($this->operationParams as $ind=>$columnDetails){
 				foreach ($columnDetails as $columnName => $type) {
-					// if(isset($input, $columnName)){
-						$sanitizedInput[$columnName] = $this->handleType($type,vtws_getParameter($input,$columnName));
-					// }
+					$sanitizedInput[$columnName] = $this->handleType($type,vtws_getParameter($input,$columnName));
 				}
 			}
 			return $sanitizedInput;

--- a/include/Webservices/OperationManager.php
+++ b/include/Webservices/OperationManager.php
@@ -125,7 +125,9 @@
 			$sanitizedInput = array();
 			foreach($this->operationParams as $ind=>$columnDetails){
 				foreach ($columnDetails as $columnName => $type) {
-					$sanitizedInput[$columnName] = $this->handleType($type,vtws_getParameter($input,$columnName));;
+					// if(isset($input, $columnName)){
+						$sanitizedInput[$columnName] = $this->handleType($type,vtws_getParameter($input,$columnName));
+					// }
 				}
 			}
 			return $sanitizedInput;

--- a/include/Webservices/OperationManager.php
+++ b/include/Webservices/OperationManager.php
@@ -152,7 +152,7 @@
 			try{
 				$operation = strtolower($this->operationName);
 				if(!$this->preLogin){
-					$params[] = $user;
+					$params['user'] = $user;
 					return call_user_func_array($this->handlerMethod,$params);
 				}else{
 					$userDetails = call_user_func_array($this->handlerMethod,$params);

--- a/include/Webservices/Query.php
+++ b/include/Webservices/Query.php
@@ -10,7 +10,7 @@
 
 	require_once("include/Webservices/QueryParser.php");
 	
-	function vtws_query($q,$user){
+	function vtws_query($query,$user){
 		
 		static $vtws_query_cache = array();	
 		
@@ -19,10 +19,10 @@
 		// Cache the instance for re-use		
 		$moduleRegex = "/[fF][rR][Oo][Mm]\s+([^\s;]+)/";
 		$moduleName = '';
-		if(preg_match($moduleRegex, $q, $m)) $moduleName = trim($m[1]);
+		if(preg_match($moduleRegex, $query, $m)) $moduleName = trim($m[1]);
 		
 		if(!isset($vtws_create_cache[$moduleName]['webserviceobject'])) {
-			$webserviceObject = VtigerWebserviceObject::fromQuery($adb,$q);
+			$webserviceObject = VtigerWebserviceObject::fromQuery($adb,$query);
 			$vtws_query_cache[$moduleName]['webserviceobject'] = $webserviceObject;
 		} else {
 			$webserviceObject = $vtws_query_cache[$moduleName]['webserviceobject'];
@@ -61,7 +61,7 @@
 			throw new WebServiceException(WebServiceErrorCode::$ACCESSDENIED,"Permission to read is denied");
 		}
 		
-		$result = $handler->query($q);
+		$result = $handler->query($query);
 		VTWS_PreserveGlobal::flush();
 		return $result;
 	}

--- a/include/Webservices/VtigerWebserviceObject.php
+++ b/include/Webservices/VtigerWebserviceObject.php
@@ -40,7 +40,6 @@ class VtigerWebserviceObject{
 	private static $_fromNameCache = array();
 		
 	static function fromName($adb,$entityName){
-		
 		$rowData = false;
 		
 		// If the information not available in cache?
@@ -51,7 +50,6 @@ class VtigerWebserviceObject{
 			if ($cacheLength == 0) {
 				$result = $adb->pquery("select * from vtiger_ws_entity where name=?",array($entityName));
 			} else {
-				// Could repeat more number of times...so let us pull rest of details into cache.
 				$result = $adb->pquery("select * from vtiger_ws_entity", array());
 			}
 			
@@ -66,10 +64,8 @@ class VtigerWebserviceObject{
 		}
 		
 		$rowData = self::$_fromNameCache[$entityName];
-		
 		if($rowData) {
-			return new VtigerWebserviceObject($rowData['id'],$rowData['name'],
-						$rowData['handler_path'],$rowData['handler_class']);
+			return new VtigerWebserviceObject($rowData['id'],$rowData['name'],$rowData['handler_path'],$rowData['handler_class']);
 		}
 		throw new WebServiceException(WebServiceErrorCode::$ACCESSDENIED,"Permission to perform the operation is denied for name : $entityName");
 	}

--- a/modules/Migration/schema/740_to_741.php
+++ b/modules/Migration/schema/740_to_741.php
@@ -23,5 +23,5 @@ if (defined('VTIGER_UPGRADE')) {
     include_once 'setup/scripts/77_Update_CalendarUserActivityTypes.php';
 
     //F-RevoCRM REST APIにて、SyncAPIの引数を追加
-    include_once 'setup/scripts/78_Update_SyncAPI.php';
+    include_once 'setup/scripts/78_Update_RESTAPI.php';
 }

--- a/modules/Migration/schema/740_to_741.php
+++ b/modules/Migration/schema/740_to_741.php
@@ -21,4 +21,7 @@ if (defined('VTIGER_UPGRADE')) {
 
     //個人カレンダーの設定テーブル変更
     include_once 'setup/scripts/77_Update_CalendarUserActivityTypes.php';
+
+    //F-RevoCRM REST APIにて、SyncAPIの引数を追加
+    include_once 'setup/scripts/78_Update_SyncAPI.php';
 }

--- a/modules/Migration/schema/740_to_741.php
+++ b/modules/Migration/schema/740_to_741.php
@@ -22,6 +22,6 @@ if (defined('VTIGER_UPGRADE')) {
     //個人カレンダーの設定テーブル変更
     include_once 'setup/scripts/77_Update_CalendarUserActivityTypes.php';
 
-    //F-RevoCRM REST APIにて、SyncAPIの引数を追加
+    //F-RevoCRM REST APIにて、足りていない引数を追加
     include_once 'setup/scripts/78_Update_RESTAPI.php';
 }

--- a/setup/scripts/78_Update_RESTAPI.php
+++ b/setup/scripts/78_Update_RESTAPI.php
@@ -17,6 +17,9 @@ require_once('modules/Vtiger/models/Module.php');
 
 global $adb, $log;
 
+/**
+ * sync.syncType
+ */
 $result = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE name = 'sync'");
 $count = $adb->num_rows($result);
 if ($count > 0) {
@@ -31,3 +34,24 @@ if ($count > 0) {
 } else {
   echo "実行が完了しました。<br>".PHP_EOL;  
 }
+
+
+
+/**
+ * convertlead.element
+ */
+$result = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE name = 'convertlead'");
+$count = $adb->num_rows($result);
+if ($count > 0) {
+  $operationId = $adb->query_result($result, 0, 'operationid');
+
+  // syncTypeがあるか確認する
+  $result = $adb->query("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'element'", array($operationId));
+  if ($adb->num_rows($result) == 0) {
+    $adb->query("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'element', 'encoded', ?)", array($operationId, ($count + 1)));
+  }
+  echo "実行が完了しました。<br>".PHP_EOL;  
+} else {
+  echo "実行が完了しました。<br>".PHP_EOL;  
+}
+

--- a/setup/scripts/78_Update_RESTAPI.php
+++ b/setup/scripts/78_Update_RESTAPI.php
@@ -20,19 +20,19 @@ global $adb, $log;
 /**
  * sync.syncType
  */
-$result = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE name = 'sync'");
-$count = $adb->num_rows($result);
+$syncTypeResult = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE wso.name = 'sync'");
+$count = $adb->num_rows($syncTypeResult);
 if ($count > 0) {
-  $operationId = $adb->query_result($result, 0, 'operationid');
+  $operationId = $adb->query_result($syncTypeResult, 0, 'operationid');
 
   // syncTypeがあるか確認する
-  $result = $adb->query("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'syncType'", array($operationId));
-  if ($adb->num_rows($result) == 0) {
-    $adb->query("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'syncType', 'string', ?)", array($operationId, ($count + 1)));
+  $syncTypeCheckresult = $adb->pquery("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'syncType';", array($operationId));
+  if ($adb->num_rows($syncTypeCheckresult) == 0) {
+    $adb->pquery("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'syncType', 'string', ?)", array($operationId, ($count + 1)));
   }
   echo "実行が完了しました。<br>".PHP_EOL;  
 } else {
-  echo "実行が完了しました。<br>".PHP_EOL;  
+  echo "実行しませんでした。<br>".PHP_EOL;  
 }
 
 
@@ -40,18 +40,17 @@ if ($count > 0) {
 /**
  * convertlead.element
  */
-$result = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE name = 'convertlead'");
-$count = $adb->num_rows($result);
+$convertleadElementResult = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE wso.name = 'convertlead'");
+$count = $adb->num_rows($convertleadElementResult);
 if ($count > 0) {
-  $operationId = $adb->query_result($result, 0, 'operationid');
+  $operationId = $adb->query_result($convertleadElementResult, 0, 'operationid');
 
   // syncTypeがあるか確認する
-  $result = $adb->query("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'element'", array($operationId));
-  if ($adb->num_rows($result) == 0) {
-    $adb->query("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'element', 'encoded', ?)", array($operationId, ($count + 1)));
+  $checkSyncTyperesult = $adb->pquery("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'element';", array($operationId));
+  if ($adb->num_rows($checkSyncTyperesult) == 0) {
+    $adb->pquery("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'element', 'encoded', ?)", array($operationId, ($count + 1)));
   }
   echo "実行が完了しました。<br>".PHP_EOL;  
 } else {
-  echo "実行が完了しました。<br>".PHP_EOL;  
+  echo "実行しませんでした。<br>".PHP_EOL;  
 }
-

--- a/setup/scripts/78_Update_SyncAPI.php
+++ b/setup/scripts/78_Update_SyncAPI.php
@@ -1,0 +1,33 @@
+<?php
+$Vtiger_Utils_Log = true;
+include_once('vtlib/Vtiger/Menu.php');
+include_once('vtlib/Vtiger/Module.php');
+include_once('modules/PickList/DependentPickListUtils.php');
+include_once('modules/ModTracker/ModTracker.php');
+include_once('include/utils/CommonUtils.php');
+include_once('includes/Loader.php');
+
+require_once('setup/utils/FRFieldSetting.php');
+require_once('setup/utils/FRFilterSetting.php');
+require_once('includes/runtime/BaseModel.php');
+require_once('modules/Settings/Vtiger/models/Module.php');
+require_once('modules/Settings/MenuEditor/models/Module.php');
+require_once('modules/Vtiger/models/MenuStructure.php');
+require_once('modules/Vtiger/models/Module.php');
+
+global $adb, $log;
+
+$result = $adb->query("SELECT wso.operationid FROM vtiger_ws_operation wso LEFT JOIN vtiger_ws_operation_parameters wsop ON wso.operationid = wsop.operationid WHERE name = 'sync'");
+$count = $adb->num_rows($result);
+if ($count > 0) {
+  $operationId = $adb->query_result($result, 0, 'operationid');
+
+  // syncTypeがあるか確認する
+  $result = $adb->query("SELECT * FROM vtiger_ws_operation_parameters WHERE operationid = ? AND name = 'syncType'", array($operationId));
+  if ($adb->num_rows($result) == 0) {
+    $adb->query("INSERT INTO vtiger_ws_operation_parameters (operationid, name, type, sequence) VALUES (?, 'syncType', 'string', ?)", array($operationId, ($count + 1)));
+  }
+  echo "実行が完了しました。<br>".PHP_EOL;  
+} else {
+  echo "実行が完了しました。<br>".PHP_EOL;  
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1093 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PHP8以上の環境で、REST APIが適切に動作しない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `call_user_func_array` の仕様変更による、関数と引数の設定がおかしいため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. REST APIで使われる関数とAPIで投げるパラメーター（＝引数名）を一致させるように修正
2. 足りていないパラメーターがあったため、 `vtiger_ws_operation_parameters` を更新するMigrationを追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- REST APIのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
Migrationが必要なため、`7.4.1` としています。
また、本PRを早めに適用したい場合は、手動で以下のコマンドを実行してください。
`php setup/scripts/78_Update_RESTAPI.php`
※Migrationで複数回目の実行も問題ありません