### PR TITLE
関連するレコードを登録する際にリストに表示されている全件を登録する機能を追加

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -2172,4 +2172,6 @@ $jsLanguageStrings = array(
 	
 	//ユーザー管理>グループ作成
 	'JS_DUPLICATES_EXIST' => '既に存在しています',
+	
+	'JS_LBL_CONFIRMALL' => '全件追加しますか？',
 );

--- a/layouts/v7/modules/Vtiger/PopupNavigation.tpl
+++ b/layouts/v7/modules/Vtiger/PopupNavigation.tpl
@@ -10,14 +10,20 @@
 -->*}
 
 {strip}
-    <div class="col-md-2">
+    <div class="col-md-4">
         {if $MULTI_SELECT}
-            {if !empty($LISTVIEW_ENTRIES)}<button class="select btn btn-default" disabled="disabled"><strong>{vtranslate('LBL_ADD', $MODULE)}</strong></button>{/if}
+            {if !empty($LISTVIEW_ENTRIES)}
+            <div class="btn-group">
+                <button class="select btn btn-default" disabled="disabled"><strong>{vtranslate('LBL_ADD', $MODULE)}</strong></button>
+                <button class="selectAll btn btn-default"><strong>{vtranslate('LBL_ALL', $MODULE)}{vtranslate('LBL_ADD', $MODULE)}</strong></button>
+            </div>
+            {/if}
+            
         {else}
             &nbsp;
         {/if}
     </div>
-    <div class="col-md-10">
+    <div class="col-md-8">
         {assign var=RECORD_COUNT value=$LISTVIEW_ENTRIES_COUNT}
         {include file="Pagination.tpl"|vtemplate_path:$MODULE SHOWPAGEJUMP=true}
     </div>

--- a/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -3215,6 +3215,16 @@ Vtiger.Class("Vtiger_Detail_Js",{
 				});
 			}
 		});
+		
+		app.event.on("post.AddAllRecords.click", function() {
+			var relatedController = self.getRelatedController();
+			if (relatedController) {
+				relatedController.addRelationsForAllRecords().then(function() {
+					relatedController.loadRelatedList();
+				});
+			}
+		});
+		
 		this.registerBlockAnimationEvent();
 		this.registerBlockStatusCheckOnLoad();
 		this.registerClearReferenceSelectionEvent();

--- a/layouts/v7/modules/Vtiger/resources/Popup.js
+++ b/layouts/v7/modules/Vtiger/resources/Popup.js
@@ -820,6 +820,16 @@ jQuery.Class("Vtiger_Popup_Js",{
 		});
 	},
 
+	registerSelectAllButton : function(){
+		var popupPageContentsContainer = this.getPopupPageContainer();
+		popupPageContentsContainer.on('click','button.selectAll', function(e){
+			app.helper.showConfirmationBox({'message' : app.vtranslate('JS_LBL_CONFIRMALL')}).then(function(e) {
+				app.event.trigger("post.AddAllRecords.click");
+				app.helper.hidePopup();
+			});
+		});
+	},
+
 	selectAllHandler : function(e){
 		var thisInstance = this;
 		var currentElement = jQuery(e.currentTarget);
@@ -977,6 +987,7 @@ jQuery.Class("Vtiger_Popup_Js",{
 		//for record selection
 		this.registerEventForSelectAllInCurrentPage();
 		this.registerSelectButton();
+		this.registerSelectAllButton();
 		this.registerEventForCheckboxChange();
 	}
 });

--- a/layouts/v7/modules/Vtiger/resources/RelatedList.js
+++ b/layouts/v7/modules/Vtiger/resources/RelatedList.js
@@ -359,6 +359,39 @@ jQuery.Class("Vtiger_RelatedList_Js",{
 		return aDeferred.promise();
 	},
     
+	addRelationsForAllRecords : function () {
+		var aDeferred = jQuery.Deferred();
+		var sourceRecordId = this.parentRecordId;
+		var sourceModuleName = this.parentModuleName;
+		var relatedModuleName = this.relatedModulename;
+		var relationId = $('#relationId').val();
+		var popupInstance = Vtiger_Popup_Js.getInstance();
+		var searchParams = popupInstance.getPopupListSearchParams();
+		
+		var params = {};
+		params['mode'] = "addRelationsForAllRecords";
+		params['module'] = sourceModuleName;
+		params['action'] = 'RelationAjax';
+		params['relationId'] = relationId;
+		params['related_module'] = relatedModuleName;
+		params['src_record'] = sourceRecordId;
+		params['search_params'] = searchParams;
+		
+        app.helper.showProgress();
+        
+		app.request.post({"data":params}).then(
+			function(responseData){
+                app.helper.hideProgress();
+				aDeferred.resolve(responseData);
+			},
+
+			function(textStatus, errorThrown){
+                app.helper.hideProgress();
+				aDeferred.reject(textStatus, errorThrown);
+			}
+		);
+		return aDeferred.promise();
+	},
     
     
     triggerRelationAdditionalActions : function() {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1102 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連するレコードを追加する際に、ポップアップの検索リストに表示されている全レコードを一括で、関連するレコードとして登録したい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  関連するレコードを追加する画面に「全て追加」ボタンを設置
2.  「全て追加」ボタンでレコードを追加する機能を追加
3.   検索で絞り込んだレコードのみを全件追加する機能

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/9e3ad867-22a4-479f-a005-c417cf4952d1)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
関連するレコードの追加処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->