### PR TITLE
#1184 プロファイル設定で一部権限を制限しているユーザーの画面からクイック作成画面を見るとレイアウトが崩れている不具合の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/partials/Topbar.tpl
+++ b/layouts/v7/modules/Vtiger/partials/Topbar.tpl
@@ -99,13 +99,14 @@
 									<hr/>
 									<li id="quickCreateModules" style="padding: 0 5px;">
 										<div class="col-lg-12" style="padding-bottom:15px;">
+											{assign var='count' value=0}
 											{foreach key=moduleName item=moduleModel from=$QUICK_CREATE_MODULES}
 												{if $moduleModel->isPermitted('CreateView') || $moduleModel->isPermitted('EditView')}
 													{assign var='quickCreateModule' value=$moduleModel->isQuickCreateSupported()}
 													{assign var='singularLabel' value=$moduleModel->getSingularLabelKey()}
 													{assign var=hideDiv value={!$moduleModel->isPermitted('CreateView') && $moduleModel->isPermitted('EditView')}}
 													{if $quickCreateModule == '1'}
-														{if $count % 3 == 0}
+														{if !$hideDiv && $count % 3 == 0}
 															<div class="row">
 															{/if}
 															{* Adding two links,Event and Task if module is Calendar *}
@@ -115,7 +116,7 @@
 																	<a id="menubar_quickCreate_Events" class="quickCreateModule" data-name="Events"
 																	   data-url="index.php?module=Events&view=QuickCreateAjax" href="javascript:void(0)">{$moduleModel->getModuleIcon('Event')}<span class="quick-create-module">{vtranslate('LBL_EVENT',$moduleName)}</span></a>
 																</div>
-																{if $count % 3 == 2}
+																{if !$hideDiv && $count % 3 == 2}
 																	</div>
 																	<br>
 																	<div class="row">
@@ -160,7 +161,7 @@
 																	</a>
 																</div>
 															{/if}
-															{if $count % 3 == 2}
+															{if !$hideDiv && $count % 3 == 2}
 																</div>
 																<br>
 															{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1184 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
プロファイル設定で一部権限を制限しているユーザーの画面からクイック作成画面を見るとレイアウトが崩れている。

##  原因 / Cause
<!-- バグの原因を記述 -->
隠れ要素(権限が制限されたモジュール)により、行の作成``` <div class="row"> ```および閉じる``` </div> ```操作が実行されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 行の作成および閉じるタイミングに$hideDivの判定を加える
2. 表示要素数$countを初期化

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* リードに制限をかけた場合のクイック作成画面
![image](https://github.com/user-attachments/assets/f20ba54e-e8e5-4c4b-8240-62e2dd95ef5c)

※ 「日報」のレイアウト崩れについては #1224 を参照ください。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
クイック作成画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->