### PR TITLE
可変列幅機能が実装されている一覧画面に列幅リセットボタンが表示されるように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/ListViewActions.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewActions.tpl
@@ -46,13 +46,13 @@
                     </button>
                 {/if}
 
-                {if php7_count($LISTVIEW_MASSACTIONS_1) gt 0 or $LISTVIEW_LINKS['LISTVIEW']|@count gt 0}
                     <div class="btn-group listViewMassActions" role="group">
                         <button type="button" class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
                             {vtranslate('LBL_MORE','Vtiger')}&nbsp;
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
+                        {if php7_count($LISTVIEW_MASSACTIONS_1) gt 0 or $LISTVIEW_LINKS['LISTVIEW']|@count gt 0}
                             {foreach item=LISTVIEW_MASSACTION from=$LISTVIEW_MASSACTIONS_1 name=advancedMassActions}
                                 <li class="hide"><a id="{$MODULE}_listView_massAction_{Vtiger_Util_Helper::replaceSpaceWithUnderScores($LISTVIEW_MASSACTION->getLabel())}" {if stripos($LISTVIEW_MASSACTION->getUrl(), 'javascript:')===0} href="javascript:void(0);" onclick='{$LISTVIEW_MASSACTION->getUrl()|substr:strlen("javascript:")};'{else} href='{$LISTVIEW_MASSACTION->getUrl()}' {/if}>{vtranslate($LISTVIEW_MASSACTION->getLabel(), $MODULE)}</a></li>
                             {/foreach}
@@ -115,6 +115,7 @@
                                     {/if}  
                                 {/if}
                             {/foreach}
+                        {/if}
                             <li>
                                 <a id="resetColumnWidths" >
                                     {vtranslate('LBL_RESET_COLUMN_WIDTHS',$MODULE)}
@@ -122,7 +123,6 @@
                             </li>
                         </ul>
                     </div>
-                {/if}
             </div>
             </div>
             <div class='col-md-6'>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1135 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. FAQモジュール一覧面に列幅をリセットするボタンがないため、列幅のリセット操作ができない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 列幅リセットボタンが設置されている親の要素が、モジュールの設定値によって非表示となるため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 列幅リセットボタンのみ、モジュールの設定値に関係なく表示されるようにテンプレートファイルを修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://github.com/user-attachments/assets/10a3326c-5b83-49d8-b742-07e13b5cf9d3)


修正後
![image](https://github.com/user-attachments/assets/682aa827-3074-49b3-a4cb-be66dae51845)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
layouts/v7/modules/Vtiger/ListViewActions.tpl を利用して、リスト上部のボタンを表示している画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->