### PR TITLE
#1157 更新履歴に削除と復元の情報を表示するように変更

### DIFF
--- a/layouts/v7/modules/Vtiger/RecentActivities.tpl
+++ b/layouts/v7/modules/Vtiger/RecentActivities.tpl
@@ -104,7 +104,66 @@
                                     {/foreach}
                                     </div>
                                 </li>
-
+                            {else if $RECENT_ACTIVITY->isDelete()}
+                                <li>
+                                    <time class="update_time cursorDefault">
+                                        <small title="{Vtiger_Util_Helper::formatDateTimeIntoDayString($RECENT_ACTIVITY->getActivityTime())}">
+                                            {Vtiger_Util_Helper::formatDateTimeIntoDayString($RECENT_ACTIVITY->getActivityTime())}
+                                        </small>
+                                    </time>
+                                    {assign var=USER_MODEL value=$RECENT_ACTIVITY->getModifiedBy()}
+                                    {assign var=IMAGE_DETAILS value=$USER_MODEL->getImageDetails()}
+                                    {if $IMAGE_DETAILS neq '' && $IMAGE_DETAILS[0] neq '' && $IMAGE_DETAILS[0].url eq ''}
+                                        <div class="update_icon bg-info">
+                                            <i class='update_image vicon-vtigeruser'></i>
+                                        </div>
+                                    {else}
+                                        {foreach item=IMAGE_INFO from=$IMAGE_DETAILS}
+                                            {if !empty($IMAGE_INFO.url)}
+                                                <div class="update_icon">
+                                                    <img class="update_image" src="{$IMAGE_INFO.url}" >
+                                                </div>
+                                            {/if}
+                                        {/foreach}
+                                    {/if}
+                                    <div class="update_info">
+                                        <div> 
+                                            <h5>
+                                                <span class="field-name">{$RECENT_ACTIVITY->getModifiedBy()->getDisplayName()} </span> {vtranslate('LBL_DELETE', $MODULE_NAME)}
+                                            </h5>
+                                        </div>
+                                    </div>
+                                </li>
+                            {else if $RECENT_ACTIVITY->isRestore()}
+                                <li>
+                                    <time class="update_time cursorDefault">
+                                        <small title="{Vtiger_Util_Helper::formatDateTimeIntoDayString($RECENT_ACTIVITY->getActivityTime())}">
+                                            {Vtiger_Util_Helper::formatDateTimeIntoDayString($RECENT_ACTIVITY->getActivityTime())}
+                                        </small>
+                                    </time>
+                                    {assign var=USER_MODEL value=$RECENT_ACTIVITY->getModifiedBy()}
+                                    {assign var=IMAGE_DETAILS value=$USER_MODEL->getImageDetails()}
+                                    {if $IMAGE_DETAILS neq '' && $IMAGE_DETAILS[0] neq '' && $IMAGE_DETAILS[0].url eq ''}
+                                        <div class="update_icon bg-info">
+                                            <i class='update_image vicon-vtigeruser'></i>
+                                        </div>
+                                    {else}
+                                        {foreach item=IMAGE_INFO from=$IMAGE_DETAILS}
+                                            {if !empty($IMAGE_INFO.url)}
+                                                <div class="update_icon">
+                                                    <img class="update_image" src="{$IMAGE_INFO.url}" >
+                                                </div>
+                                            {/if}
+                                        {/foreach}
+                                    {/if}
+                                    <div class="update_info">
+                                        <div> 
+                                            <h5>
+                                                <span class="field-name">{$RECENT_ACTIVITY->getModifiedBy()->getDisplayName()} </span> {vtranslate('LBL_RESTORED', $MODULE_NAME)}
+                                            </h5>
+                                        </div>
+                                    </div>
+                                </li>
                             {else if ($RECENT_ACTIVITY->isRelationLink() || $RECENT_ACTIVITY->isRelationUnLink())}
                                 {assign var=RELATED_MODULE value= $RELATION->getLinkedRecord()->getModuleName()}
                                 <li>

--- a/layouts/v7/skins/contact/style.css
+++ b/layouts/v7/skins/contact/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/inventory/style.css
+++ b/layouts/v7/skins/inventory/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -3089,6 +3089,7 @@ input[type="text"]:read-only {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/marketing_and_sales/style.css
+++ b/layouts/v7/skins/marketing_and_sales/style.css
@@ -3033,6 +3033,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/project/style.css
+++ b/layouts/v7/skins/project/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/sales/style.css
+++ b/layouts/v7/skins/sales/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/support/style.css
+++ b/layouts/v7/skins/support/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/tools/style.css
+++ b/layouts/v7/skins/tools/style.css
@@ -3039,6 +3039,7 @@ th {
   left: 19%;
 }
 .updates_timeline > li {
+  padding-bottom: 10px;
   position: static;
   top: 0;
   display: block;

--- a/layouts/v7/skins/vtiger/style.less
+++ b/layouts/v7/skins/vtiger/style.less
@@ -3343,6 +3343,7 @@ strong, b, th{
 }
 
 .updates_timeline > li {
+    padding-bottom: 10px;
     position: static;
     top: 0;
     display: block;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1157 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 更新履歴に表示していなかった、「削除」と 「復元」情報を表示するように変更

## スクリーンショット / Screenshot
![image](https://github.com/user-attachments/assets/49e53e8e-7f00-41a7-9b45-0b95c1aeb20b)


## 影響範囲  / Affected Area
各レコードの更新履歴

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った