### PR TITLE
レコードの抽出条件を設定したリストを開いた際にFatalErrorが発生する場合がある 不具合の修正

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1308,7 +1308,7 @@ class QueryGenerator {
 		if(is_string($value)) {
 			$value = trim($value);
 		} elseif(is_array($value)) {
-			$value = array_map(trim, $value);
+			$value = array_map('trim', $value);
 		}
 		return array('name'=>$fieldname,'value'=>$value,'operator'=>$operator);
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1234 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レコードの抽出条件を設定したリストを開いた際にFatalErrorが発生する場合がある。

##  原因 / Cause
<!-- バグの原因を記述 -->
array_mapの第一引数の渡し方が不適切だったため。
DBを検索する際の条件として複数の値を使う場合に、検索に使用する値が配列で渡ってくる。
配列に対してarray_mapでそれぞれの値にtrimかを実行しているが、このtrimの渡し方が不適切だったためエラーが発生した。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
array_mapの第一引数の渡し方を修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
SQL発行時に検索条件の値が範囲になる場合

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った