### PR TITLE
thinkingreed-inc#1228 項目設定で設定したデフォルト値「0」が編集画面でセットされない不具合修正

### DIFF
--- a/modules/Calendar/models/EditRecordStructure.php
+++ b/modules/Calendar/models/EditRecordStructure.php
@@ -66,7 +66,7 @@ class Calendar_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mode
 							}
 							if ($fieldValue == '') {
 								$defaultValue = $fieldModel->getDefaultFieldValue();
-								if ($defaultValue && !$recordId) {
+								if ($defaultValue != "" && !$recordId) {
 									$defaultValue = $fieldModel->getDefaultFieldValue();
 									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
 										$fieldValue = date('Y-m-d');

--- a/modules/Dailyreports/models/EditRecordStructure.php
+++ b/modules/Dailyreports/models/EditRecordStructure.php
@@ -38,7 +38,7 @@ class Dailyreports_EditRecordStructure_Model extends Vtiger_EditRecordStructure_
 							$fieldModel->set('fieldvalue', $recordModel->get($fieldName));
 						}else{
 							$defaultValue = $fieldModel->getDefaultFieldValue();
-							if(!empty($defaultValue) && !$recordId)
+							if($defaultValue != "" && !$recordId)
 								$fieldModel->set('fieldvalue', $defaultValue);
 							if($fieldName == "reports_to_id") {
 							    if( $current_user->reports_to_id > 0 ) {

--- a/modules/Inventory/models/EditRecordStructure.php
+++ b/modules/Inventory/models/EditRecordStructure.php
@@ -40,7 +40,7 @@ class Inventory_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mod
 								$fieldValue = $recordModel->getInventoryTermsAndConditions();
 							} else if($fieldValue == '') {
                                 $defaultValue = $fieldModel->getDefaultFieldValue();
-                                if(!empty($defaultValue) && !$recordId){
+                                if($defaultValue != "" && !$recordId){
 									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
 										$fieldValue = date('Y-m-d');
 									}

--- a/modules/Vtiger/models/EditRecordStructure.php
+++ b/modules/Vtiger/models/EditRecordStructure.php
@@ -37,7 +37,7 @@ class Vtiger_EditRecordStructure_Model extends Vtiger_RecordStructure_Model {
 							$fieldModel->set('fieldvalue', $recordModel->get($fieldName));
 						}else{
 							$defaultValue = $fieldModel->getDefaultFieldValue();
-							if(!empty($defaultValue) && !$recordId)
+							if($defaultValue != "" && !$recordId)
 								if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
 									$fieldModel->set('fieldvalue', date('Y-m-d'));
 								}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1228

##  不具合の内容 / Bug
1. 項目設定でデフォルト値「0」を設定しても、新規作成画面に「0」がセットされない

##  原因 / Cause
1. デフォルト値の存在チェックでempty関数が使用されていた。
　empty関数は0をfalseと判定するため、不具合が発生

##  変更内容 / Details of Change
1. デフォルト値の存在チェックは != "" で行うように修正

## スクリーンショット / Screenshot
![image](https://github.com/user-attachments/assets/151108f3-49b7-4072-ba89-147372ad2653)

顧客企業の企業形態のデフォルト値を「0」に設定
![image](https://github.com/user-attachments/assets/c835fdbd-d62c-4ba2-9c4b-834afe2fba75)


## 影響範囲  / Affected Area
modules/Calendar/models/EditRecordStructure.php
modules/Dailyreports/models/EditRecordStructure.php
modules/Inventory/models/EditRecordStructure.php
modules/Vtiger/models/EditRecordStructure.php

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [×] 自らテストを行った
- [×] 不必要な変更が無い
- [×] 影響範囲の検討を行った

## 備考 / Remarks
なし