### PR TITLE
カレンダーの一括削除などを行うとエラーが発生する不具合の修正

### DIFF
--- a/modules/Calendar/actions/MassDelete.php
+++ b/modules/Calendar/actions/MassDelete.php
@@ -14,15 +14,35 @@ class Calendar_MassDelete_Action extends Vtiger_MassDelete_Action {
 		$adb = PearDatabase::getInstance();
 		$moduleName = $request->getModule();
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+		$cvId = $request->get('viewname');
 
 		if ($request->get('selected_ids') == 'all' && $request->get('mode') == 'FindDuplicates') {
             $recordIds = Vtiger_FindDuplicate_Model::getMassDeleteRecords($request);
         } else {
             $recordIds = $this->getRecordsListFromRequest($request);
         }
-		$cvId = $request->get('viewname');
+		
+		$skipRecords = [];
+		asort($recordIds, SORT_NUMERIC);
 		foreach($recordIds as $recordId) {
 			if(Users_Privileges_Model::isPermitted($moduleName, 'Delete', $recordId)) {
+				// Inveteeで作成された子レコードは親が削除された際に削除されるので、改めて削除処理行われないようにする
+				$query = 'SELECT activityid 
+						  FROM vtiger_activity 
+						  WHERE invitee_parentid = ? 
+						  	AND deleted = 0 
+							AND activityid <> ? 
+						  ORDER BY activityid';
+				$result = $adb->pquery($query, array($recordId, $recordId));
+				for($i = 0; $i < $adb->num_rows($result); $i++) {
+					$skipRecords[$adb->query_result($result, $i, 'activityid')] = true;
+				}
+				
+				if (isset($skipRecords[$recordId])) {
+					unset($skipRecords[$recordId]);
+					continue;
+				}
+				
 				$recordModel = Vtiger_Record_Model::getInstanceById($recordId, $moduleModel);
 				$parentRecurringId = $recordModel->getParentRecurringRecord();
 				$adb->pquery('DELETE FROM vtiger_activity_recurring_info WHERE activityid=? AND recurrenceid=?', array($parentRecurringId, $recordId));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1207

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダー（ToDoまたは活動）の一覧画面から全件または複数のレコードを選択して削除するとエラーが発生する。
削除処理は選択したレコードが全件が削除されることもあるが、途中で処理が停止している場合もある。

##  原因 / Cause
<!-- バグの原因を記述 -->
参加者の予定として作成された活動レコード（子レコード）とその親レコードを同時に選択して削除した場合に発生する。
1. 選択されたレコードのうちの親レコードが論理削除される
2. その際に子レコードも同時に論理削除処理が行わる
3. 論理削除済みの子レコードについても削除処理を実行しようとする
4. レコードが論理削除済みのためRecordModel作成時にエラーが発生する

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
 親レコードを論理削除する際に子レコードのIDを 取得し、それをもとに再度論理削除が実行されないように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー（ToDoまたは活動）の選択削除または全件選択の論理削除機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った