### PR TITLE
レコード数が少ない時にスクロールバーでレコードが隠れる不具合を修正

### DIFF
--- a/resources/styles.css
+++ b/resources/styles.css
@@ -42,6 +42,11 @@ td.listViewEntryValue  .fieldValue .value {
   max-width: 98%;
 }
 
+@media (min-width: 0px) and (max-width: 830px) {
+  .listViewPageDiv #table-content.table-container {
+    scrollbar-width: none;
+  }
+}
 
 /*
  * 一覧の左側の列固定（IE11非対応）


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1138

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.一覧画面にてレコード件数が少ないときに、スクロールバーがレコードに被ってしまいクリックがやりにくいことがある。スマートフォンなどではスクロールバーが細いため問題にならないが、WindowsPCの場合スクロールバーが非常に邪魔になる。 

##  原因 / Cause
<!-- バグの原因を記述 -->
mediaqueryで830px以下になった際に、本来非表示になるスクロールバーが表示されてしまう

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. スクロールバーが表示されないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://github.com/user-attachments/assets/cee391c9-3df2-45c9-a2ed-5f27c8080224)

修正後
![image](https://github.com/user-attachments/assets/cdbb233e-80f1-4717-b94f-150e17dbc66f)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
各モジュールのリスト画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
