### PR TITLE
カレンダーの月表示で終了時刻が表示されるように修正

### DIFF
--- a/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1480,6 +1480,16 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				'</span>&nbsp;'
 				);
 	},
+	
+	// 月表示終了時間を追加
+	addMonthViewEventEndTime: function (event, element, viewName) {
+		if (viewName !== 'month') return;
+		
+		var timeFormat = this.getDefaultCalendarTimeFormat();
+		var endTimeText = ' - ' + moment(event.end).format(timeFormat);
+		element.find('.fc-content > .fc-time').append(endTimeText);
+	},
+	
 	_deleteCalendarEvent: function (eventId, sourceModule, extraParams) {
 		var thisInstance = this;
 		if (typeof extraParams === 'undefined') {
@@ -1741,6 +1751,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	},
 	performPreEventRenderActions: function (event, element) {
 		var calendarView = this.getCalendarViewContainer().fullCalendar('getView');
+		this.addMonthViewEventEndTime(event, element, calendarView.name);
 		this.addActivityTypeIcons(event, element);
 		this.registerPopoverEvent(event, element, calendarView);
 	},


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1189 

##  要望の内容 / Bug
カレンダーを月表示にした際、活動の開始時刻は表示されるが、終了時刻は表示されない。
終了時刻も表示されるようにしてほしい。

##  変更内容 / Details of Change
月表示の場合に終了時刻が表示されるように修正

## スクリーンショット / Screenshot
![image](https://github.com/user-attachments/assets/4813ba19-51b9-4694-a390-31f400bbb4de)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーの月表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
