### PR TITLE
月表示の際に1日の予定を全件表示できるようにする修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1917,12 +1917,12 @@ Vtiger.Class("Calendar_Calendar_Js", {
                                 columnFormat: dateFormat + ' dddd'
                             }
 			},
-			height: (CalendarHeight),
+			contentHeight: CalendarHeight,
 			fixedWeekCount: false,
 			firstDay: thisInstance.daysOfWeek[thisInstance.getUserPrefered('start_day')],
 			scrollTime: thisInstance.getUserPrefered('start_hour'),
 			editable: true,
-			eventLimit: true,
+			eventLimit: false,
 			defaultDate:defaultDate,
 			defaultView:defaultView,
 			slotLabelFormat: userDefaultTimeFormat,


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1206 

##  要望の内容 / Bug
1日あたりの予定が複数登録されている場合に、カレンダーで「月」表示を行うと1日の表示マスの高さによる制限で1日の予定が全件表示されない。
この場合、1日の予定全件を確認するために「+7more」などの表示をクリックして表示を展開させる必要がある。これを1日の予定が全件表示される状態に変更してほしい。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 表示件数の制限を解除
2. 1日のマスの高さを自動調整されるように修正
3. カレンダー全体の高さが必要に応じて伸びるように修正

## スクリーンショット / Screenshot
![image](https://github.com/user-attachments/assets/8eee49bf-5fbc-4965-9434-61939006c8a8)

## 影響範囲  / Affected Area
カレンダーの月表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
