### PR TITLE
1226 テンプレート内で利用するphpの関数などを事前に登録するように修正

### DIFF
--- a/includes/runtime/Viewer.php
+++ b/includes/runtime/Viewer.php
@@ -70,6 +70,46 @@ class Vtiger_Viewer extends Smarty {
 			
 			$this->log("URI: $debugViewerURI, TYPE: " . $_SERVER['REQUEST_METHOD']);
 		}
+
+		$inSettings = isset($_REQUEST["parent"]) && $_REQUEST["parent"] == "Settings";
+
+		$classes = array('Vtiger_MenuStructure_Model', 'Users_Privileges_Model', 
+			'Vtiger_Module_Model', 'Settings_MenuEditor_Module_Model', 'Vtiger_Util_Helper', 
+			'ZEND_JSON', 'Zend_Json', 'Zend_JSON', 'ZEND_json',
+			'Vtiger_Theme', 'Users_Record_Model', 'Vtiger_Module_Model', 'Vtiger_Field_Model', 'Vtiger_Record_Model',
+			'Settings_Picklist_Module_Model', 'CustomView_Record_Model', 'Vtiger_Extension_View',
+			'Vtiger_Tag_Model', 'Settings_Vtiger_Module_Model', 'PBXManager_Server_Model',
+			'Vtiger_Functions', 'Users', 'CurrencyField', 'Reports_Field_Model', 
+			'DateTimeField', 'Calendar_Time_UIType', 'Calendar_Field_Model',
+			'Vtiger_Date_UIType', 'Vtiger_Time_UIType', 'Vtiger_RelationListView_Model',
+			'Inventory_TaxRegion_Model', 'EmailTemplates_Module_Model');
+
+		if ($inSettings) {
+			$classes = array_merge($classes, array(
+				'getInventoryModules', 'Settings_Vtiger_MenuItem_Model', 'Settings_Webforms_Record_Model',
+				'Settings_Vtiger_CompanyDetails_Model', 'Inventory_Charges_Model', 'Settings_PBXManager_Module_Model',
+				'PBXManager_PBXManager_Connector', 'Settings_Webforms_Record_Model', 'Google_Config_Connector'
+			));
+		}
+
+		foreach ($classes as $clazz) {
+			if (class_exists($clazz)) {
+				$this->registerClass($clazz, $clazz);
+			}
+		}
+
+		$modifiers = array('vtranslate', 'vtlib_isModuleActive', 'vimage_path', 'strstr', 'stripos', 'strpos', 'date', 'vtemplate_path', 'vresource_url', 
+			'html_entity_decode', 'decode_html', 'vtlib_purify', 'php7_count', 'getUserFullName', 'array_flip', 'explode', 'trim', 'array_push', 'array_merge',
+			'array_map', 'array_key_exists', 'get_class', 'vtlib_array', 'getDuplicatesPreventionMessage', 'htmlentities', 'purifyHtmlEventAttributes',
+			'getCurrencySymbolandCRate', 'getProductBaseCurrency', 'mb_substr', 'isPermitted', 'getOwnerName', 'getEntityName', 'function_exists', 'php7_trim', 'php7_htmlentities',
+			'strtolower', 'strtoupper', 'str_replace', 'urlencode', 'getTranslatedCurrencyString', 'getTranslatedString', 'is_object', 'is_numeric','preg_match',
+			'php7_sizeof', 'method_exists','implode','mt_rand','substr','in_array','array_keys', 'json_decode', 'getCurrencyDecimalPlaces', 'number_format', 'isRecordExists');
+		
+		foreach ($modifiers as $modifier) {
+			if (function_exists($modifier)) {
+				$this->registerPlugin(\Smarty::PLUGIN_MODIFIER, $modifier, $modifier);
+			}
+		}
 	}
 
 	// Backward compatible to SmartyBC
@@ -110,7 +150,7 @@ class Vtiger_Viewer extends Smarty {
 	 * @return <String> - Module specific template path if exists, otherwise default template path for the given template name
 	 */
 	public function getTemplatePath($templateName, $moduleName='') {
-		$moduleName = str_replace(':', '/', $moduleName);
+		$moduleName = isset($moduleName) ? str_replace(':', '/', $moduleName) : '';
 		$completeFilePath = $this->getTemplateDir(0). DIRECTORY_SEPARATOR . "modules/$moduleName/$templateName";
 		if(!empty($moduleName) && file_exists($completeFilePath)) {
 			return "modules/$moduleName/$templateName";

--- a/includes/runtime/Viewer.php
+++ b/includes/runtime/Viewer.php
@@ -82,13 +82,13 @@ class Vtiger_Viewer extends Smarty {
 			'Vtiger_Functions', 'Users', 'CurrencyField', 'Reports_Field_Model', 
 			'DateTimeField', 'Calendar_Time_UIType', 'Calendar_Field_Model',
 			'Vtiger_Date_UIType', 'Vtiger_Time_UIType', 'Vtiger_RelationListView_Model',
-			'Inventory_TaxRegion_Model', 'EmailTemplates_Module_Model');
+			'Inventory_TaxRegion_Model', 'EmailTemplates_Module_Model', 'Project_Record_Model', 'Settings_SMSNotifier_ProviderField_Model',);
 
 		if ($inSettings) {
 			$classes = array_merge($classes, array(
 				'getInventoryModules', 'Settings_Vtiger_MenuItem_Model', 'Settings_Webforms_Record_Model',
 				'Settings_Vtiger_CompanyDetails_Model', 'Inventory_Charges_Model', 'Settings_PBXManager_Module_Model',
-				'PBXManager_PBXManager_Connector', 'Settings_Webforms_Record_Model', 'Google_Config_Connector'
+				'PBXManager_PBXManager_Connector', 'Settings_Webforms_Record_Model', 'Google_Config_Connector', 'Settings_LayoutEditor_Module_Model',
 			));
 		}
 
@@ -98,12 +98,13 @@ class Vtiger_Viewer extends Smarty {
 			}
 		}
 
-		$modifiers = array('vtranslate', 'vtlib_isModuleActive', 'vimage_path', 'strstr', 'stripos', 'strpos', 'date', 'vtemplate_path', 'vresource_url', 
+		$modifiers = array('vtranslate', 'vtlib_isModuleActive', 'vimage_path', 
+			'strstr', 'stripos', 'strpos', 'date', 'vtemplate_path', 'vresource_url', 
 			'html_entity_decode', 'decode_html', 'vtlib_purify', 'php7_count', 'getUserFullName', 'array_flip', 'explode', 'trim', 'array_push', 'array_merge',
 			'array_map', 'array_key_exists', 'get_class', 'vtlib_array', 'getDuplicatesPreventionMessage', 'htmlentities', 'purifyHtmlEventAttributes',
 			'getCurrencySymbolandCRate', 'getProductBaseCurrency', 'mb_substr', 'isPermitted', 'getOwnerName', 'getEntityName', 'function_exists', 'php7_trim', 'php7_htmlentities',
 			'strtolower', 'strtoupper', 'str_replace', 'urlencode', 'getTranslatedCurrencyString', 'getTranslatedString', 'is_object', 'is_numeric','preg_match',
-			'php7_sizeof', 'method_exists','implode','mt_rand','substr','in_array','array_keys', 'json_decode', 'getCurrencyDecimalPlaces', 'number_format', 'isRecordExists');
+			'php7_sizeof', 'method_exists','implode','mt_rand','substr','in_array','array_keys', 'json_decode', 'getCurrencyDecimalPlaces', 'number_format', 'isRecordExists', 'vtws_getOwnerType', 'ucwords', 'array_reverse', 'end', 'textlength_check', 'is_null', 'getTabid', 'array_slice', 'mb_strlen', 'strtotime');
 		
 		foreach ($modifiers as $modifier) {
 			if (function_exists($modifier)) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1226 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
Smarty v4.5以上をインストールすると、下記の例のようなDeprecated（非推奨）エラーが表示される場合がある。

エラー例：
Deprecated: Using unregistered function "vtranslate" in a template is deprecated and will be removed in a future release. Use Smarty::registerPlugin to explicitly register a custom modifier. in /var/www/html/F-RevoCRM/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatecompilerbase.php on line 663

##  原因 / Cause
<!-- バグの原因を記述 -->
Smarty v5.0.0から事前に関数などの登録を必須にする実装の変更が予定されているため、v4.5から非推奨エラーを通知するようになった。
https://github.com/smarty-php/smarty/discussions/967

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
Smartyで利用する関数などを事前に登録するように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
Smartyを利用して表示を行っているView全て

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
