### PR TITLE
複数選択の値をメール送信ワークフローに使用するとFatalErrorが発生する不具合の修正

### DIFF
--- a/modules/com_vtiger_workflow/VTSimpleTemplate.inc
+++ b/modules/com_vtiger_workflow/VTSimpleTemplate.inc
@@ -309,14 +309,13 @@ class VTSimpleTemplate{
 
 			case 'multipicklist' :  require_once 'includes/runtime/LanguageHandler.php';
 									require_once 'includes/runtime/Globals.php';
-									if(strpos($fieldValue, '|##|') !== false){
-										$fieldValueParts = explode(' |##| ',$fieldValue);
-									}
+									$fieldValueParts = explode(' |##| ',$fieldValue);
 									foreach($fieldValueParts as $index=>$fieldValue) {
 										$fieldValueParts[$index] = vtranslate($fieldValue,$moduleName,$ownerObject->column_fields['language']);
 									}
 									$fieldValue = implode(',', $fieldValueParts);
 									break;
+									
 			case 'boolean'		:  require_once 'includes/runtime/LanguageHandler.php';
 									require_once 'includes/runtime/Globals.php';
 									if($fieldValue == 1){


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1198 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
メール送信を行うワークフローでメールに選択肢（複数）項目の値を使用すると、FatalErrorが発生しワークフローなど保存後処理が完了しない症状が発生

##  原因 / Cause
<!-- バグの原因を記述 -->
メール送信ワークフローで使用する値の変換処理が原因
選択肢（複数）の値が1個のみの場合、配列を期待している引数に文字列が渡され、型の不一致でFatalErrorが発生した

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
値が1個の場合でも、変換処理の引数が配列で渡されるように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- ワークフローにてメールを送信する処理
- ワークフローにてSMSを送信する処理
- ワークフローにて活動を作成する処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
