### PR TITLE
#1123 ウィジェットの削除ボタンと更新ボタンが重ならないように修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -658,7 +658,8 @@ ul#productsImageContainer > li a{
   align-items: center;
 }
 /* rc-handleと重ならないように調整 */
-.fa-remove {
+.listview-table tr.listViewContentHeader .fa-remove{
   position: relative;
   right: 15px;
-}
+  z-index: 1;
+} 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1123 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
スクリーンショットにて提示するが、ウィジェット右下の更新ボタン・削除ボタンが重なって表示されている。

##  原因 / Cause
<!-- バグの原因を記述 -->
一覧画面において、列幅調整用のhandleと削除ボタン（ソート時に表示）が重なることを避けるために、削除ボタンの位置を調整していたため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
一覧画面のヘッダーに表示される削除ボタンの位置だけを調整するように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![スクリーンショット 2024-10-11 160225](https://github.com/user-attachments/assets/6d212bca-5d43-4407-9d44-42b9f120ddd2)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
listview-tableの削除ボタン

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->