### PR TITLE
#1108 リードのウィジェットの不具合を修正

### DIFF
--- a/modules/Leads/models/Module.php
+++ b/modules/Leads/models/Module.php
@@ -149,11 +149,12 @@ class Leads_Module_Model extends Vtiger_Module_Model {
         }
 
 		$result = $db->pquery('SELECT COUNT(*) as count, CASE WHEN vtiger_leadstatus.leadstatus IS NULL OR vtiger_leadstatus.leadstatus = "" THEN "" ELSE 
-						vtiger_leadstatus.leadstatus END AS leadstatusvalue FROM vtiger_leaddetails 
-						INNER JOIN vtiger_crmentity ON vtiger_leaddetails.leadid = vtiger_crmentity.crmid
-						AND deleted=0 AND converted = 0 '.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.
+						vtiger_leadstatus.leadstatus END AS leadstatusvalue FROM vtiger_leaddetails'
+						.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.
 						'INNER JOIN vtiger_leadstatus ON vtiger_leaddetails.leadstatus = vtiger_leadstatus.leadstatus 
-                        WHERE vtiger_leaddetails.leadstatus IN ('.generateQuestionMarks($picklistvaluesmap).') 
+                        WHERE vtiger_leaddetails.leadstatus IN ('.generateQuestionMarks($picklistvaluesmap).')
+						AND vtiger_leaddetails.deleted = 0 
+						AND vtiger_leaddetails.converted = 0 
 						GROUP BY leadstatusvalue ORDER BY vtiger_leadstatus.sortorderid', $params);
 
 		$response = array();
@@ -198,10 +199,12 @@ class Leads_Module_Model extends Vtiger_Module_Model {
         
 		$result = $db->pquery('SELECT COUNT(*) as count, CASE WHEN vtiger_leaddetails.leadsource IS NULL OR vtiger_leaddetails.leadsource = "" THEN "" 
 						ELSE vtiger_leaddetails.leadsource END AS leadsourcevalue FROM vtiger_leaddetails 
-						INNER JOIN vtiger_crmentity ON vtiger_leaddetails.leadid = vtiger_crmentity.crmid
-						AND deleted=0 AND converted = 0 '.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.
+						INNER JOIN vtiger_crmentity ON vtiger_leaddetails.leadid = vtiger_crmentity.crmid'
+						.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.
 						'INNER JOIN vtiger_leadsource ON vtiger_leaddetails.leadsource = vtiger_leadsource.leadsource 
                         WHERE vtiger_leaddetails.leadsource IN ('.generateQuestionMarks($picklistvaluesmap).') 
+						AND vtiger_leaddetails.deleted = 0 
+						AND vtiger_leaddetails.converted = 0 
 						GROUP BY leadsourcevalue ORDER BY vtiger_leadsource.sortorderid', $params);
 		
 		$response = array();
@@ -245,10 +248,12 @@ class Leads_Module_Model extends Vtiger_Module_Model {
 		
 		$result = $db->pquery('SELECT COUNT(*) as count, CASE WHEN vtiger_leaddetails.industry IS NULL OR vtiger_leaddetails.industry = "" THEN "" 
 						ELSE vtiger_leaddetails.industry END AS industryvalue FROM vtiger_leaddetails 
-						INNER JOIN vtiger_crmentity ON vtiger_leaddetails.leadid = vtiger_crmentity.crmid
-						AND deleted=0 AND converted = 0 '.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.'
+						INNER JOIN vtiger_crmentity ON vtiger_leaddetails.leadid = vtiger_crmentity.crmid'
+						.Users_Privileges_Model::getNonAdminAccessControlQuery($this->getName()). $ownerSql .' '.$dateFilterSql.'
 						INNER JOIN vtiger_industry ON vtiger_leaddetails.industry = vtiger_industry.industry 
                         WHERE vtiger_leaddetails.industry IN ('.generateQuestionMarks($picklistvaluesmap).') 
+						AND vtiger_leaddetails.deleted = 0 
+						AND vtiger_leaddetails.converted = 0 
 						GROUP BY industryvalue ORDER BY vtiger_industry.sortorderid', $params);
 		
 		$response = array();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1108

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
リードのデータが保存された状態で、ダッシュボードの以下のリード関連のウィジェットを表示しても、
該当しているデータが表示されていない。

- リード（業界別）
- リード（ステータス別）
- リード（紹介元別）

##  原因 / Cause
<!-- バグの原因を記述 -->
リードのウィジェットで利用するSQLでWHERE句のカラム指定でテーブル名を記述していないため、
mysql の 1052エラーが発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
テーブル名も含めてカラム名を指定するように変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/50287fc3-c82e-4c97-a6a5-b2ad6f17cc5d)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- リード（業界別）
- リード（ステータス別）
- リード（紹介元別）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った