### PR TITLE
#907 google-chromeのdeprecatedなオプションを変更

### DIFF
--- a/docker/headlesschrome/converthtmltopdf.php
+++ b/docker/headlesschrome/converthtmltopdf.php
@@ -10,7 +10,7 @@ if ($filepath) {
     // 白紙事象の対応の為、PDFのサイズが10kb未満の場合は再度変換処理を行う。最大20回までとする。
     for ($i = 0; $i < $max_loop_count; $i++) {
         // htmlからPDF変換
-        exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --allow-file-access-from-files --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --print-to-pdf-no-header --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html 2>&1", $output, $retval);
+        exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --allow-file-access-from-files --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --no-pdf-header-footer --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html 2>&1", $output, $retval);
         if ($retval != 0) {
             error_log(date("Y/m/d H:i:s") . "." . substr(explode(".", (microtime(true) . ""))[1], 0, 3) . ", output:" . __LINE__ . print_r($output, true) . ", retval:" . $retval . PHP_EOL, 3, $logFilename);
         }

--- a/modules/Vtiger/helpers/PDF.php
+++ b/modules/Vtiger/helpers/PDF.php
@@ -70,7 +70,7 @@ class PDF_helper {
 				$recordIdData = array($recordIdData);
 			}
 			$pdfdataarray = array();
-			// shell_exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --print-to-pdf-no-header --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html");
+			// shell_exec("/usr/bin/google-chrome --headless --no-sandbox --disable-setuid-sandbox --disable-software-rasterizer --disable-gpu --virtual-time-budget=9999999 --run-all-compositor-stages-before-draw --no-pdf-header-footer --print-to-pdf=" . $filepath . ".pdf" . " " . $filepath . ".html");
 			// shell_exec("chmod a+r ".$filepath . ".pdf");
 			foreach ($recordIdData as $key => $recordId) {
 				$result = $adb->pquery("SELECT templatename, body FROM vtiger_pdftemplates WHERE templateid = ?", array($templateId));
@@ -146,7 +146,7 @@ class PDF_helper {
 
 				// headlesschrome側にてPDF変換処理を行う
 				if(empty($dokerfiledirectory)) {
-					$command = $chromeurl." --headless --disable-gpu --print-to-pdf-no-header --print-to-pdf=" . $hostfilepath . ".pdf " . $hostfilepath . ".html";
+					$command = $chromeurl." --headless --disable-gpu --no-pdf-header-footer --print-to-pdf=" . $hostfilepath . ".pdf " . $hostfilepath . ".html";
 					exec($command);
 				} else {
 					$paramsarray = array("filepath" => $dockerfilepath);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #907

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
--print-to-pdf-no-header を利用することでdeprecatedのWarningがapacheログに残る

##  原因 / Cause
<!-- バグの原因を記述 -->
https://developer.chrome.com/docs/chromium/headless?hl=ja
Googleのサイトに「--print-to-pdf-no-header」が非推奨となっていることが明記されている。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
--no-pdf-header-footer に修正

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
headlesschrom を利用したPDF出力

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
