### PR TITLE
#1222 クイック作成画面にて日報のレイアウトが崩れている不具合の修正

### DIFF
--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -2051,7 +2051,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 
 		$moduleIcon = "<i class='vicon-$lowerModuleName' title='$title'></i>";
 		if ($this->source == 'custom') {
-			$moduleShortName = mb_substr(trim($title), 0, 2);
+			$moduleShortName = mb_substr(trim($title), 0, 1);
 			$moduleIcon = "<span class='custom-module' title='$title'>$moduleShortName</span>";
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1222 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
クイック作成画面にて日報のレイアウトが崩れている

##  原因 / Cause
<!-- バグの原因を記述 -->
069e98a4c306f68d93df41e2df49e38e2b388d0f にて日報アイコンが「日」の1文字から「日報」の2文字へと変更された。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
日報アイコンを1文字に戻す。

※ 2文字になっているのはデグレと判断したため、元のデザインに戻す修正を行いました。
※ 2文字が意図的である場合、フォントサイズを変更することで対処可能です。(ユーザー使用言語の影響あり)

## スクリーンショット / Screenshot
* 日報アイコンが1文字のクイック作成画面
![image](https://github.com/user-attachments/assets/8008e748-8609-4ba0-82c5-38ad4de2b04f)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
クイック作成画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->