### PR TITLE
#1219 一括編集でバリデーションが効くように修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/List.js
+++ b/layouts/v7/modules/Vtiger/resources/List.js
@@ -1262,11 +1262,15 @@ Vtiger.Class("Vtiger_List_Js", {
 			var editInstance = Vtiger_Edit_Js.getInstance();
 			editInstance.registerBasicEvents(container);
 			var form_original_data = $("#massEdit").serialize();
-			$('#massEdit').on('submit', function (event) {
-				thisInstance.saveMassEdit(event, form_original_data, isOwnerChanged);
-				isOwnerChanged = false;
+			$('#massEdit').vtValidate({
+				ignore: '.ignore-validation',
+				submitHandler: function (form) {
+					thisInstance.saveMassEdit(e, form_original_data, isOwnerChanged);
+					isOwnerChanged = false;
+					return false; 
+				}
 			});
-			
+
 			//automatically select fields for mass edit when updated
 			$('#massEdit :input').change(function() {
 				var _replacedName =  $(this).attr('name').replace('[]', "");
@@ -1275,6 +1279,17 @@ Vtiger.Class("Vtiger_List_Js", {
 				}
 				$(this).closest('tr').find("input[id^=include_in_mass_edit_" + _replacedName + "]").prop( "checked", true );
 			});
+
+			function addIgnoreValidation() {
+				$('#massEdit input[type="checkbox"]').each(function() {
+					let fieldname = $(this).attr('data-update-field');
+					$(`[name="${fieldname}"]`)[$(this).is(':checked') ? 'removeClass' : 'addClass']('ignore-validation');
+					$(`[name="${fieldname}_display"]`)[$(this).is(':checked') ? 'removeClass' : 'addClass']('ignore-validation');
+				});
+			}
+			
+			addIgnoreValidation();
+			$('#massEdit').on('change', 'input[type="checkbox"]', addIgnoreValidation);
 			
 			app.helper.registerLeavePageWithoutSubmit($("#massEdit"));
 			app.helper.registerModalDismissWithoutSubmit($("#massEdit"));

--- a/modules/Inventory/models/MassEditRecordStructure.php
+++ b/modules/Inventory/models/MassEditRecordStructure.php
@@ -34,11 +34,11 @@ class Inventory_MassEditRecordStructure_Model extends Vtiger_MassEditRecordStruc
 				foreach($fieldModelList as $fieldName=>$fieldModel) {
 					if($fieldModel->isEditable() && $fieldModel->isMassEditable()) {
 						if($fieldModel->isViewable() && $this->isFieldRestricted($fieldModel)) {
-							if ($fieldModel->isMandatory()) {
-								$dataType = $fieldModel->get('typeofdata');
-								$explodeDataType = explode('~', $dataType);
-								$fieldModel->set('typeofdata', $explodeDataType[0] . '~O');
-							}
+							// if ($fieldModel->isMandatory()) {
+							// 	$dataType = $fieldModel->get('typeofdata');
+							// 	$explodeDataType = explode('~', $dataType);
+							// 	$fieldModel->set('typeofdata', $explodeDataType[0] . '~O');
+							// }
 
 							if($recordExists) {
 								$fieldModel->set('fieldvalue', $recordModel->get($fieldName));

--- a/modules/Vtiger/models/MassEditRecordStructure.php
+++ b/modules/Vtiger/models/MassEditRecordStructure.php
@@ -34,11 +34,11 @@ class Vtiger_MassEditRecordStructure_Model extends Vtiger_EditRecordStructure_Mo
 				foreach($fieldModelList as $fieldName=>$fieldModel) {
 					if($fieldModel->isEditable() && $fieldModel->isMassEditable()) {
 						if($fieldModel->isViewable() && $this->isFieldRestricted($fieldModel)) {
-							if ($fieldModel->isMandatory()) {
-								$dataType = $fieldModel->get('typeofdata');
-								$explodeDataType = explode('~', $dataType);
-								$fieldModel->set('typeofdata', $explodeDataType[0] . '~O');
-							}
+							// if ($fieldModel->isMandatory()) {
+							// 	$dataType = $fieldModel->get('typeofdata');
+							// 	$explodeDataType = explode('~', $dataType);
+							// 	$fieldModel->set('typeofdata', $explodeDataType[0] . '~O');
+							// }
 
 							if($recordExists) {
 								$fieldModel->set('fieldvalue', $recordModel->get($fieldName));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1219

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一括編集画面でバリデーション効かず、必須項目でも空で送信できる状態だった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 一括編集のsubmitやテンプレートからバリデーションを外していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. チェックボタンがついた項目にのみvalidation.jsの機能が効くように修正

## スクリーンショット / Screenshot
- チェックボックス未選択
![image](https://github.com/user-attachments/assets/2b58c3ac-bb4f-4a57-a68f-4a62990e6e8c)

- 必須項目未入力
![image](https://github.com/user-attachments/assets/30308e87-135e-4e76-8a1c-772f34a0c588)

- URL形式不正
![image](https://github.com/user-attachments/assets/5c79bed9-d505-4958-9f3d-1dc302fe9f7e)


## 影響範囲  / Affected Area
すべての一括編集モーダル

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->