### PR TITLE
thinkingreed-inc#1101 編集ページに編集不可項目を表示する機能を実装

### DIFF
--- a/languages/ja_jp/Settings/LayoutEditor.php
+++ b/languages/ja_jp/Settings/LayoutEditor.php
@@ -163,6 +163,8 @@ $languageStrings = array(
 	'LBL_PREFER_INTERNAL_RECORD' => 'F-RevoCRMのレコードを優先',
 	'LBL_PREFER_EXTERNAL_RECORD' => '外部アプリケーションのレコードを優先',
 	'LBL_SYNC_TOOLTIP_MESSAGE' => '最新のレコードを優先 - 最近変更されたレコードが保持されます<br>F-RevoCRMのレコードを優先 - 既存のレコードがそのまま保持されます<br>外部アプリケーションのレコードを優先 - 外部アプリケーションからのデータがコピーされます',
+	'LBL_EDIT_READONLY_DISPLAY' => '編集画面に読み取り専用項目の表示',
+	'LBL_EDIT_READONLY_DISPLAY_DETAIL_VIEW' => '編集画面において、読み取り専用項目を表示します',
 );
 
 $jsLanguageStrings = array(

--- a/layouts/v7/modules/Settings/LayoutEditor/Index.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/Index.tpl
@@ -28,6 +28,13 @@
 					{/foreach}
 				</select>
 			</div>
+			<div class="col-sm-4" name="editReadonlyDisplayDiv">
+				<span class="pull-right">
+					<i class="fa fa-info-circle" title="{vtranslate('LBL_EDIT_READONLY_DISPLAY_DETAIL_VIEW', $QUALIFIED_MODULE)}"></i>&nbsp; {vtranslate('LBL_EDIT_READONLY_DISPLAY', $QUALIFIED_MODULE)}&nbsp;
+					<input style="opacity: 0;" type="checkbox" {if $SELECTED_MODULE_MODEL->isEditreadonlydisplay()} checked value='1' {else} value='0' {/if} class="cursorPointer bootstrap-switch" name="editReadonlyDisplay" 
+					data-on-text="Yes" data-off-text="No" data-on-color="primary"/>
+				</span>
+			</div>
 		</div>
 		<br>
 		<br>

--- a/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1753,6 +1753,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 			thisInstance.showRelatedTabModulesList(relatedContainer);
 			var mode = jQuery(e.currentTarget).find('a').data('mode');
 			jQuery('.selectedMode').val(mode);
+			jQuery("div[name='editReadonlyDisplayDiv']").hide();
 		});
 	},
 	/**
@@ -2077,6 +2078,40 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		}
 	},
 
+	// 編集時に編集不可項目の表示ボタン
+	registerEventForEditReadonlyDisplay: function () {
+		jQuery("input[name='editReadonlyDisplay']").on('switchChange.bootstrapSwitch', function (e) {
+			var currentElement = jQuery(e.currentTarget);
+			if (currentElement.val() == 1) {
+				currentElement.attr('value', 0);
+			} else {
+				currentElement.attr('value', 1);
+			}
+
+			var moduleName = app.getModuleName();
+			if (moduleName != 'LayoutEditor') {
+				moduleName = 'LayoutEditor';
+			}
+
+			var params = {
+				module: moduleName,
+				parent: app.getParentModuleName(),
+				sourceModule: jQuery('#selectedModuleName').val(),
+				action: 'Module',
+				mode: 'updateEditReadonlyDisplay',
+				edit_readonly_display: currentElement.val()
+			}
+
+			app.request.post({data: params}).then(function (error, data) {
+				if (data) {
+					app.helper.showSuccessNotification({
+						message: app.vtranslate('JS_STATUS_CHANGED_SUCCESSFULLY')
+					});
+				}
+			});
+		});
+	},
+
 	fieldListTabClicked: false,
 	triggerFieldListTabClickEvent: function () {
 		var thisInstance = this;
@@ -2084,6 +2119,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		contents.find('.detailViewTab').click(function (e) {
 			var detailViewLayout = contents.find('#detailViewLayout');
 			thisInstance.showFieldsListUI(detailViewLayout, e).then(function (data) {
+				jQuery("div[name='editReadonlyDisplayDiv']").show();
 				if (!thisInstance.fieldListTabClicked) {
 					thisInstance.registerBlockEvents();
 					thisInstance.registerFieldEvents();
@@ -2096,6 +2132,10 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					jQuery("input[name='collapseBlock']").bootstrapSwitch();
 					jQuery("input[name='collapseBlock']").bootstrapSwitch('handleWidth', '40px');
 					jQuery("input[name='collapseBlock']").bootstrapSwitch('labelWidth', '25px');
+					jQuery("input[name='editReadonlyDisplay']").bootstrapSwitch();
+					jQuery("input[name='editReadonlyDisplay']").bootstrapSwitch('handleWidth', '27px');
+					jQuery("input[name='editReadonlyDisplay']").bootstrapSwitch('labelWidth', '25px');
+					thisInstance.registerEventForEditReadonlyDisplay();
 					thisInstance.registerSwitchActionOnFieldProperties();
 					thisInstance.registerAddCustomField();
 					app.helper.showVerticalScroll(jQuery('.addFieldTypes'), {'setHeight': '350px'});
@@ -2136,6 +2176,7 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 		var contents = jQuery('#layoutEditorContainer').find('.contents');
 
 		contents.find('.duplicationTab').click(function (e) {
+			jQuery("div[name='editReadonlyDisplayDiv']").hide();
 			var duplicationContainer = contents.find('#duplicationContainer');
 			thisInstance.showDuplicationHandlingUI(duplicationContainer, e).then(function (data) {
 				var form = jQuery('.duplicateHandlingForm');

--- a/layouts/v7/modules/Vtiger/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/partials/EditViewContents.tpl
@@ -30,10 +30,10 @@
 							{assign var=COUNTER value=0}
 							{foreach key=FIELD_NAME item=FIELD_MODEL from=$BLOCK_FIELDS name=blockfields}
 								{assign var="isReferenceField" value=$FIELD_MODEL->getFieldDataType()}
-                                                                {assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
+                                {assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
 								{assign var="refrenceList" value=$FIELD_MODEL->getReferenceList()}
 								{assign var="refrenceListCount" value=php7_count($refrenceList)}
-								{if $FIELD_MODEL->isEditable() eq true}
+								{if $FIELD_MODEL->isEditable() eq true || $FIELD_MODEL->isReadonlyEditView() eq true}
 									{if $FIELD_MODEL->get('uitype') eq "19" || ($FIELD_MODEL->isCkEditor())}
 										{if $COUNTER eq '1'}
 											<td></td><td></td></tr><tr>

--- a/layouts/v7/modules/Vtiger/uitypes/Boolean.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Boolean.tpl
@@ -17,11 +17,13 @@
     {assign var="FIELD_NAME" value=$FIELD_MODEL->getFieldName()}
 {/if}
 <input type="hidden" name="{$FIELD_NAME}" value=0 />
-<input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement" style="width:15px;height:15px;" data-fieldname="{$FIELD_NAME}" data-fieldtype="checkbox" type="checkbox" name="{$FIELD_NAME}"
-{if $FIELD_MODEL->get('fieldvalue') eq true} checked {/if} {if !empty($SPECIAL_VALIDATOR)}data-validator="{Zend_Json::encode($SPECIAL_VALIDATOR)}"{/if}
+<input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement" style="width:15px;height:15px;{if $FIELD_MODEL->isReadonlyEditView() eq true} background-color:#d3d3d3;opacity:0.8;{/if}" data-fieldname="{$FIELD_NAME}" data-fieldtype="checkbox" type="checkbox" name="{$FIELD_NAME}"
+{if $FIELD_MODEL->get('fieldvalue') eq true &&
+    $FIELD_MODEL->get('fieldvalue') neq 'no' && $FIELD_MODEL->get('fieldvalue') neq vtranslate('LBL_NO', $FIELD_MODEL->getModuleName())} checked {/if} {if !empty($SPECIAL_VALIDATOR)}data-validator="{Zend_Json::encode($SPECIAL_VALIDATOR)}"{/if}
 {if $FIELD_INFO["mandatory"] eq true} data-rule-required = "true" {/if}
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}
+{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled {/if}
 />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/Currency.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Currency.tpl
@@ -24,6 +24,7 @@
     {if php7_count($FIELD_INFO['validator'])}
         data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
     {/if}
+    {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
     />
 </div>
 {else if ($FIELD_MODEL->get('uitype') eq '72') && ($FIELD_NAME eq 'unit_price')}
@@ -36,6 +37,7 @@
             {if php7_count($FIELD_INFO['validator'])}
                 data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
             {/if}
+        {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
         />
           <input type="hidden" name="base_currency" value="{$BASE_CURRENCY_NAME}">
           <input type="hidden" name="cur_{$BASE_CURRENCY_ID}_check" value="on">
@@ -56,6 +58,7 @@
         {if php7_count($FIELD_INFO['validator'])}
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}
+    {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
           />
 </div>
 {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Date.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Date.tpl
@@ -25,6 +25,7 @@
     {if php7_count($FIELD_INFO['validator'])}
         data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
     {/if}
+    {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
     data-rule-date="true"
     autocomplete="off" />
 <span class="input-group-addon"><i class="fa fa-calendar "></i></span>

--- a/layouts/v7/modules/Vtiger/uitypes/DateTime.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/DateTime.tpl
@@ -18,5 +18,6 @@
     {if php7_count($FIELD_INFO['validator'])} 
         data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
     {/if}
+    {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
     />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/DocumentsFileUpload.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/DocumentsFileUpload.tpl
@@ -30,6 +30,7 @@
             {if php7_count($FIELD_INFO['validator'])} 
                 data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
             {/if}
+            {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
             />
 	{else}
         <div class="fileUploadBtn btn btn-primary">
@@ -40,6 +41,7 @@
                 {if php7_count($FIELD_INFO['validator'])} 
                     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
                 {/if}
+                {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
                 />
         </div>
 	{/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Email.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Email.tpl
@@ -21,5 +21,6 @@
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}
+{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
  />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/File.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/File.tpl
@@ -20,6 +20,7 @@
 					{if php7_count($FIELD_INFO['validator'])} 
 						data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 					{/if}
+					{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 					/>
 		</div>&nbsp;&nbsp;
 		<span class="uploadFileSizeLimit fa fa-info-circle" data-toggle="tooltip" data-placement="top" title="{vtranslate('LBL_MAX_UPLOAD_SIZE',$MODULE)} {$MAX_UPLOAD_LIMIT_MB} {vtranslate('MB',$MODULE)}">

--- a/layouts/v7/modules/Vtiger/uitypes/Image.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Image.tpl
@@ -29,7 +29,9 @@
 					{if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
 					{if php7_count($FIELD_INFO['validator'])} 
 						data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
-					{/if} />
+					{/if}
+					{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
+					/>
 			</div>
 
 			<div class="uploadedFileDetails {if $IS_EXTERNAL_LOCATION_TYPE}hide{/if}">

--- a/layouts/v7/modules/Vtiger/uitypes/MultiOwner.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/MultiOwner.tpl
@@ -26,6 +26,7 @@
             {if php7_count($FIELD_INFO['validator'])} 
                 data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
             {/if}
+			{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
             >
 		<optgroup label="{vtranslate('LBL_USERS')}">
 			{foreach key=OWNER_ID item=OWNER_NAME from=$ALL_ACTIVEUSER_LIST}

--- a/layouts/v7/modules/Vtiger/uitypes/MultiPicklist.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/MultiPicklist.tpl
@@ -26,6 +26,7 @@
 			{if php7_count($FIELD_INFO['validator'])} 
 				data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 			{/if}
+			{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 			>
 		{foreach item=PICKLIST_VALUE key=PICKLIST_NAME from=$PICKLIST_VALUES}
 			{assign var=CLASS_NAME value="picklistColor_{$FIELD_MODEL->getFieldName()}_{$PICKLIST_NAME|replace:' ':'_'}"}

--- a/layouts/v7/modules/Vtiger/uitypes/Number.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Number.tpl
@@ -28,5 +28,6 @@ value="{$FIELD_VALUE}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}
+{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/Owner.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Owner.tpl
@@ -30,6 +30,7 @@
             {if php7_count($FIELD_INFO['validator'])} 
                 data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
             {/if}
+			{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
             >
 		{if $FIELD_MODEL->isCustomField() || $VIEW_SOURCE eq 'MASSEDIT'} <option value="">{vtranslate('LBL_SELECT_OPTION','Vtiger')}</option> {/if}
 

--- a/layouts/v7/modules/Vtiger/uitypes/OwnerGroup.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/OwnerGroup.tpl
@@ -22,7 +22,9 @@
 		{if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
 		{if php7_count($FIELD_INFO['validator'])} 
 			data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
-		{/if}>
+		{/if}
+		{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
+		>
 		<option value="">{vtranslate('LBL_SELECT_OPTION','Vtiger')}</option>
 		{foreach key=OWNER_ID item=OWNER_NAME from=$ALL_ACTIVEGROUP_LIST}
 			<option value="{$OWNER_ID}" data-picklistvalue='{$OWNER_NAME}' {if $VIEW_SOURCE neq 'MASSEDIT' && $FIELD_MODEL->get('fieldvalue') eq $OWNER_ID} selected {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Password.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Password.tpl
@@ -21,5 +21,6 @@
         {if php7_count($FIELD_INFO['validator'])} 
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}
+        {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
         />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/Percentage.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Percentage.tpl
@@ -21,6 +21,7 @@
 			{if php7_count($FIELD_INFO['validator'])}
 				data-specific-rules="{ZEND_JSON::encode($FIELD_INFO["validator"])}"
 			{/if}
+			{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 			/>
 		<span class="input-group-addon">%</span>
 	</div>

--- a/layouts/v7/modules/Vtiger/uitypes/Phone.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Phone.tpl
@@ -21,5 +21,6 @@ value="{$FIELD_MODEL->get('fieldvalue')}" {if !empty($SPECIAL_VALIDATOR)}data-va
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}
+{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
  />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/Picklist.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Picklist.tpl
@@ -21,6 +21,7 @@
 	{if php7_count($FIELD_INFO['validator'])}
 		data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 	{/if}
+	{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 	>
 	{if $FIELD_MODEL->isEmptyPicklistOptionAllowed()}<option value="">{vtranslate('LBL_SELECT_OPTION','Vtiger')}</option>{/if}
 	{foreach item=PICKLIST_VALUE key=PICKLIST_NAME from=$PICKLIST_VALUES}

--- a/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Reference.tpl
@@ -20,7 +20,7 @@
 {assign var="QUICKCREATE_RESTRICTED_MODULES" value=Vtiger_Functions::getNonQuickCreateSupportedModules()}
 <div class="referencefield-wrapper {if $FIELD_VALUE neq 0} selected {/if}">
     {if {$REFERENCE_LIST_COUNT} eq 1}
-        <input name="popupReferenceModule" type="hidden" value="{$REFERENCE_LIST[0]}"/>
+        <input name="popupReferenceModule" type="hidden" value="{$REFERENCE_LIST[0]}" {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}/>
     {/if}
     {if {$REFERENCE_LIST_COUNT} gt 1}
         {assign var="DISPLAYID" value=$FIELD_MODEL->get('fieldvalue')}
@@ -29,9 +29,9 @@
             {assign var="REFERENCED_MODULE_NAME" value=$REFERENCED_MODULE_STRUCT->get('name')}
         {/if}
         {if in_array($REFERENCED_MODULE_NAME, $REFERENCE_LIST)}
-            <input name="popupReferenceModule" type="hidden" value="{$REFERENCED_MODULE_NAME}" />
+            <input name="popupReferenceModule" type="hidden" value="{$REFERENCED_MODULE_NAME}" {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}/>
         {else}
-            <input name="popupReferenceModule" type="hidden" value="{$REFERENCE_LIST[0]}" />
+            <input name="popupReferenceModule" type="hidden" value="{$REFERENCE_LIST[0]}" {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}/>
         {/if}
     {/if}
     {assign var="displayId" value=$FIELD_VALUE}
@@ -48,13 +48,14 @@
             {if php7_count($FIELD_INFO['validator'])} 
                 data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
             {/if}
+            {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
             />
-        <a href="#" class="clearReferenceSelection {if empty($FIELD_VALUE)}hide{/if}"> x </a>
+        <a href="#" class="clearReferenceSelection {if empty($FIELD_VALUE)}hide{/if}" {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled  style="display:none;" {/if}> x </a>
             <span class="input-group-addon relatedPopup cursorPointer" title="{vtranslate('LBL_SELECT', $MODULE)}">
                 <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_select" class="fa fa-search"></i>
             </span>
         {if (($REQ.view eq 'Edit') or ($MODULE_NAME eq 'Webforms')) && !in_array($REFERENCE_LIST[0],$QUICKCREATE_RESTRICTED_MODULES)}
-            <span class="input-group-addon createReferenceRecord cursorPointer clearfix" title="{vtranslate('LBL_CREATE', $MODULE)}">
+            <span class="input-group-addon createReferenceRecord cursorPointer clearfix" title="{vtranslate('LBL_CREATE', $MODULE)}" {if $FIELD_MODEL->isReadonlyEditView() eq true}  style="display:none;"  {/if}>
             <i id="{$MODULE}_editView_fieldName_{$FIELD_NAME}_create" class="fa fa-plus"></i>
         </span>
         {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/String.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/String.tpl
@@ -29,5 +29,6 @@
 		{if !empty($FIELD_INFO['validator']) && (php7_count($FIELD_INFO['validator']))}
 			data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 		{/if}
+		{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 		   />
 {/strip}

--- a/layouts/v7/modules/Vtiger/uitypes/Text.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Text.tpl
@@ -16,20 +16,22 @@
   {assign var="FIELD_NAME" value=$FIELD_MODEL->getFieldName()}
 {/if}
 {if $FIELD_MODEL->get('uitype') eq '19' || $FIELD_MODEL->get('uitype') eq '20'}
-    <textarea style="height:250px; max-width: initial; width:100%;" rows="3" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement textAreaElement col-lg-12 {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if $FIELD_NAME eq "notecontent"}id="{$FIELD_NAME}"{/if} {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
+    <textarea style="height:250px; max-width: initial; width:100%;{if $FIELD_MODEL->isReadonlyEditView() eq true}background-color:#d3d3d3;opacity:0.8;{/if}" rows="3" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement textAreaElement col-lg-12 {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if $FIELD_NAME eq "notecontent"}id="{$FIELD_NAME}"{/if} {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
         {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
         {if php7_count($FIELD_INFO['validator'])}
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}
+        {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled {/if}
         >
     {purifyHtmlEventAttributes($FIELD_MODEL->get('fieldvalue'),true)|regex_replace:"/(?!\w)\&nbsp;(?=\w)/":" "}
     </textarea>
 {else}
-    <textarea style="height:250px"rows="5" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
+    <textarea style="height:250px{if $FIELD_MODEL->isReadonlyEditView() eq true}background-color:#d3d3d3;opacity:0.8;{/if}"rows="5" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
         {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
         {if php7_count($FIELD_INFO['validator'])}
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}
+        {if $FIELD_MODEL->isReadonlyEditView() eq true} disabled {/if}
         >
     {purifyHtmlEventAttributes($FIELD_MODEL->get('fieldvalue'),true)|regex_replace:"/(?!\w)\&nbsp;(?=\w)/":" "}
     </textarea>

--- a/layouts/v7/modules/Vtiger/uitypes/Time.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Time.tpl
@@ -23,6 +23,7 @@
 		{if php7_count($FIELD_INFO['validator'])}
 			data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 		{/if}
+		{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
 		 data-rule-time="true"/>
 		<span class="input-group-addon" style="width: 30px;">
 			<i class="fa fa-clock-o"></i>

--- a/layouts/v7/modules/Vtiger/uitypes/Url.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Url.tpl
@@ -21,5 +21,6 @@
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}
+{if $FIELD_MODEL->isReadonlyEditView() eq true} disabled style='background-color:#d3d3d3;opacity:0.8;'{/if}
  />
 {/strip}

--- a/modules/Migration/schema/740_to_741.php
+++ b/modules/Migration/schema/740_to_741.php
@@ -24,4 +24,7 @@ if (defined('VTIGER_UPGRADE')) {
 
     //F-RevoCRM REST APIにて、足りていない引数を追加
     include_once 'setup/scripts/78_Update_RESTAPI.php';
+
+    //vtiger_tabにeditReadonlyDisplayカラムを追加
+    include_once 'setup/scripts/79_Add_EditReadonlyDisplay.php';
 }

--- a/modules/Settings/LayoutEditor/actions/Module.php
+++ b/modules/Settings/LayoutEditor/actions/Module.php
@@ -1,0 +1,35 @@
+<?php
+
+/*+**********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.1
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is:  vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ ************************************************************************************/
+
+class Settings_LayoutEditor_Module_Action extends Settings_Vtiger_Index_Action {
+    
+    public function __construct() {
+        $this->exposeMethod('updateEditReadonlyDisplay');
+    }
+    
+    public function updateEditReadonlyDisplay(Vtiger_Request $request) {
+        $response = new Vtiger_Response();
+        try{
+            $editReadonlyDisplay = $request->get('edit_readonly_display');
+            $sourceModule = $request->get('sourceModule');
+            $moduleModel = Vtiger_Module_Model::getInstance($sourceModule);
+            $moduleModel->updateEditreadonlydisplay($editReadonlyDisplay);
+            $response->setResult(array('success'=>true));
+        }catch(Exception $e) {
+            $response->setError($e->getCode(),$e->getMessage());
+        }
+        $response->emit();
+    }
+    
+    public function validateRequest(Vtiger_Request $request) {
+        $request->validateWriteAccess();
+    }
+}

--- a/modules/Vtiger/models/EditRecordStructure.php
+++ b/modules/Vtiger/models/EditRecordStructure.php
@@ -32,7 +32,7 @@ class Vtiger_EditRecordStructure_Model extends Vtiger_RecordStructure_Model {
 			if (!empty ($fieldModelList)) {
 				$values[$blockLabel] = array();
 				foreach($fieldModelList as $fieldName=>$fieldModel) {
-					if($fieldModel->isEditable()) {
+					if($fieldModel->isEditable() || ($moduleModel->isEditReadonlyDisplay() && $fieldModel->isReadonlyEditView())) {
 						if($recordModel->get($fieldName) != '') {
 							$fieldModel->set('fieldvalue', $recordModel->get($fieldName));
 						}else{

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -1682,4 +1682,16 @@ class Vtiger_Field_Model extends Vtiger_Field {
 		$this->fieldInfo['validator'] = $this->getValidator();
 		return $this->fieldInfo;
 	}
+
+	/**
+	 * 編集画面でreadonlyのフィールドか判定する
+	 * @return <Boolean> true/false
+	 */
+	public function isReadonlyEditView()
+	{
+		if (!$this->isEditable() && $this->isViewableInDetailView()) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -2067,4 +2067,20 @@ class Vtiger_Module_Model extends Vtiger_Module {
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
 		return $moduleModel->getModuleIcon();
 	}
+
+	public function isEditReadonlyDisplay() {
+		return $this->editReadonlyDisplay;
+	}
+
+	public function updateEditreadonlydisplay($editReadonlyDisplay) {
+		global $adb;
+
+		if ($editReadonlyDisplay == 1) {
+			$editReadonlyDisplay = true;
+		} else {
+			$editReadonlyDisplay = false;
+		}
+
+		$adb->pquery("UPDATE vtiger_tab SET editreadonlydisplay = ? WHERE tabid = ?", array($editReadonlyDisplay, $this->getId()));
+	}
 }

--- a/setup/Setup.php
+++ b/setup/Setup.php
@@ -88,6 +88,9 @@ $db->query('update vtiger_relatedlists set relationfieldid = "598" where relatio
 // PDFテンプレートのアップデート
 require_once ("scripts/64_Update_PDFTemplate.php");
 
+// vtiger_tabにeditReadonlyDisplayカラムを追加
+require_once ("scripts/78_Add_EditReadonlyDisplay.php");
+
 // メニュー設定
 // FRMenuSetting::apply(array(
 //     'Accounts',

--- a/vtlib/Vtiger/ModuleBasic.php
+++ b/vtlib/Vtiger/ModuleBasic.php
@@ -52,6 +52,7 @@ class Vtiger_ModuleBasic {
 	var $allowDuplicates = false;
 	var $isSyncable = 0;
 	var $syncActionForDuplicate = 1;
+	var $editReadonlyDisplay = false;
 
 
 	const EVENT_MODULE_ENABLED     = 'module.enabled';
@@ -95,6 +96,7 @@ class Vtiger_ModuleBasic {
 		if (isset($valuemap['issyncable'])) $this->isSyncable = $valuemap['issyncable'];
 		if (isset($valuemap['allowduplicates'])) $this->allowDuplicates = $valuemap['allowduplicates'];
 		if (isset($valuemap['sync_action_for_duplicates'])) $this->syncActionForDuplicate = $valuemap['sync_action_for_duplicates'];
+		$this->editReadonlyDisplay = $valuemap['editreadonlydisplay'];
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1101

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. モジュールの項目設定ページに編集不可項目の表示切替スイッチを追加
2. 有効化したモジュールの編集ページで編集不可項目を表示

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
項目設定
<img width="947" alt="編集ページ" src="https://github.com/user-attachments/assets/ed985454-c0fe-45d8-8f37-f6897508dc30">

編集ページ 編集不可項目 ｰ 非表示
![image](https://github.com/user-attachments/assets/cd0f0bf2-596b-4c48-80d8-4159a0cb18a5)


編集ページ 編集不可項目 ｰ 表示
![image](https://github.com/user-attachments/assets/e282c7da-2ad1-40e4-9c54-9f74424ef77b)


## 影響範囲  / Affected Area
- 各UItypeテンプレート
- vtiger_tabのCRUD

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った