### PR TITLE
#1201 PDFテンプレートに通貨が表示されないバグの修正

### DIFF
--- a/include/utils/EmailTemplate.php
+++ b/include/utils/EmailTemplate.php
@@ -173,7 +173,7 @@ class EmailTemplate {
 						}
 						$value = $row->get($fieldColumnMapping[$field]);
 						//Emails are wrapping with hyperlinks, so skipping email fields as well
-						if($fieldModel->isReferenceField() || $fieldModel->isOwnerField() || $fieldModel->get('uitype') == 13) {
+						if($fieldModel->isReferenceField() || $fieldModel->isOwnerField() || in_array($fieldModel->get('uitype'), [13, 117])) {
 							if ($referenceColumn == 'contactid' && $this->module == 'Events') {
 								/**Getting multi reference record's reference/owner/uitype = 13 values 
 								 * and storing it in a class variable, later we will glue them with comma(,)


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1201 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PDFテンプレートに通貨の変数を設定して、PDFを出力しても値が空で表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
通貨はvtiger_ws_entity_nameテーブルでidで検索された場合は通貨名に変換するロジックを持つ。
通貨名に変換後、通貨名を利用してvtiger_currency_infoのidで検索していたため、
nullを取得・設定していた。
```
＜SQL例＞
select
    currency_name as entityname, 
    id 
from
    vtiger_currency_info 
where
    id in ('Argentina, Pesos')
```

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. SQLでid検索するように通貨名を変換しない

## スクリーンショット / Screenshot
- 修正後
![image](https://github.com/user-attachments/assets/562999ee-2db9-46ee-a566-f8e35286fd06)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
uitypeが117のフィールドをPDF出力する場合

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った