### PR TITLE
thinkingreed-inc#1167 レポート一覧で一括削除できないバグの修正

### DIFF
--- a/modules/Reports/models/Record.php
+++ b/modules/Reports/models/Record.php
@@ -1177,7 +1177,7 @@ class Reports_Record_Model extends Vtiger_Record_Model {
 		return Reports_ScheduleReports_Model::getInstanceById($this->getId());
 	}
 
-	public function getRecordsListFromRequest(Vtiger_Request $request) {
+	public static function getRecordsListFromRequest(Vtiger_Request $request) {
 		$folderId = $request->get('viewname');
 		$module = $request->get('module');
 		$selectedIds = $request->get('selected_ids');


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1167

##  不具合の内容 / Bug
レポート一覧から一括削除機能を実施しようとするとエラーメッセージが画面に表示されて失敗する。

##  原因 / Cause
<!-- バグの原因を記述 -->
PHP8系対応漏れ
インスタンスメソッドをstaticメソッドとして呼び出してエラーが発生していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  メソッドをstaticメソッドに変更

## 影響範囲  / Affected Area
- レポート一覧の一括削除
- レポート一覧の一括移動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
