### PR TITLE
#1231 全検索を使ってリードを出すとき、Convertedされたレコードが正しく紐づかず、表示されるべきレコードが不適格になる不具合の修正

### DIFF
--- a/modules/Leads/models/Module.php
+++ b/modules/Leads/models/Module.php
@@ -328,11 +328,12 @@ class Leads_Module_Model extends Vtiger_Module_Model {
 		$convertedInfo = array();
 		if ($recordIdsList) {
 			$db = PearDatabase::getInstance();
-			$result = $db->pquery("SELECT converted FROM vtiger_leaddetails WHERE leadid IN (".generateQuestionMarks($recordIdsList).")", $recordIdsList);
+			$result = $db->pquery("SELECT leadid, converted FROM vtiger_leaddetails WHERE leadid IN (".generateQuestionMarks($recordIdsList).")", $recordIdsList);
 			$numOfRows = $db->num_rows($result);
 
 			for ($i=0; $i<$numOfRows; $i++) {
-				$convertedInfo[$recordIdsList[$i]] = $db->query_result($result, $i, 'converted');
+				$leadid = $db->query_result($result, $i, 'leadid');
+				$convertedInfo[$leadid] = $db->query_result($result, $i, 'converted');
 			}
 		}
 		return $convertedInfo;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1231 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 全検索時、リードだけ表示されるべきものが正しくない

##  原因 / Cause
<!-- バグの原因を記述 -->
convertedを判定して、出すものと出さないものを仕分けしているが、連想配列で値を持ったときにIDに対するConvertedの結果が必ずしも正しくならないコードとなっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. DBからleadidを取得し、それをキーとして、ValueにConvertedの値をいれるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
単純な一覧では使われていないが、 `Vtiger_Record_Model::getSearchResult` を利用し、ラベルで全体を当てる処理がある場合に発生する可能性がある。
- Leads
- Products
- 全検索

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->