### PR TITLE
ドキュメントモジュールの一覧から検索を行うと勝手に無効化される不具合の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1227,8 +1227,11 @@ Vtiger.Class("Vtiger_List_Js", {
 				thisInstance.registerInlineEdit(currentTrElement);
 			}
 		});
-		this.registerInlineEditSaveEvent();
-		this.registerInlineEditCancelEvent();
+		
+		if (listViewContainer.find('#isExcelEditSupported').val() !== 'no') {
+			this.registerInlineEditSaveEvent();
+			this.registerInlineEditCancelEvent();
+		}
 
 		app.event.on('post.listViewInlineEdit.click', function (event, editedRow) {
 			vtUtils.applyFieldElementsView(editedRow);

--- a/modules/Documents/models/Module.php
+++ b/modules/Documents/models/Module.php
@@ -26,6 +26,10 @@ class Documents_Module_Model extends Vtiger_Module_Model {
 		return false;
 	}
 	
+	public function isExcelEditAllowed() {
+		return false;
+	}
+	
 	/**
 	 * Function returns the url which gives Documents that have Internal file upload
 	 * @return string


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1173 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ドキュメントモジュールの一覧画面にてEnterキーを押して検索を実行すると、「成功」のメッセージが表示される。
2. 検索結果をクリアで解除すると、一覧先頭のファイル名のリンクが外れている。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Enter押下の際に一覧のインライン編集の保存イベントが発火していた。（ドキュメントモジュールはインライン編集はもともとの仕様で不可） 
2. 有効無効の値が更新されて、無効になっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  インライン編集が使用しないモジュールでは、原因となったイベントがセットされないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 検索機能を持つ一覧画面
- インライン編集機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->