### PR TITLE
共有カレンダーにてユーザーリストの表示が崩れる不具合の修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -134,7 +134,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 					var feedIndicatorTemplate = jQuery('#calendarview-feeds').find('ul.dummy > li.feed-indicator-template');
 					feedIndicatorTemplate.removeClass('.feed-indicator-template');
 					var newFeedIndicator = feedIndicatorTemplate.clone(true,true);
-					newFeedIndicator.find('span:first').text(selectedUserName);
+					newFeedIndicator.find('span:first').addClass('userName textOverflowEllipsis').text(selectedUserName).attr('title',selectedUserName);
 					var newFeedCheckbox = newFeedIndicator.find('.toggleCalendarFeed');
 					newFeedCheckbox.attr('data-calendar-sourcekey','Events_'+selectedUserId).
 					attr('data-calendar-feed','Events').

--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -316,7 +316,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 					var feedIndicatorTemplate = jQuery('#calendarview-feeds').find('ul.dummy > li.feed-indicator-template');
 					feedIndicatorTemplate.removeClass('.feed-indicator-template');
 					var newFeedIndicator = feedIndicatorTemplate.clone(true,true);
-					newFeedIndicator.find('span:first').addClass('userName textOverflowEllipsis').text(user);
+					newFeedIndicator.find('span:first').addClass('userName textOverflowEllipsis').text(user).attr('title',user);
 					var newFeedCheckbox = newFeedIndicator.find('.toggleCalendarFeed');
 					newFeedCheckbox.attr('data-calendar-sourcekey','Events_'+id).
 					attr('data-calendar-feed','Events').

--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -316,7 +316,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 					var feedIndicatorTemplate = jQuery('#calendarview-feeds').find('ul.dummy > li.feed-indicator-template');
 					feedIndicatorTemplate.removeClass('.feed-indicator-template');
 					var newFeedIndicator = feedIndicatorTemplate.clone(true,true);
-					newFeedIndicator.find('span:first').text(user);
+					newFeedIndicator.find('span:first').addClass('userName textOverflowEllipsis').text(user);
 					var newFeedCheckbox = newFeedIndicator.find('.toggleCalendarFeed');
 					newFeedCheckbox.attr('data-calendar-sourcekey','Events_'+id).
 					attr('data-calendar-feed','Events').

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -709,3 +709,23 @@ ul#productsImageContainer > li a{
   right: 15px;
   z-index: 1;
 } 
+
+/* カレンダーユーザーの選択リスト */
+.activitytypes .activitytype-indicator .userName.textOverflowEllipsis {
+  vertical-align: middle;
+}
+@media (min-width: 767px) and (max-width: 991px) {
+  .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {
+    max-width: 600px;
+  } 
+}
+@media (min-width: 575px) and (max-width: 768px) {
+  .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {
+    max-width: 400px;
+  }
+}
+@media (min-width: 401px) and (max-width: 576px) {
+  .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {
+    max-width: 200px;
+  }
+}

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -729,3 +729,7 @@ ul#productsImageContainer > li a{
     max-width: 200px;
   }
 }
+
+.calendarview div.sidebar-essentials {
+  overflow: hidden;
+}

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -711,8 +711,13 @@ ul#productsImageContainer > li a{
 } 
 
 /* カレンダーユーザーの選択リスト */
+
+.sidebar-essentials {
+  scrollbar-width: thin;
+}
 .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {
   vertical-align: middle;
+  max-width: 90px;
 }
 @media (min-width: 767px) and (max-width: 991px) {
   .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -711,8 +711,8 @@ ul#productsImageContainer > li a{
 } 
 
 /* カレンダーユーザーの選択リスト */
-
-.sidebar-essentials {
+div.main-container .sidebar-essentials {
+  overflow-x: hidden;
   scrollbar-width: thin;
 }
 .activitytypes .activitytype-indicator .userName.textOverflowEllipsis {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1148

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 共有カレンダーのマイグループにて、マイグループを再選択した際に姓名の文字数が長いユーザーの表示が崩れる場合がある

##  原因 / Cause
<!-- バグの原因を記述 -->
1. htmlにclass設定が適切に付与されていなかったため必要なスタイルが付与されていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. グループを変更した際のhtml生成時に適切にclassが付与されるように修正
2. スタイルの調整

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://github.com/user-attachments/assets/7e1fa7e9-b9ff-402b-8f0e-d1c50aad6467)

修正後
![image](https://github.com/user-attachments/assets/7958ac94-7602-4433-90ec-07dbae0d2537)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
共有カレンダーのユーザーリスト部分

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->