### PR TITLE
選択肢の連動設定を行うと選択肢の順番が入れ替わる場合がある不具合の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Edit.js
+++ b/layouts/v7/modules/Vtiger/resources/Edit.js
@@ -224,21 +224,29 @@ Vtiger_Index_Js("Vtiger_Edit_Js",{
 					listOfAvailableOptions = jQuery('option',targetPickList);
 					targetPickList.data('available-options', listOfAvailableOptions);
 				}
-				
-				var targetOptions = new jQuery();
+
+				var targetOptions = [];                
 				var optionSelector = [];
+                var targetPickListSelectedValue = '';
+                
 				optionSelector.push('');
 				for(var i=0; i<targetPickListMap.length; i++){
 					optionSelector.push(targetPickListMap[i]);
 				}
+                
 				jQuery.each(listOfAvailableOptions, function(i,e) {
 					var picklistValue = jQuery(e).val();
 					if(jQuery.inArray(picklistValue, optionSelector) != -1) {
-						targetOptions = targetOptions.add(jQuery(e));
+                        var optionObj = jQuery(e);
+                        // 選択済みの選択肢の値を取得する
+                        // あとで選択状態にするため
+                        if(optionObj.prop("selected")) {
+                            targetPickListSelectedValue = optionObj.val();
+                        }
+                        targetOptions.push(optionObj);
 					}
 				})
-				var targetPickListSelectedValue = '';
-				var targetPickListSelectedValue = targetOptions.filter('[selected]').val();
+                
                 if(targetPickListMap.length == 1) { 
                     var targetPickListSelectedValue = targetPickListMap[0]; // to automatically select picklist if only one picklistmap is present.
                 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1239 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
選択肢の連動設定がされた選択項目の連動元の選択肢の値を複数回変更すると連動先の選択肢の順番が入れ替わってしまうことがある。

##  原因 / Cause
<!-- バグの原因を記述 -->
Option要素オブジェクトの順番が処理の際に入れ替わってしまうことがある。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
Option要素オブジェクトを保持する方法を、順番が保証されないオブジェクトから順番が保証される配列に変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
選択肢連動設定がされた単数選択項目

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
