### PR TITLE
thinkingreed-inc#1144 カレンダー更新時に活動が重複登録されてしまうため、共有IDと登録者の組み合わせが重複してる場合…

### DIFF
--- a/modules/Events/actions/SaveAjax.php
+++ b/modules/Events/actions/SaveAjax.php
@@ -69,40 +69,43 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 			$result['calendarModule'] = $request->get('calendarModule');
 			$result['sourceModule'] = $request->get('calendarModule');
 
-			// Handled to save follow up event
-			$followupMode = $request->get('followup');
+            // Handled to save follow up event
+            $followupMode = $request->get('followup');
 
-			if ($followupMode == 'on') {
-				//Start Date and Time values
-				$startTime = Vtiger_Time_UIType::getTimeValueWithSeconds($request->get('followup_time_start'));
-				$startDateTime = Vtiger_Datetime_UIType::getDBDateTimeValue($request->get('followup_date_start') . " " . $startTime);
-				list($startDate, $startTime) = explode(' ', $startDateTime);
+            if ($followupMode == 'on') {
+                //Start Date and Time values
+                $startTime = Vtiger_Time_UIType::getTimeValueWithSeconds($request->get('followup_time_start'));
+                $startDateTime = Vtiger_Datetime_UIType::getDBDateTimeValue($request->get('followup_date_start') . " " . $startTime);
+                list($startDate, $startTime) = explode(' ', $startDateTime);
 
-				$subject = $request->get('subject');
-				if ($startTime != '' && $startDate != '') {
-					$recordModel->set('eventstatus', 'Planned');
-					$recordModel->set('subject', '[Followup] ' . $subject);
-					$recordModel->set('date_start', $startDate);
-					$recordModel->set('time_start', $startTime);
+                $subject = $request->get('subject');
+                if ($startTime != '' && $startDate != '') {
+                    $recordModel->set('eventstatus', 'Planned');
+                    $recordModel->set('subject', '[Followup] ' . $subject);
+                    $recordModel->set('date_start', $startDate);
+                    $recordModel->set('time_start', $startTime);
 
-					$currentUser = Users_Record_Model::getCurrentUserModel();
-					$activityType = $recordModel->get('activitytype');
-					if ($activityType == 'Call') {
-						$minutes = $currentUser->get('callduration');
-					} else {
-						$minutes = $currentUser->get('othereventduration');
-					}
-					$dueDateTime = date('Y-m-d H:i:s', strtotime("$startDateTime+$minutes minutes"));
-					list($endDate, $endTime) = explode(' ', $dueDateTime);
+                    $currentUser = Users_Record_Model::getCurrentUserModel();
+                    $activityType = $recordModel->get('activitytype');
+                    if ($activityType == 'Call') {
+                        $minutes = $currentUser->get('callduration');
+                    } else {
+                        $minutes = $currentUser->get('othereventduration');
+                    }
+                    $dueDateTime = date('Y-m-d H:i:s', strtotime("$startDateTime+$minutes minutes"));
+                    list($endDate, $endTime) = explode(' ', $dueDateTime);
 
-					$recordModel->set('due_date', $endDate);
-					$recordModel->set('time_end', $endTime);
-					$recordModel->set('mode', 'create');
-					$recordModel->save();
-				}
-			}
-			$response->setEmitType(Vtiger_Response::$EMIT_JSON);
-			$response->setResult($result);
+                    $recordModel->set('due_date', $endDate);
+                    $recordModel->set('time_end', $endTime);
+                    $recordModel->set('mode', 'create');
+                    $recordModel->save();
+                }
+            }
+            $response->setEmitType(Vtiger_Response::$EMIT_JSON);
+            $response->setResult($result);
+
+            $this->isDuplicateCheck($recordModel);
+
 		} catch (DuplicateException $e) {
 			$response->setError($e->getMessage(), $e->getDuplicationMessage(), $e->getMessage());
 		} catch (Exception $e) {
@@ -224,4 +227,24 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 		return $recordModel;
 	}
 
+    /**
+     * 重複チェック
+     *
+     * @param Vtiger_Record_Model $recordModel
+     * @param Users_Record_Model $user
+     * @return void
+     *
+    */
+    function isDuplicateCheck( Vtiger_Record_Model $recordModel )
+    {
+        // 同じ共有IDで同じ登録者の場合のデータを削除します。
+        global $adb;
+        $result = $adb->pquery("SELECT `activityid`,`invitee_parentid` FROM `vtiger_activity` GROUP BY `smownerid`,`invitee_parentid` HAVING COUNT(*) > 1");
+        for($index = 0;$index < $adb->num_rows($result);$index++)
+        {
+            $activityidId = $adb->query_result($result,$index,'activityid');
+            $adb->pquery("DELETE FROM `vtiger_activity` WHERE `activityid`= ". $activityidId);
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
…削除するように修正。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1144

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動に参加者を追加すると、それぞれの参加者が担当になった活動レコードが生成されるが、
活動の編集方法によっては関連づいた活動レコード内で同じ担当者の状態のレコードに変更できてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動更新時に共有IDと登録者の重複チェックをしていないため発生してる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. データ更新時、重複データがあれば削除するように修正しました。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->