### PR TITLE
1212 プロジェクト関連タブからプロジェクトタスクの作成が開けない不具合の修正

### DIFF
--- a/modules/ProjectTask/views/QuickCreateAjax.php
+++ b/modules/ProjectTask/views/QuickCreateAjax.php
@@ -34,7 +34,7 @@ class ProjectTask_QuickCreateAjax_View extends Vtiger_IndexAjax_View {
 			$fieldsInfo[$name] = $model->getFieldInfo();
 		}
 
-		$recordStructureInstance = Vtiger_RecordStructure_Model::getInstanceFromRecordModel($recordModel, Vtiger_RecordStructure_Model::RECORD_STRUCTURE_MODE_QUICKCREATE);
+		$recordStructureInstance = Vtiger_RecordStructure_Model::getInstanceFromRecordModel($recordModel, Vtiger_RecordStructure_Model::RECORD_STRUCTURE_MODE_EDIT);		
 		$picklistDependencyDatasource = Vtiger_DependencyPicklist::getPicklistDependencyDatasource($moduleName);
 
 		$viewer = $this->getViewer($request);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1212 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
 プロジェクトモジュールの関連タブからプロジェクトタスクレコ―ドを作成しようとするとエラーが発生して作成画面を開くことができない。

##  原因 / Cause
<!-- バグの原因を記述 -->
 クイック作成の対象項目取得モードが他のモジュールと異なっていたため、取得した項目情報の展開に失敗していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
クイック作成の対象項目の取得が他のモジュールと同じモードで実行されるように修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
プロジェクトタスクモジュールのクイック作成画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
