### PR TITLE
開始日と終了日を1週間近く跨いだ場合に予定が表示されない不具合の修正

### DIFF
--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -279,10 +279,10 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 
 	protected function pullEvents($start, $end, &$result, $userid = false, $color = null, $textColor = 'white', $isGroupId = false, $conditions = '') {
 		$dbStartDateOject = DateTimeField::convertToDBTimeZone($start);
-		$dbStartDateTime = $dbStartDateOject->format('Y-m-d H:i:s');
+		$dbStartDate = $dbStartDateOject->format('Y-m-d');
 
 		$dbEndDateObject = DateTimeField::convertToDBTimeZone($end);
-		$dbEndDateTime = $dbEndDateObject->format('Y-m-d H:i:s');
+		$dbEndDate = $dbEndDateObject->format('Y-m-d');
 
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 		$db = PearDatabase::getInstance();
@@ -315,7 +315,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			$query .=  $this->generateCalendarViewConditionQuery($conditions).'AND ';
 		}
 		
-		$query.= " CONCAT(date_start, '', time_start)  <= ? AND CONCAT(due_date, '', time_end) >= ?";
+		$query.= " date_start <= ? AND due_date >= ?";
 		
 		if(empty($userid)){
 			$eventUserId  = $currentUser->getId();
@@ -326,7 +326,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		
 		$query.= " AND vtiger_crmentity.smownerid IN (".  generateQuestionMarks($userIds).")";
 		
-		$params = array($dbEndDateTime, $dbStartDateTime, $userIds);
+		$params = array($dbEndDate, $dbStartDate, $userIds);
 		$queryResult = $db->pquery($query, $params);
 
 		$creatorfield = Vtiger_Field_Model::getInstance('creator', $moduleModel);

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -280,13 +280,9 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 	protected function pullEvents($start, $end, &$result, $userid = false, $color = null, $textColor = 'white', $isGroupId = false, $conditions = '') {
 		$dbStartDateOject = DateTimeField::convertToDBTimeZone($start);
 		$dbStartDateTime = $dbStartDateOject->format('Y-m-d H:i:s');
-		$dbStartDateTimeComponents = explode(' ', $dbStartDateTime);
-		$dbStartDate = $dbStartDateTimeComponents[0];
 
 		$dbEndDateObject = DateTimeField::convertToDBTimeZone($end);
 		$dbEndDateTime = $dbEndDateObject->format('Y-m-d H:i:s');
-		$dbEndDateTimeComponents = explode(' ', $dbEndDateTime);
-		$dbEndDate = $dbEndDateTimeComponents[0];
 
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 		$db = PearDatabase::getInstance();
@@ -318,9 +314,9 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			$conditions = Zend_Json::decode(Zend_Json::decode($conditions));
 			$query .=  $this->generateCalendarViewConditionQuery($conditions).'AND ';
 		}
-		$query.= " ((concat(date_start, '', time_start)  >= ? AND concat(due_date, '', time_end) < ? ) OR ( due_date >= ? AND due_date <= ?))";
-
-		$params=array($dbStartDateTime,$dbEndDateTime,$dbStartDate, $dbEndDate);
+		
+		$query.= " CONCAT(date_start, '', time_start)  <= ? AND CONCAT(due_date, '', time_end) >= ?";
+		
 		if(empty($userid)){
 			$eventUserId  = $currentUser->getId();
 		}else{
@@ -329,7 +325,8 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		$userIds = array_merge(array($eventUserId), $this->getGroupsIdsForUsers($eventUserId));
 		
 		$query.= " AND vtiger_crmentity.smownerid IN (".  generateQuestionMarks($userIds).")";
-		$params= array_merge($params,$userIds);
+		
+		$params = array($dbEndDateTime, $dbStartDateTime, $userIds);
 		$queryResult = $db->pquery($query, $params);
 
 		$creatorfield = Vtiger_Field_Model::getInstance('creator', $moduleModel);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1181

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 終日の予定を帯で入れた際に、開始から終了まで正しく表示されない
2. 毎回発生するわけでは無く、発生の条件が不明

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 検索を早めるために追加した活動レコードの検索条件に誤りがあった
2. 条件が誤っていたため、活動レコードに登録されている完了日を含む直近1週間前にならないとカレンダーの表示の対象として結果に含まれていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 検索条件を修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 活動モジュールの共有カレンダー表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->