### PR TITLE
#1117 Enterキーで検索できるように修正

### DIFF
--- a/layouts/v7/modules/ModComments/ListViewContents.tpl
+++ b/layouts/v7/modules/ModComments/ListViewContents.tpl
@@ -91,7 +91,7 @@
                         <tr class="searchRow">
                             <th class="inline-search-btn">
                                 <div class="table-actions">
-                                    <button class="btn btn-success btn-sm" data-trigger="listSearch">{vtranslate("LBL_SEARCH",$MODULE)}</button>
+                                    <button type="button" class="btn btn-success btn-sm" data-trigger="listSearch">{vtranslate("LBL_SEARCH",$MODULE)}</button>
                                 </div>
                             </th>
                             {foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}

--- a/layouts/v7/modules/RecycleBin/ListViewContents.tpl
+++ b/layouts/v7/modules/RecycleBin/ListViewContents.tpl
@@ -68,11 +68,11 @@
                         <tr class="searchRow listViewSearchContainer">
                             <th class="inline-search-btn">
                                 <div class="table-actions">
-                                    <button class="btn btn-sm btn-success {if count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
+                                    <button type="button" class="btn btn-sm btn-success {if count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
                                         <i class="fa fa-search"></i>&nbsp;
                                         <span class="s2-btn-text">{vtranslate("LBL_SEARCH",$MODULE)}</span>
                                     </button>
-                                    <button class="searchAndClearButton btn btn-sm btn-danger {if count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
+                                    <button type="button" class="searchAndClearButton btn btn-sm btn-danger {if count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
                                 </div>
                         </th>
                         {foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}

--- a/layouts/v7/modules/Reports/ListViewContents.tpl
+++ b/layouts/v7/modules/Reports/ListViewContents.tpl
@@ -76,11 +76,11 @@
 							<tr class="searchRow listViewSearchContainer">
                                                             <th class="inline-search-btn">
                                                                 <div class="table-actions">
-                                                                    <button class="btn-sm btn btn-success {if php7_count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
+                                                                    <button type="button" class="btn-sm btn btn-success {if php7_count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
                                                                         <i class="fa fa-search"></i>&nbsp;
                                                                         <span class="s2-btn-text">{vtranslate("LBL_SEARCH",$MODULE)}</span>
                                                                     </button>
-                                                                    <button class="searchAndClearButton btn-sm  btn btn-danger {if php7_count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
+                                                                    <button type="button" class="searchAndClearButton btn-sm  btn btn-danger {if php7_count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
                                                                 </div>
                                                             </th>
 								{foreach item=LISTVIEW_HEADER key=LISTVIEW_HEADER_KEY from=$LISTVIEW_HEADERS}

--- a/layouts/v7/modules/Reports/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/Reports/ListViewRecordActions.tpl
@@ -59,8 +59,8 @@
             {/if}    
         
         <div class="btn-group inline-save hide">
-            <button class="button btn-success btn-small save" name="save"><i class="fa fa-check"></i></button>
-            <button class="button btn-danger btn-small cancel" name="Cancel"><i class="fa fa-close"></i></button>
+            <button type="button" class="button btn-success btn-small save" name="save"><i class="fa fa-check"></i></button>
+            <button type="button" class="button btn-danger btn-small cancel" name="Cancel"><i class="fa fa-close"></i></button>
         </div>
     </div>
 {/strip}

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -117,11 +117,11 @@
                                     <tr class="searchRow listViewSearchContainer">
                                         <th class="inline-search-btn">
                                             <div class="table-actions">
-                                                <button class="btn btn-success btn-sm {if php7_count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
+                                                <button type="button" class="btn btn-success btn-sm {if php7_count($SEARCH_DETAILS) gt 0}hide{/if}" data-trigger="listSearch">
                                                     <i class="fa fa-search"></i> &nbsp;
                                                     <span class="s2-btn-text">{vtranslate("LBL_SEARCH",$MODULE)}</span>
                                                 </button>
-                                                <button class="searchAndClearButton t-btn-sm btn btn-danger {if php7_count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
+                                                <button type="button" class="searchAndClearButton t-btn-sm btn btn-danger {if php7_count($SEARCH_DETAILS) eq 0}hide{/if}" data-trigger="clearListSearch"><i class="fa fa-close"></i>&nbsp;{vtranslate("LBL_CLEAR",$MODULE)}</button>
                                             </div>
                                         </th>
                                     {foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1117

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
一覧画面でヘッダーカラムの検索フィールドにて、Enterキーによる検索を実行した場合に、
入力した内容でフィルタリングされない。

##  原因 / Cause
<!-- バグの原因を記述 -->
#985 で floatThead を利用しなくなったことにより、Enterキーで検索した際に検索ボタンの
クリックイベントが2回起動するようになっていた。
2回の起動でクリックイベントの処理が画面描画に間に合わず、リストが正しくない状態で表示されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
検索ボタンに`type="button"`を追加して、フォームのデフォルトで起動するクリックイベントを無効化した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/7fbe90ae-b52c-4fc6-b5c7-8667c0a43f47)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
各モジュールの一覧検索

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->