### PR TITLE
一覧画面でスクロールを行うとヘッダーの項目名部分と検索ボックス部分の隙間からスクロールしたコンテンツが見えないように修正

### DIFF
--- a/layouts/v7/modules/Portal/ListViewContents.tpl
+++ b/layouts/v7/modules/Portal/ListViewContents.tpl
@@ -42,14 +42,14 @@
 			<table id="listview-table" class="table listview-table portal-table">
 				<thead>
 					<tr class="listViewContentHeader">
-						<th>
-				<div class="table-actions" style="margin-left:0px !important;">
-					<span class="input">
-						<input class="listViewEntriesMainCheckBox" type="checkbox">
-					</span>
-				</div>
+				<th class="table-bottom-border" nowrap="nowrap">
+					<div class="table-actions" style="margin-left:0px !important;">
+						<span class="input">
+							<input class="listViewEntriesMainCheckBox" type="checkbox">
+						</span>
+					</div>
 				</th>
-				<th>
+				<th class="table-bottom-border" nowrap="nowrap">
 					<a href="#" class="listViewContentHeaderValues" data-nextsortorderval="{if $COLUMN_NAME eq 'portalname'}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="portalname">
 						{if $COLUMN_NAME eq 'portalname'}
 							<i class="fa fa-sort {$FASORT_IMAGE}"></i>
@@ -62,7 +62,7 @@
 						<a href="#" class="removeSorting"><i class="fa fa-remove"></i></a>
 						{/if}
 				</th>
-				<th>
+				<th class="table-bottom-border" nowrap="nowrap">
 					<a href="#" class="listViewContentHeaderValues"
 					   data-nextsortorderval="{if $COLUMN_NAME eq 'portalurl'}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="portalurl">
 						{if $COLUMN_NAME eq 'portalurl'}
@@ -76,7 +76,7 @@
 						<a href="#" class="removeSorting"><i class="fa fa-remove"></i></a>
 						{/if}
 				</th>
-				<th>
+				<th class="table-bottom-border" nowrap="nowrap">
 					<a href="#" class="listViewContentHeaderValues"
 					   data-nextsortorderval="{if $COLUMN_NAME eq 'createdtime'}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="createdtime">
 						{if $COLUMN_NAME eq 'createdtime'}

--- a/layouts/v7/modules/RecycleBin/ListViewContents.tpl
+++ b/layouts/v7/modules/RecycleBin/ListViewContents.tpl
@@ -36,7 +36,7 @@
                 <table id="listview-table"  class="table {if $LISTVIEW_ENTRIES_COUNT eq '0'}listview-table-norecords {else} listview-table{/if} ">
                     <thead>
                         <tr class="listViewContentHeader">
-                            <th>
+                            <th class="none-border-bottom">
                                 {if !$SEARCH_MODE_RESULTS}
                         <div class="table-actions">
                             <span class="input">
@@ -48,7 +48,7 @@
                     {/if}
                     </th>
                     {foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}
-                        <th>
+                        <th class="none-border-bottom" nowrap="nowrap">
                             <a href="#" class="listViewContentHeaderValues" data-nextsortorderval="{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="{$LISTVIEW_HEADER->get('name')}">
                                 {if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}
                                     <i class="fa fa-sort {$FASORT_IMAGE}"></i>

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -54,7 +54,7 @@
 			<table id="listview-table" class="table {if $LISTVIEW_ENTRIES_COUNT eq '0'}listview-table-norecords {/if} listview-table column-2-fixed">
 				<thead>
 					<tr class="listViewContentHeader">
-						<th>
+				<th {if !$MODULE_MODEL->isFilterColumnEnabled() && !$LISTVIEW_ENTRIES_COUNT eq '0' }class="table-bottom-border"{/if}>
 							{if !$SEARCH_MODE_RESULTS}
 					<div class="table-actions">
 						<div class="dropdown" style="float:left;">
@@ -95,7 +95,7 @@
 					{else}
 						{assign var=NO_SORTING value=0}
 					{/if}
-					<th {if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')} nowrap="nowrap" {/if}>
+					<th {if !$MODULE_MODEL->isFilterColumnEnabled() && !$LISTVIEW_ENTRIES_COUNT eq '0'}class="table-bottom-border" {/if}{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')} nowrap="nowrap" {/if}>
 						<a href="#" class="{if $NO_SORTING}noSorting{else}listViewContentHeaderValues{/if}" {if !$NO_SORTING}data-nextsortorderval="{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="{$LISTVIEW_HEADER->get('name')}"{/if} data-field-id='{$LISTVIEW_HEADER->getId()}'>
 							{if !$NO_SORTING}
 								{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2974,15 +2974,18 @@ Vtiger.Class("Vtiger_List_Js", {
 		var tableContainer = $table.closest('.table-container');
 		var listViewContentHeader = tableContainer.find('.listViewContentHeader');
 		var listViewSearchHeader = tableContainer.find('.listViewSearchContainer');
+		var isEmptyRecord = tableContainer.find('.emptyRecordsContent').length;
 		var rows = tableContainer.find('tr.listViewEntries');
 
-		var thDummy = ''+
-        '<th class="dummy">'+
-		'</th>';
+		var borderOptionClass = '';
+		if(listViewSearchHeader.length <= 0) {
+			borderOptionClass = ' table-bottom-border';
+		}else if(app.getModuleName() === 'RecycleBin' && isEmptyRecord) {
+			borderOptionClass = ' none-border-bottom';
+		}
 
-		var tdDummy = ''+
-        '<td class="dummy">'+
-		'</td>';
+		var thDummy = `<th class="dummy${borderOptionClass}"></th>`;
+		var tdDummy = '<td class="dummy"></td>';
 
         listViewContentHeader.append(thDummy);
 		listViewSearchHeader.append(thDummy);

--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -2824,9 +2824,12 @@ Vtiger.Class("Vtiger_List_Js", {
 			'height': height,
 			'width': width
 		});
-		$table.resizableColumns('refreshContainerSize');
-		$table.resizableColumns('adjustDummyColumnWidth');
-		$table.resizableColumns('syncHandleWidths');
+		
+		if(typeof $table.resizableColumns === 'Object') {
+			$table.resizableColumns('refreshContainerSize');
+			$table.resizableColumns('adjustDummyColumnWidth');
+			$table.resizableColumns('syncHandleWidths');
+		}
 		// $table.floatThead('reflow');
 		tableContainer.perfectScrollbar('update');
 	},

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -12,18 +12,24 @@ table#listview-table {
 table#listview-table tr{
   border-bottom: #ddd 1px solid;
 }
-tr.searchRow.listViewSearchContainer > th{
+tr.listViewContentHeader > th {
+  border-bottom: #ddd 1px solid;
+}
+tr.searchRow.listViewSearchContainer > th {
   border-bottom: #ddd 1px solid;
 }
 tbody tr.listViewEntries:first-child {
   border-top: none !important;
   border-bottom: none !important;
 }
-tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions.fix-data-column {
+tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions {
   border-top: 0px !important;
 }
 tr.listViewEntries:nth-of-type(1) > td.listViewEntryValue {
   border-top: 0px !important;
+}
+thead > tr.listViewContentHeader > th.table-bottom-border {
+  border-bottom: #ddd 1px solid;
 }
 
 /*

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -9,28 +9,21 @@ table#listview-table {
   border-spacing: 0;
   border-collapse: separate;
 }
-table#listview-table tr{
+table#listview-table tr, 
+tr.listViewContentHeader > th,
+tr.searchRow.listViewSearchContainer > th,
+tr.listViewContentHeader > th.table-bottom-border {
   border-bottom: #ddd 1px solid;
 }
 tr.listViewEntries:first-child {
   border-top: none !important;
   border-bottom: none !important;
 }
-tr.listViewContentHeader > th {
-  border-bottom: #ddd 1px solid;
-}
-tr.searchRow.listViewSearchContainer > th {
-  border-bottom: #ddd 1px solid;
-}
-tr.listViewContentHeader > th.table-bottom-border {
-  border-bottom: #ddd 1px solid;
-}
+
 tr.listViewContentHeader > th.none-border-bottom {
   border-bottom: none !important;
 }
-tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions {
-  border-top: 0px !important;
-}
+tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions,
 tr.listViewEntries:nth-of-type(1) > td.listViewEntryValue {
   border-top: 0px !important;
 }

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -38,6 +38,10 @@ table#listview-table .emptyRecordsDiv > td {
 tr.listViewEntries:nth-of-type(1) > td.dummy {
   border-top: none;
 }
+td.listViewEntryValue  .fieldValue .value {
+  max-width: 98%;
+}
+
 
 /*
  * 一覧の左側の列固定（IE11非対応）

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -2,6 +2,30 @@
   clear: both;
 }
 
+/* 
+ *一覧画面の列幅可変機能追加に伴う修正
+ */
+table#listview-table {
+  border-spacing: 0;
+  border-collapse: separate;
+}
+table#listview-table tr{
+  border-bottom: #ddd 1px solid;
+}
+tr.searchRow.listViewSearchContainer > th{
+  border-bottom: #ddd 1px solid;
+}
+tbody tr.listViewEntries:first-child {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions.fix-data-column {
+  border-top: 0px !important;
+}
+tr.listViewEntries:nth-of-type(1) > td.listViewEntryValue {
+  border-top: 0px !important;
+}
+
 /*
  * 一覧の左側の列固定（IE11非対応）
  */
@@ -22,11 +46,9 @@
     background-clip: padding-box;
   }
   .listViewRecordActions.fix-data-column {
-    border-top: 0px !important;
     border-bottom: 0px !important;
   }
   .listViewEntryValue {
-    border-top: 0px !important;
     border-bottom: 0px !important;
   }
   .listViewEntries {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -12,14 +12,20 @@ table#listview-table {
 table#listview-table tr{
   border-bottom: #ddd 1px solid;
 }
+tr.listViewEntries:first-child {
+  border-top: none !important;
+  border-bottom: none !important;
+}
 tr.listViewContentHeader > th {
   border-bottom: #ddd 1px solid;
 }
 tr.searchRow.listViewSearchContainer > th {
   border-bottom: #ddd 1px solid;
 }
-tbody tr.listViewEntries:first-child {
-  border-top: none !important;
+tr.listViewContentHeader > th.table-bottom-border {
+  border-bottom: #ddd 1px solid;
+}
+tr.listViewContentHeader > th.none-border-bottom {
   border-bottom: none !important;
 }
 tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions {
@@ -28,8 +34,16 @@ tr.listViewEntries:nth-of-type(1) > td.listViewRecordActions {
 tr.listViewEntries:nth-of-type(1) > td.listViewEntryValue {
   border-top: 0px !important;
 }
-thead > tr.listViewContentHeader > th.table-bottom-border {
-  border-bottom: #ddd 1px solid;
+table#listview-table .emptyRecordsDiv > td {
+  border: none;
+}
+.dummy {
+  right: 0;
+  z-index: 1;
+  background: #fff;
+}
+tr.listViewEntries:nth-of-type(1) > td.dummy {
+  border-top: none;
 }
 
 /*
@@ -62,12 +76,6 @@ thead > tr.listViewContentHeader > th.table-bottom-border {
   }
   .listViewEntries:last-child {
     border-bottom: 0px;
-  }
-  .dummy {
-    right: 0;
-    z-index: 1;
-    /* border-top: 1px solid #ddd; */
-    background: #fff;
   }
 }
 /*


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1134

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一覧画面でスクロールを行うとヘッダーの項目名部分と検索ボックス部分の隙間からスクロールしたコンテンツが見える 

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 一覧画面で使用するtableのスタイル設定が不適切だったため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.一覧画面で使用するtableのスタイルを修正 

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://github.com/user-attachments/assets/b488c5bb-7e73-48f4-92ee-c400f73caef9)

修正後
![image](https://github.com/user-attachments/assets/5ec0de93-b21e-4985-a0f9-c85004c435ba)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
 各一覧画面のスタイル

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->