### PR TITLE
#1203 項目の新規作成でデフォルト値に不要な半角スペースを設定させない

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl
@@ -18,16 +18,11 @@
 					{if !$NAME_ATTR}
 						{assign var=NAME_ATTR value="fieldDefaultValue"}
 					{/if}
-					{if $DEFAULT_VALUE eq false && !$IS_SET}
-						{assign var=DEFAULT_VALUE value=$FIELD_MODEL->get('defaultvalue')}
-					{/if}
+					{assign var=DEFAULT_VALUE value=$FIELD_MODEL->get('defaultvalue')}
 
 					{if $FIELD_MODEL->getFieldDataType() eq "picklist"}
 						{if !is_array($PICKLIST_VALUES)}
 							{assign var=PICKLIST_VALUES value=$FIELD_INFO.picklistvalues}
-						{/if}
-						{if !$DEFAULT_VALUE}
-							{assign var=DEFAULT_VALUE value=$FIELD_MODEL->get('defaultvalue')}
 						{/if}
 						{assign var=DEFAULT_VALUE value={decode_html($DEFAULT_VALUE)}}
 						<select class="col-sm-9 select2" name="{$NAME_ATTR}">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1203

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目の新規作成をする際、デフォルト値に最初から半角スペースが設定されている場合がある

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 項目作成モーダルのデフォルト値は、該当モジュールの最後の項目のデフォルト値を表示していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 項目作成モーダルのField_Modelからデフォルト値を取得するように修正

## スクリーンショット / Screenshot
周辺を選択してもデフォルト値のフィールドに何も入っていない状態
![image](https://github.com/user-attachments/assets/25b8a8f9-cf26-4c03-8831-2ca7dd2d22d3)

## 影響範囲  / Affected Area
- 項目作成モーダルのみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->