### PR TITLE
クイック作成メニューのレイアウトが崩れる不具合の修正

### DIFF
--- a/modules/Vtiger/models/Menu.php
+++ b/modules/Vtiger/models/Menu.php
@@ -61,6 +61,9 @@ class Vtiger_Menu_Model extends Vtiger_Module_Model {
 
 		foreach ($allModules as $module) {
 			if (($userPrivModel->isAdminUser() || $userPrivModel->hasGlobalReadPermission() || $userPrivModel->hasModulePermission($module->getId())) && !in_array($module->getName(), $restrictedModulesList) && $module->get('parent') != '') {
+				if(!$module->isPermitted('CreateView') && $module->isPermitted('EditView')) {
+					continue;
+				}
 				$menuModels[$module->getName()] = $module;
 			}
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1241 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
クイック作成メニューのレイアウトが権限の設定によっては崩れて表示される場合がある。

##  原因 / Cause
<!-- バグの原因を記述 -->
クイック作成のメニューを作成する際に、クイック作成が利用できないモジュールの情報もテンプレートエンジンに渡されており、その影響でクイック作成のメニューのレイアウトが 崩れていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
テンプレートエンジンに不要なモジュールの情報を渡さないように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/819c2ae3-c623-408c-9c0f-9788e0a0d896)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
クイック作成メニュー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->