### PR TITLE
関連している活動に重複したユーザーで活動の登録が行われないように修正

### DIFF
--- a/languages/ja_jp/Calendar.php
+++ b/languages/ja_jp/Calendar.php
@@ -190,6 +190,7 @@ $languageStrings = array(
 	'Duration' => '期間',
 	'Duration Minutes' => '期間(分)',
 	'No Time' => '時間なし',
+	'LBL_DUPULICATE_EVENT_EXISTS'=> 'この活動は復元できません。活動の参加者が重複しています。',
 );
 
 $jsLanguageStrings = array(

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -659,12 +659,9 @@ function insertIntoRecurringTable(& $recurObj)
 		$duplicateResult      = $adb->pquery($getDuplicateQuery, [ $id ]);
 		$duplicateResultCount = $adb->num_rows($duplicateResult);
 		
-		// 重複したレコードは復元せずに削除
+		// 重複したレコードは復元しない
 		if($duplicateResultCount !== 0) {
-			$recycleBinModule = new RecycleBin_Module_Model();
-			$recycleBinModule->deleteRecords([ $id ]);
-			
-			return;
+			throw new Exception(vtranslate('LBL_DUPULICATE_EVENT_EXISTS', $module));
 		}
 		
 		// レコードの復元処理

--- a/modules/Events/actions/Save.php
+++ b/modules/Events/actions/Save.php
@@ -9,7 +9,88 @@
  *************************************************************************************/
 
 class Events_Save_Action extends Calendar_Save_Action {
+	public function process(Vtiger_Request $request) {
+		try {
+			$recordModel = $this->saveRecord($request);
+			$this->deleteDuplicateInviteeEvent($recordModel);
 
+			$refererUrl  = $_SERVER['HTTP_REFERER'];
+			$parsedurl = parse_url($refererUrl);
+			$searchParams = explode('&', $parsedurl['query']);
+			foreach ($searchParams as $searchParam){
+				$explodedParams = explode('=', $searchParam);
+				$parsedParams[$explodedParams[0]] =$explodedParams[1];
+			}
+			if($parsedParams['referer'] == 'SharedCalendar') {
+				$loadUrl = 'index.php?module=Calendar&view=SharedCalendar&calendarStartDate='. $recordModel->get('date_start');
+			} else {
+				$loadUrl = 'index.php?module=Calendar&view=Calendar&calendarStartDate='. $recordModel->get('date_start');
+			}
+
+			if ($request->get('fromQuickCreate')) {
+				$loadUrl = 'index.php'.$request->get('quickCreateReturnURL');
+			} else if($request->get('returntab_label')) {
+				$loadUrl = 'index.php?'.$request->getReturnURL();
+			} else if($request->get('relationOperation')) {
+				$parentModuleName = $request->get('sourceModule');
+				$parentRecordId = $request->get('sourceRecord');
+				$parentRecordModel = Vtiger_Record_Model::getInstanceById($parentRecordId, $parentModuleName);
+				//TODO : Url should load the related list instead of detail view of record
+				$loadUrl = $parentRecordModel->getDetailViewUrl();
+			} else if ($request->get('returnToList')) {
+				$moduleModel = $recordModel->getModule();
+				$listViewUrl = $moduleModel->getListViewUrl();
+
+				if ($recordModel->get('visibility') === 'Private') {
+					$loadUrl = $listViewUrl;
+				} else {
+					$userId = $recordModel->get('assigned_user_id');
+					$sharedType = $moduleModel->getSharedType($userId);
+					if ($sharedType === 'selectedusers') {
+						$currentUserModel = Users_Record_Model::getCurrentUserModel();
+						$sharedUserIds = Calendar_Module_Model::getCaledarSharedUsers($userId);
+						if (!array_key_exists($currentUserModel->id, $sharedUserIds)) {
+							$loadUrl = $listViewUrl;
+						}
+					} else if ($sharedType === 'private') {
+						$loadUrl = $listViewUrl;
+					}
+				}
+			} else if ($request->get('returnmodule') && $request->get('returnview')){
+				$loadUrl = 'index.php?'.$request->getReturnURL();
+			}
+			header("Location: $loadUrl");
+		} catch (DuplicateException $e) {
+			$mode = '';
+			if ($request->getModule() === 'Events') {
+				$mode = 'Events';
+			}
+
+			$requestData = $request->getAll();
+			unset($requestData['action']);
+			unset($requestData['__vtrftk']);
+
+			if ($request->isAjax()) {
+				$response = new Vtiger_Response();
+				$response->setError($e->getMessage(), $e->getDuplicationMessage(), $e->getMessage());
+				$response->emit();
+			} else {
+				$requestData['view'] = 'Edit';
+				$requestData['mode'] = $mode;
+				$requestData['module'] = 'Calendar';
+				$requestData['duplicateRecords'] = $e->getDuplicateRecordIds();
+
+				global $vtiger_current_version;
+				$viewer = new Vtiger_Viewer();
+				$viewer->assign('REQUEST_DATA', $requestData);
+				$viewer->assign('REQUEST_URL', "index.php?module=Calendar&view=Edit&mode=$mode&record=".$request->get('record'));
+				$viewer->view('RedirectToEditView.tpl', 'Vtiger');
+            }
+		} catch (Exception $e) {
+			 throw new Exception($e->getMessage());
+		}
+	}
+	
 	/**
 	 * Function to save record
 	 * @param <Vtiger_Request> $request - values of the record
@@ -124,4 +205,78 @@ class Events_Save_Action extends Calendar_Save_Action {
 		}
 		return $recordModel;
 	}
+	
+	/**
+     * parentidが同じ複数のレコードで参加者が重複した場合はparentレコードではないものを論理削除する
+     *
+     * @param Vtiger_Record_Model $recordModel
+     * @return void
+     *
+    */
+    function deleteDuplicateInviteeEvent(Vtiger_Record_Model $recordModel)
+    {
+		global $adb;
+		$recordId = $recordModel->getId();
+		$ownerId  = $recordModel->get('assigned_user_id');
+		
+		// parentid と 参加者が重複している招待レコードを探す
+		$query = "SELECT activityid, invitee_parentid, smownerid
+				  FROM vtiger_activity 
+				  WHERE invitee_parentid = ( SELECT invitee_parentid 
+											 FROM vtiger_activity 
+											 WHERE activityid = ? ) 
+					AND smownerid = ? AND deleted = 0";
+		$params      = [ $recordId, $ownerId ];
+        $result      = $adb->pquery($query, $params);
+		$resultCount = $adb->num_rows($result);
+		
+		if($resultCount === 1) {
+			return;
+		}
+		
+		// 参加者が重複している招待レコードがあれば論理削除する
+		for($i=0; $i<$resultCount; $i++) {
+			$activityId = $adb->query_result($result, $i, 'activityid');
+			$inviteeParentId  = $adb->query_result($result, $i, 'invitee_parentid');
+			$smownerId        = $adb->query_result($result, $i, 'smownerid');
+			
+			// 親レコードは消さない
+			if($activityId === $inviteeParentId) {
+				continue;
+			}
+			
+			// 削除するレコードのRecordModelを取得
+			$recordModel  = Vtiger_Record_Model::getInstanceById($activityId, 'Events');
+			
+			// 繰り返し情報を削除
+			$recurringQuery  = "DELETE 
+								FROM vtiger_activity_recurring_info 
+								WHERE recurrenceid= ?";
+			$recurringParams = [ $recordModel->getId() ]; 
+			$adb->pquery($recurringQuery, $recurringParams);
+			
+			// 参加者情報を再度作り直す（子レコードで更新した場合に完全に招待が消えることがあるため）
+			$inviteeQuery  = "DELETE FROM vtiger_invitees WHERE activityid = ?";
+			$inviteeParams = [ $inviteeParentId ]; 
+			$adb->pquery($inviteeQuery, $inviteeParams);
+			
+			// 参加者のIDを取得
+			$query         = "SELECT smownerid 
+							  FROM vtiger_activity 
+							  WHERE deleted = 0 
+							  	AND invitee_parentid = ? AND activityid <> ?";
+			$params        = [ $inviteeParentId, $recordModel->getId() ];
+			$result        = $adb->pquery($query, $params);
+			
+			for($i=0; $i<$adb->num_rows($result); $i++) {
+				$smownerId = $adb->query_result($result, $i, 'smownerid');
+				$inviteeQuery  = "INSERT INTO vtiger_invitees VALUES (?,?,?)";
+				$inviteeParams = [ $inviteeParentId, $smownerId, 'sent' ]; 
+				$adb->pquery($inviteeQuery, $inviteeParams);
+			}
+			
+			// レコードの削除
+			$recordModel->getModule()->deleteRecord($recordModel);
+		}
+    }
 }

--- a/modules/Events/actions/SaveAjax.php
+++ b/modules/Events/actions/SaveAjax.php
@@ -17,6 +17,7 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 
 			vglobal('VTIGER_TIMESTAMP_NO_CHANGE_MODE', $request->get('_timeStampNoChangeMode', false));
 			$recordModel = $this->saveRecord($request);
+			$this->deleteDuplicateInviteeEvent($recordModel);
 			vglobal('VTIGER_TIMESTAMP_NO_CHANGE_MODE', false);
 
 			$fieldModelList = $recordModel->getModule()->getFields();

--- a/modules/Events/actions/SaveAjax.php
+++ b/modules/Events/actions/SaveAjax.php
@@ -69,40 +69,43 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 			$result['calendarModule'] = $request->get('calendarModule');
 			$result['sourceModule'] = $request->get('calendarModule');
 
-			// Handled to save follow up event
-			$followupMode = $request->get('followup');
+            // Handled to save follow up event
+            $followupMode = $request->get('followup');
 
-			if ($followupMode == 'on') {
-				//Start Date and Time values
-				$startTime = Vtiger_Time_UIType::getTimeValueWithSeconds($request->get('followup_time_start'));
-				$startDateTime = Vtiger_Datetime_UIType::getDBDateTimeValue($request->get('followup_date_start') . " " . $startTime);
-				list($startDate, $startTime) = explode(' ', $startDateTime);
+            if ($followupMode == 'on') {
+                //Start Date and Time values
+                $startTime = Vtiger_Time_UIType::getTimeValueWithSeconds($request->get('followup_time_start'));
+                $startDateTime = Vtiger_Datetime_UIType::getDBDateTimeValue($request->get('followup_date_start') . " " . $startTime);
+                list($startDate, $startTime) = explode(' ', $startDateTime);
 
-				$subject = $request->get('subject');
-				if ($startTime != '' && $startDate != '') {
-					$recordModel->set('eventstatus', 'Planned');
-					$recordModel->set('subject', '[Followup] ' . $subject);
-					$recordModel->set('date_start', $startDate);
-					$recordModel->set('time_start', $startTime);
+                $subject = $request->get('subject');
+                if ($startTime != '' && $startDate != '') {
+                    $recordModel->set('eventstatus', 'Planned');
+                    $recordModel->set('subject', '[Followup] ' . $subject);
+                    $recordModel->set('date_start', $startDate);
+                    $recordModel->set('time_start', $startTime);
 
-					$currentUser = Users_Record_Model::getCurrentUserModel();
-					$activityType = $recordModel->get('activitytype');
-					if ($activityType == 'Call') {
-						$minutes = $currentUser->get('callduration');
-					} else {
-						$minutes = $currentUser->get('othereventduration');
-					}
-					$dueDateTime = date('Y-m-d H:i:s', strtotime("$startDateTime+$minutes minutes"));
-					list($endDate, $endTime) = explode(' ', $dueDateTime);
+                    $currentUser = Users_Record_Model::getCurrentUserModel();
+                    $activityType = $recordModel->get('activitytype');
+                    if ($activityType == 'Call') {
+                        $minutes = $currentUser->get('callduration');
+                    } else {
+                        $minutes = $currentUser->get('othereventduration');
+                    }
+                    $dueDateTime = date('Y-m-d H:i:s', strtotime("$startDateTime+$minutes minutes"));
+                    list($endDate, $endTime) = explode(' ', $dueDateTime);
 
-					$recordModel->set('due_date', $endDate);
-					$recordModel->set('time_end', $endTime);
-					$recordModel->set('mode', 'create');
-					$recordModel->save();
-				}
-			}
-			$response->setEmitType(Vtiger_Response::$EMIT_JSON);
-			$response->setResult($result);
+                    $recordModel->set('due_date', $endDate);
+                    $recordModel->set('time_end', $endTime);
+                    $recordModel->set('mode', 'create');
+                    $recordModel->save();
+                }
+            }
+            $response->setEmitType(Vtiger_Response::$EMIT_JSON);
+            $response->setResult($result);
+
+            $this->isDuplicateCheck($recordModel);
+
 		} catch (DuplicateException $e) {
 			$response->setError($e->getMessage(), $e->getDuplicationMessage(), $e->getMessage());
 		} catch (Exception $e) {
@@ -224,4 +227,24 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 		return $recordModel;
 	}
 
+    /**
+     * 重複チェック
+     *
+     * @param Vtiger_Record_Model $recordModel
+     * @param Users_Record_Model $user
+     * @return void
+     *
+    */
+    function isDuplicateCheck( Vtiger_Record_Model $recordModel )
+    {
+        // 同じ共有IDで同じ登録者の場合のデータを削除します。
+        global $adb;
+        $result = $adb->pquery("SELECT `activityid`,`invitee_parentid` FROM `vtiger_activity` GROUP BY `smownerid`,`invitee_parentid` HAVING COUNT(*) > 1");
+        for($index = 0;$index < $adb->num_rows($result);$index++)
+        {
+            $activityidId = $adb->query_result($result,$index,'activityid');
+            $adb->pquery("DELETE FROM `vtiger_activity` WHERE `activityid`= ". $activityidId);
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1144 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動に参加者を追加すると、それぞれの参加者が担当になった活動レコードが生成されるが、
活動の編集方法によっては関連づいた活動レコード内で同じ担当者の状態のレコードに変更できてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動レコ―ドの編集を行った際に、重複したユーザーが登録される可能性が考慮されていないため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動保存時に関連する活動のユーザーを確認し、重複する場合はユニークになるように重複した内容のレコードを論理削除するように修正
2. ゴミ箱から復元した際にも重複が発生する可能性があるため、重複する場合はエラーメッセージ表示して復元を行わない

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
重複するレコードの復元操作を行った際にエラーメッセージ
![image](https://github.com/user-attachments/assets/5ad31826-f207-4b6f-b69d-aa92c82107f9)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 活動の保存機能
- ゴミ箱から活動のレコードを復元する処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->