### PR TITLE
受注モジュールの周期（繰り返し請求情報）項目の選択肢に「半期」が初期追加されるように修正

### DIFF
--- a/include/ComboStrings.php
+++ b/include/ComboStrings.php
@@ -320,6 +320,7 @@ $combo_strings = Array(
 								'Weekly' => 'Weekly',
 								'Monthly' => 'Monthly',
 								'Quarterly' => 'Quarterly',
+                                                                'Half-Yearly' => 'Half-Yearly',
 								'Yearly' => 'Yearly'
 							),		
 'payment_duration_dom' => Array('Net 30 days'=>'Net 30 days',

--- a/setup/sql/dump_firstinstall.sql
+++ b/setup/sql/dump_firstinstall.sql
@@ -9844,7 +9844,7 @@ CREATE TABLE `vtiger_recurring_frequency` (
 
 LOCK TABLES `vtiger_recurring_frequency` WRITE;
 /*!40000 ALTER TABLE `vtiger_recurring_frequency` DISABLE KEYS */;
-INSERT INTO `vtiger_recurring_frequency` VALUES (2,'Daily',1,1,NULL),(3,'Weekly',2,1,NULL),(4,'Monthly',3,1,NULL),(5,'Quarterly',4,1,NULL),(6,'Yearly',5,1,NULL);
+INSERT INTO `vtiger_recurring_frequency` VALUES (2,'Daily',1,1,NULL),(3,'Weekly',2,1,NULL),(4,'Monthly',3,1,NULL),(5,'Quarterly',4,1,NULL),(6,'Half-Yearly',5,1,NULL),(7,'Yearly',6,1,NULL);
 /*!40000 ALTER TABLE `vtiger_recurring_frequency` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -9866,7 +9866,7 @@ CREATE TABLE `vtiger_recurring_frequency_seq` (
 
 LOCK TABLES `vtiger_recurring_frequency_seq` WRITE;
 /*!40000 ALTER TABLE `vtiger_recurring_frequency_seq` DISABLE KEYS */;
-INSERT INTO `vtiger_recurring_frequency_seq` VALUES (6);
+INSERT INTO `vtiger_recurring_frequency_seq` VALUES (7);
 /*!40000 ALTER TABLE `vtiger_recurring_frequency_seq` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1121

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
受注モジュールの周期（繰り返し請求情報）項目の選択肢に「半期」が表示されない。
内部に半期の実装があるのは確認済み。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インストール時に選択肢の追加が行われていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インストール時の初期値に追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/2553befa-e75d-41f0-a531-d80e6d5beb83)

## 影響範囲  / Affected Area
- インストール時
- 請求の繰り返し生成処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->