### PR TITLE
モジュールの一覧画面からレコードを複製する機能の追加

### DIFF
--- a/layouts/v7/modules/Vtiger/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewRecordActions.tpl
@@ -39,6 +39,9 @@
 				{if $RECORD_ACTIONS['edit']}
 					<li><a data-id="{$LISTVIEW_ENTRY->getId()}" href="javascript:void(0);" data-url="{$LISTVIEW_ENTRY->getEditViewUrl()}&app={$SELECTED_MENU_CATEGORY}" name="editlink">{vtranslate('LBL_EDIT', $MODULE)}</a></li>
 				{/if}
+                {if $RECORD_ACTIONS['duplicate']}
+					<li><a data-id="{$LISTVIEW_ENTRY->getId()}" href="javascript:void(0);" data-url="{$LISTVIEW_ENTRY->getEditViewUrl()}&isDuplicate=true&app={$SELECTED_MENU_CATEGORY}" name='editlink'>{vtranslate('LBL_DUPLICATE', $MODULE)}</a></li>
+				{/if}
 				{if $RECORD_ACTIONS['delete']}
 					<li><a data-id="{$LISTVIEW_ENTRY->getId()}" href="javascript:void(0);" class="deleteRecordButton">{vtranslate('LBL_DELETE', $MODULE)}</a></li>
 				{/if}

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -561,15 +561,17 @@ class Vtiger_List_View extends Vtiger_Index_View {
 	}
 
 	public function getRecordActionsFromModule($moduleModel) {
-		$editPermission = $deletePermission = 0;
+		$editPermission = $deletePermission = $duplicatePermission = 0;
 		if ($moduleModel) {
 			$editPermission	= $moduleModel->isPermitted('EditView');
 			$deletePermission = $moduleModel->isPermitted('Delete');
+			$duplicatePermission = $moduleModel->isPermitted('Duplicates');
 		}
 
 		$recordActions = array();
 		$recordActions['edit'] = $editPermission;
 		$recordActions['delete'] = $deletePermission;
+		$recordActions['duplicate'] = $duplicatePermission;
 
 		return $recordActions;
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1125 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レコードを複製する場合、現状モジュールのレコード一覧画面から対象レコードを選択した後の、概要・詳細画面「その他▼」からしか複製ができない。
編集や削除のように、モジュールのレコード一覧画面から複製ができるようにしてほしい。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
一覧画面からレコードを複製するボタンの追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/a3fe01f1-596b-4502-a888-6708e5924f96)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
モジュールの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->