### PR TITLE
#871 Chromeをヘッドレスモードで動かすDockerfileのubuntu24.04対応

### DIFF
--- a/docker/headlesschrome/Dockerfile
+++ b/docker/headlesschrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:24.04
 
 RUN apt update -y
 
@@ -7,10 +7,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y tzdata
 
 RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN apt-get install fonts-liberation libasound2 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2 libexpat1 libgbm1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 libcurl3-gnutls libcurl3-nss libcurl4 xdg-utils fonts-noto -y
+RUN apt-get install fonts-liberation2 libasound2t64 libatk-bridge2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2 libexpat1 libgbm1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 libcurl3-gnutls libcurl4 xdg-utils libu2f-udev libvulkan1 fonts-noto -y
 RUN fc-cache -fv
 RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install libappindicator1 -y
+RUN apt-get install libayatana-appindicator3-1 -y
 RUN dpkg -i google-chrome-stable_current_amd64.deb
 RUN apt -f install -y
 RUN apt install apache2 php -y

--- a/docker/headlesschrome/docker-compose.yml
+++ b/docker/headlesschrome/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   webdb:
@@ -13,8 +13,8 @@ services:
     command: >
       sh -c 'usermod -u `stat -c %u /html2pdf/` www-data
              groupmod -g `stat -c %u /html2pdf/` www-data
-             chown -R www-data.www-data /var/www/html
-             chown -R www-data.www-data /html2pdf
+             chown -R www-data:www-data /var/www/html
+             chown -R www-data:www-data /html2pdf
              exec /sbin/init'
 
     dns: 8.8.8.8


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #871

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Ubuntuの24.04にはないライブラリをインストールしようとしてエラーが発生していた。


##  原因 / Cause
<!-- バグの原因を記述 -->
利用するubuntuのバージョンは常に最新を取得するような記述になっていたが、
Ubuntu24.04がリリースされて以降、削除されたライブラリを
Dockerfileでインストールしようとしてビルドに失敗していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Dockerのバージョンを24.04に指定
2. ライブラリを最新化
3. docker-composeファイルの記入ミスを修正

## 影響範囲  / Affected Area
Dockerコンテナ headlesschrome のビルド

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
