### PR TITLE
一覧画面にて関連項目のtd要素にマウスホバーするとaタグなどが入った状態のtitle属性が表示されないようにする修正

### DIFF
--- a/include/ListView/ListViewController.php
+++ b/include/ListView/ListViewController.php
@@ -497,8 +497,8 @@ class ListViewController {
 				} elseif ( in_array($uitype,array(7,9,90)) ) {
 					$value = "<span align='right'>".textlength_check($value)."</span>";
 				} elseif($field && $field->isNameField) {
-					$value = "<a href='?module=$field->moduleName&view=Detail&".
-								"record=$recordId' title='".vtranslate($field->moduleName, $field->moduleName)."'>$value</a>";
+					$value = "<a href='index.php?module=$field->moduleName&view=Detail&".
+								"record=$recordId' title=title='".vtranslate($referenceModuleName, $referenceModuleName).":". $entityNames[$value] ."'>$value</a>";
 				} elseif($field->getUIType() == 61) {
 					$attachmentId = (int)$value;
 					$displayValue = '--';

--- a/include/ListView/ListViewController.php
+++ b/include/ListView/ListViewController.php
@@ -498,7 +498,7 @@ class ListViewController {
 					$value = "<span align='right'>".textlength_check($value)."</span>";
 				} elseif($field && $field->isNameField) {
 					$value = "<a href='index.php?module=$field->moduleName&view=Detail&".
-								"record=$recordId' title=title='".vtranslate($referenceModuleName, $referenceModuleName).":". $entityNames[$value] ."'>$value</a>";
+								"record=$recordId' title='".vtranslate($field->moduleName, $field->moduleName).":". $value ."'>$value</a>";
 				} elseif($field->getUIType() == 61) {
 					$attachmentId = (int)$value;
 					$displayValue = '--';

--- a/layouts/v7/modules/ModComments/ListViewContents.tpl
+++ b/layouts/v7/modules/ModComments/ListViewContents.tpl
@@ -121,7 +121,7 @@
                                 {assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER->get('name')}
                                 {assign var=LISTVIEW_ENTRY_RAWVALUE value=$LISTVIEW_ENTRY->getRaw($LISTVIEW_HEADER->get('column'))}
                                 {assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-                                <td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
+                                <td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)|strip_tags}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
                                     <span class="fieldValue">
                                         <span class="value textOverflowEllipsis">
                                             {if $LISTVIEW_HEADER->get('uitype') eq '72'}

--- a/layouts/v7/modules/Products/ProductsPopupContents.tpl
+++ b/layouts/v7/modules/Products/ProductsPopupContents.tpl
@@ -80,7 +80,7 @@
                                 {assign var="ROW_NUMBER" value={$smarty.foreach.listViewEntry.index}}
                                 {assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER->get('name')}
                                 {assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-                                <td class="listViewEntryValue textOverflowEllipsis" title="{$RECORD_DATA[$LISTVIEW_HEADERNAME]}">
+                                <td class="listViewEntryValue textOverflowEllipsis" title="{$RECORD_DATA[$LISTVIEW_HEADERNAME]|strip_tags}">
                                     {if $LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4'}
                                         <a>{$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}</a>
                                     {else if $LISTVIEW_HEADER->get('uitype') eq '72'}

--- a/layouts/v7/modules/Reports/ListViewContents.tpl
+++ b/layouts/v7/modules/Reports/ListViewContents.tpl
@@ -122,7 +122,7 @@
 									{assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER_KEY}
 									{assign var=LISTVIEW_ENTRY_RAWVALUE value=$LISTVIEW_ENTRY->getRaw($LISTVIEW_HEADER_KEY)}
 									{assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-									<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADERNAME}" title="{$LISTVIEW_ENTRY_RAWVALUE}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="">
+									<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADERNAME}" title="{$LISTVIEW_ENTRY_RAWVALUE|strip_tags}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="">
 										<span class="fieldValue">
 											<span class="value textOverflowEllipsis">
 												{if $LISTVIEW_HEADERNAME eq 'reporttype'}

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -157,7 +157,7 @@
 							{assign var=LISTVIEW_ENTRY_RAWVALUE value=$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
 						{/if}
 						{assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-						<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
+						<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)|strip_tags}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
 							<span class="fieldValue">
 								<span class="value">
 									{if ($LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4') and $MODULE_MODEL->isListViewNameFieldNavigationEnabled() eq true }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1150

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  各モジュールの一覧画面にて、関連項目のtd要素にマウスホバーするとaタグなどが入った状態のtitle属性が表示されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1.  HTMLが含まれている場合を考慮せずに表示を行っていたから

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  テンプレートファイルでHTMLを取り除く処理を追加
2. 併せてホバーした際に項目の値ではなくモジュール名しか表示されない点も修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
![image](https://github.com/user-attachments/assets/16100451-d1a5-4166-9489-a8342bb376cb)

修正後
![image](https://github.com/user-attachments/assets/9b2993e0-2e9d-4e8e-bb67-0b815a7bc73d)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
各モジュールの一覧画面にてaタグを含む出力がされる場合

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
