### PR TITLE
大量のレコードを Export するとメモリを食いつぶし OS ごとフリーズしてしまう不具合の修正

### DIFF
--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -218,7 +218,7 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 											$query .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 										}
 										$batchOffset = $request->get('batchoffset');
-										if($batchOffset){
+										if(isset($batchOffset)){
 											$query .= ' LIMIT '.$this->exportBatchLimit.' OFFSET '.$batchOffset;
 										}
 										break;
@@ -256,7 +256,7 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 												$query .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 											}
 											$batchOffset = $request->get('batchoffset');
-											if($batchOffset){
+											if(isset($batchOffset)){
 												$query .= ' LIMIT '.$this->exportBatchLimit.' OFFSET '.$batchOffset;
 											}
 											break;

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -31,7 +31,7 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 
 	private $moduleInstance;
 	private $focus;
-	private $exportBatchLimit = 100; // 1回のクエリで取得するデータ数上限
+	private $exportBatchLimit = 10_000; // 1回のクエリで取得するデータ数上限
 
 	/**
 	 * Function exports the data based on the mode

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -31,6 +31,7 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 
 	private $moduleInstance;
 	private $focus;
+	private $exportBatchLimit = 100; // 1回のクエリで取得するデータ数上限
 
 	/**
 	 * Function exports the data based on the mode
@@ -44,9 +45,6 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 		$this->moduleFieldInstances = $this->moduleFieldInstances($moduleName);
 		$this->focus = CRMEntity::getInstance($moduleName);
 
-		$query = $this->getExportQuery($request);
-		$result = $db->pquery($query, array());
-
 		$redirectedModules = array('Users', 'Calendar');
 		if($request->getModule() != $moduleName && in_array($moduleName, $redirectedModules) && !$this->moduleCall){
 			$handlerClass = Vtiger_Loader::getComponentClassName('Action', 'ExportData', $moduleName);
@@ -54,37 +52,51 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			$handler->ExportData($request);
 			return;
 		}
-		$translatedHeaders = $this->getHeaders();
-		$entries = array();
-		for ($j = 0; $j < $db->num_rows($result); $j++) {
-			$entries[] = $this->sanitizeValues($db->fetchByAssoc($result, $j));
-		}
 
-		//エクスポート時の選択肢項目の翻訳処理
-		for ($i = 0; $i < $j; $i++){
-			$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-			$moduleFields = $moduleModel->getFields();
-			foreach ($entries[$i] as $columnName => $fieldValue) {
-				$fieldModel = $moduleFields[$columnName];
-				if(empty($fieldModel)){
-					foreach($moduleFields as $key => $fieldinfo){
-						if($fieldinfo->column == $columnName){
-							$fieldName = $fieldinfo->name;
+		$batchoffset = 0;
+		while(true){ // 取得するデータが無い場合に終了
+			$request->set('batchoffset', $batchoffset);
+			$query = $this->getExportQuery($request);
+			$result = $db->pquery($query, array());
+			$entries = array();
+			for ($j = 0; $j < $db->num_rows($result); $j++) {
+				$entries[] = $this->sanitizeValues($db->fetchByAssoc($result, $j));
+			}
+			if(empty($entries)){
+				break;
+			}
+
+			//エクスポート時の選択肢項目の翻訳処理
+			for ($i = 0; $i < $j; $i++){
+				$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+				$moduleFields = $moduleModel->getFields();
+				foreach ($entries[$i] as $columnName => $fieldValue) {
+					$fieldModel = $moduleFields[$columnName];
+					if(empty($fieldModel)){
+						foreach($moduleFields as $key => $fieldinfo){
+							if($fieldinfo->column == $columnName){
+								$fieldName = $fieldinfo->name;
+							}
 						}
+						$fieldModel = $moduleFields[$fieldName];
 					}
-					$fieldModel = $moduleFields[$fieldName];
-				}
 
-				$fieldDataType = ($fieldModel) ? $fieldModel->getFieldDataType() : '';
+					$fieldDataType = ($fieldModel) ? $fieldModel->getFieldDataType() : '';
 
-				if ($fieldDataType == 'picklist') {
-					$entries[$i][$columnName] = vtranslate($fieldValue,$moduleName);
+					if ($fieldDataType == 'picklist') {
+						$entries[$i][$columnName] = vtranslate($fieldValue,$moduleName);
+					}
 				}
 			}
 
+			if($batchoffset == 0){
+				$translatedHeaders = $this->getHeaders();
+				$this->output($request, $translatedHeaders, $entries);
+			}else{
+				$this->output($request, '', $entries);
+			}
+			$batchoffset = $batchoffset + $this->exportBatchLimit; // オフセットの更新
 		}
-
-		$this->output($request, $translatedHeaders, $entries);
 	}
 
 	public function getHeaders() {
@@ -205,6 +217,10 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			case 'ExportAllData'	:	if ($orderBy && $orderByFieldModel) {
 											$query .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 										}
+										$batchOffset = $request->get('batchoffset');
+										if($batchOffset){
+											$query .= ' LIMIT '.$this->exportBatchLimit.' OFFSET '.$batchOffset;
+										}
 										break;
 
 			case 'ExportCurrentPage' :	$pagingModel = new Vtiger_Paging_Model();
@@ -239,6 +255,10 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 											if ($orderBy && $orderByFieldModel) {
 												$query .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 											}
+											$batchOffset = $request->get('batchoffset');
+											if($batchOffset){
+												$query .= ' LIMIT '.$this->exportBatchLimit.' OFFSET '.$batchOffset;
+											}
 											break;
 
 
@@ -272,16 +292,18 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 		$fileName = str_replace(',', '_', $fileName);
 		$exportType = $this->getExportContentType($request);
 
-		header("Content-Disposition:attachment;filename=$fileName.csv");
-		header("Content-Type:$exportType;charset=UTF-8");
-		header("Expires: Mon, 31 Dec 2000 00:00:00 GMT" );
-		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT" );
-		header("Cache-Control: post-check=0, pre-check=0", false );
+		if(!empty($headers)){ // 最初のバッチ処理で実行
+			header("Content-Disposition:attachment;filename=$fileName.csv");
+			header("Content-Type:$exportType;charset=UTF-8");
+			header("Expires: Mon, 31 Dec 2000 00:00:00 GMT" );
+			header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT" );
+			header("Cache-Control: post-check=0, pre-check=0", false );
 
-		$header = implode("\",\"", $headers);
-		$header = "\"" .$header;
-		$header .= "\"\r\n";
-		echo chr(0xEF).chr(0xBB).chr(0xBF).$header;
+			$header = implode("\",\"", $headers);
+			$header = "\"" .$header;
+			$header .= "\"\r\n";
+			echo chr(0xEF).chr(0xBB).chr(0xBF).$header;
+		}
 
 		$cnt = 0;
 		foreach($entries as $row) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1132 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
データを Export する際に対象のレコード数が多いと, メモリを食いつぶしてフリーズする

##  原因 / Cause
<!-- バグの原因を記述 -->
ExportData()関数にて1度のクエリで大量のデータを取得している. 
このとき, メモリサイズが事前に確保されておらず, CSVファイル出力前段階でメモリ使用量が急増していた.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1度に全てのデータを処理するのではなく, クエリを複数に分割し, 
各クエリで取得したデータごとに逐次CSVファイルに書き出すように修正.
なお, 1度のクエリで処理するレコード数の上限は, 
modules/Vtiger/actions/ExportData.php の$exportBatchLimitにて指定(デフォルト10,000)

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
* レコードのエクスポート機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
10万点のレコードのエクスポートは本件の修正で実行できることを確認しました. 
もし, 修正適用後もメモリ不足が発生する場合には, 上記$exportBatchLimitを変更してください.
