### PR TITLE
#1162 共有カレンダーにて、特殊文字が含まれているユーザー名が正しく表示されない不具合の修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -305,7 +305,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 			var cashDisabledFeedsStorageKey = thisInstance.getDisabledFeeds();
 
 			Object.keys(users).forEach(function (id) {
-				var user = users[id];
+				var user = app.getDecodedValue(users[id]);
 				if(id == myId) {
 					thisInstance.refreshFeed($(".activitytype-indicator.calendar-feed-indicator.mine").find("input[type='checkbox']"));
 					return ;//continue


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1162 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
ユーザー名に「×」や「∞」などの特殊文字が含まれている場合、共有カレンダーの左カラムに表示されるグループごとのユーザー名一覧にて、ユーザー名が正しく表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
* 通常時：CalendarSharedUsers.tpl内の$USER に特殊文字を含むユーザ名(例: &amp;infin;テストユーザ)が格納され、HTMLとして出力される. このため、ブラウザが自動的に &amp;infin; を解釈して ∞ へ変換する.

* グループ選択時：SharedCalendar.js内のchangeUserList関数では、ユーザ名がそのまま設定される. このためブラウザによる変換が行われず、&amp;infin; がそのまま表示される.

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
動的な処理でのみ発生する不具合であるため、changeUserList関数内でユーザ名をデコードするように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
&amp;infin; が ∞ へ変換された様子
![image](https://github.com/user-attachments/assets/4a46258c-5908-4900-9ae7-87372b6d022e)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->