### PR TITLE
#1133 レポートのPHP8対応漏れ修正

### DIFF
--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -4247,7 +4247,7 @@ class ReportRun extends CRMEntity {
 			$keyvalue = getTabModuleName($tabid) . "_" . $fieldlabel1;
 			$fieldvalues = Array();
 			if (php7_count($roleids) > 1) {
-				$mulsel = "select distinct $fieldname from vtiger_$fieldname inner join vtiger_role2picklist on vtiger_role2picklist.picklistvalueid = vtiger_$fieldname.picklist_valueid where roleid in (\"" . implode($roleids, "\",\"") . "\") and picklist_valueid in (select picklistid from vtiger_$fieldname)"; // order by sortid asc - not requried
+				$mulsel = "select distinct $fieldname from vtiger_$fieldname inner join vtiger_role2picklist on vtiger_role2picklist.picklistvalueid = vtiger_$fieldname.picklist_valueid where roleid in (\"" . implode("\",\"", $roleids) . "\") and picklist_valueid in (select picklistid from vtiger_$fieldname)"; // order by sortid asc - not requried
 			} else {
 				$mulsel = "select distinct $fieldname from vtiger_$fieldname inner join vtiger_role2picklist on vtiger_role2picklist.picklistvalueid = vtiger_$fieldname.picklist_valueid where roleid ='" . $roleid . "' and picklistid in (select picklist_valueid from vtiger_$fieldname)"; // order by sortid asc - not requried
 			}

--- a/modules/Reports/actions/ChartSave.php
+++ b/modules/Reports/actions/ChartSave.php
@@ -15,6 +15,7 @@ class Reports_ChartSave_Action extends Reports_Save_Action {
 
 		$record = $request->get('record');
 		$reportModel = new Reports_Record_Model();
+		$reportModel->report = new Reports();
 		$reportModel->setModule('Reports');
 		if(!empty($record) && !$request->get('isDuplicate')) {
 			$reportModel->setId($record);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1133

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  共有されたレポートの詳細画面を表示できない
2.  レポートの新規作成からグラフを作成できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. PHP8系で廃止された 「implode(array$array, string $separator)」でエラーが発生して閲覧できなかった
2. レポート作成で対応した 6e9bdbab48f36f4d11b950fd5db2d4e2cee95902 のグラフ横展開漏れ

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「implode(string $separator, array$array)」に変更
2. 6e9bdbab48f36f4d11b950fd5db2d4e2cee95902 と同じ横展開を実施

## 影響範囲  / Affected Area
レポートの閲覧

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った