### PR TITLE
1244 関連モジュールの値を利用して表現式のワークフローを動作させるとFatalErrorが発生する不具合の修正

### DIFF
--- a/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
+++ b/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc
@@ -158,7 +158,7 @@ class VTUpdateFieldsTask extends VTTask {
                     if (php7_count($matches1) == 0) {
                         preg_match('/\((\w+) : \((\w+)\) (\w+)/', $fieldValue, $matches1);
                     }
-					if(count($matches1) > 0){
+					if(php7_count($matches1) > 0){
 						$referenceField = $matches1[1];
 						$referencedModule = $matches1[2];
 						$referencedFieldName = $matches1[3];
@@ -378,7 +378,7 @@ class VTUpdateFieldsTask extends VTTask {
 								$webserviceObject = VtigerWebserviceObject::fromName($adb, 'Users');
 								$fieldValueInDB = vtws_getId($webserviceObject->getEntityId(), $fieldValueRaw);
 								$fieldValueInDBArray = vtws_getIdComponents($fieldValueInDB);
-								$fieldValueInDB = $fieldValueInDBArray[count($fieldValueInDBArray) - 1];
+								$fieldValueInDB = $fieldValueInDBArray[php7_count($fieldValueInDBArray) - 1];
 							}
 						}else {
 							$fieldValue = '';
@@ -399,13 +399,13 @@ class VTUpdateFieldsTask extends VTTask {
 
 					if (
 						$fieldValueType == 'fieldname'
-						&& (count($referenceList) > 0 || $rightOperandFieldType == "owner")
+						&& (php7_count($referenceList) > 0 || $rightOperandFieldType == "owner")
 						&& $fieldInstance->getFieldDataType() == 'reference'
 					) {
 						$_moduleFocus->column_fields[$fieldName] = $fieldValueRaw;
 					} else if (
 						$fieldValueType == 'expression'
-						&& (count($referenceList) > 0 || ($moduleFieldInstance && $moduleFieldInstance->getFieldDataType() == 'owner'))
+						&& (php7_count($referenceList) > 0 || ($moduleFieldInstance && $moduleFieldInstance->getFieldDataType() == 'owner'))
 						&& $fieldInstance->getFieldDataType() == 'reference'
 					) {
 						$_moduleFocus->column_fields[$fieldName] = $fieldValueRaw;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1224 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
Workflowの処理で関連が空の場合にFatalErrorが発生する

---以下エラー内容---
Fatal error: Uncaught TypeError: count(): Argument https://github.com/thinkingreed-inc/F-RevoCRM/issues/1 ($value) must be of type Countable|array, null given in /var/www/html/F-RevoCRM/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc:408
Stack trace: #0 /var/www/html/F-RevoCRM/modules/com_vtiger_workflow/VTWorkflowManager.inc(427): VTUpdateFieldsTask->doTask() https://github.com/thinkingreed-inc/F-RevoCRM/issues/1 /var/www/html/F-RevoCRM/modules/com_vtiger_workflow/VTEventHandler.inc(114): Workflow->performTasks() https://github.com/thinkingreed-inc/F-RevoCRM/issues/2 /var/www/html/F-RevoCRM/include/events/VTEventTrigger.inc(143): VTWorkflowEventHandler->handleEvent() https://github.com/thinkingreed-inc/F-RevoCRM/pull/3 /var/www/html/F-RevoCRM/include/events/VTEventsManager.inc(118): VTEventTrigger->trigger() https://github.com/thinkingreed-inc/F-RevoCRM/pull/4 /var/www/html/F-RevoCRM/data/CRMEntity.php(1076): VTEventsManager->triggerEvent() https://github.com/thinkingreed-inc/F-RevoCRM/issues/5 /var/www/html/F-RevoCRM/modules/Vtiger/models/Module.php(169): CRMEntity->save() https://github.com/thinkingreed-inc/F-RevoCRM/pull/6 /var/www/html/F-RevoCRM/modules/Vtiger/models/Record.php(261): Vtiger_Module_Model->saveRecord() https://github.com/thinkingreed-inc/F-RevoCRM/pull/7 /var/www/html/F-RevoCRM/modules/Vtiger/actions/Save.php(117): Vtiger_Record_Model->save() https://github.com/thinkingreed-inc/F-RevoCRM/pull/8 /var/www/html/F-RevoCRM/modules/Vtiger/actions/Save.php(54): Vtiger_Save_Action->saveRecord() https://github.com/thinkingreed-inc/F-RevoCRM/pull/9 /var/www/html/F-RevoCRM/modules/Potentials/actions/Save.php(24): Vtiger_Save_Action->process() https://github.com/thinkingreed-inc/F-RevoCRM/issues/10 /var/www/html/F-RevoCRM/includes/main/WebUI.php(226): Potentials_Save_Action->process() https://github.com/thinkingreed-inc/F-RevoCRM/pull/11 /var/www/html/F-RevoCRM/index.php(26): Vtiger_WebUI->process() https://github.com/thinkingreed-inc/F-RevoCRM/pull/12 {main} thrown in /var/www/html/F-RevoCRM/modules/com_vtiger_workflow/tasks/VTUpdateFieldsTask.inc on line 408

##  原因 / Cause
<!-- バグの原因を記述 -->
php8対応漏れ 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
php8に対応した処理に置き換え

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
項目更新を行うワークフロー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
