### PR TITLE
#1159 ユーザーのプロフィール画像が保存できない不具合の修正

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1045,7 +1045,7 @@ class Users extends CRMEntity {
 		if($module == 'Users') {
 			$save_file = validateImageFile($file_details);
 		}
-		if ($save_file == 'false') {
+		if ($save_file === false) {
 			return;
 		}
 


### PR DESCRIPTION
### ##  関連Issue / Related Issue
- fix #1159 

##  不具合の内容 / Bug
1. プロフィール画像が保存できない

##  原因 / Cause
1. 正常に画像が保存されているが、不適切な条件分岐により途中で処理がしゅうりょうしていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 条件を厳密になるように修正

## スクリーンショット / Screenshot

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
プロフィール画像部分のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->