### PR TITLE
フォントファミリーをヒラギノ＞Noto＞メイリオ＞MSゴシックとなるように修正

### DIFF
--- a/layouts/v7/skins/contact/style.css
+++ b/layouts/v7/skins/contact/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/contact/style.css
+++ b/layouts/v7/skins/contact/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/inventory/style.css
+++ b/layouts/v7/skins/inventory/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/inventory/style.css
+++ b/layouts/v7/skins/inventory/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2466,6 +2466,7 @@ input[type="text"]:read-only {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7585,7 +7586,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/marketing/style.css
+++ b/layouts/v7/skins/marketing/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7586,7 +7586,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/marketing_and_sales/style.css
+++ b/layouts/v7/skins/marketing_and_sales/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7522,7 +7523,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/marketing_and_sales/style.css
+++ b/layouts/v7/skins/marketing_and_sales/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7523,7 +7523,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/project/style.css
+++ b/layouts/v7/skins/project/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/project/style.css
+++ b/layouts/v7/skins/project/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/sales/style.css
+++ b/layouts/v7/skins/sales/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/sales/style.css
+++ b/layouts/v7/skins/sales/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/support/style.css
+++ b/layouts/v7/skins/support/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/support/style.css
+++ b/layouts/v7/skins/support/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/tools/style.css
+++ b/layouts/v7/skins/tools/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -2420,6 +2420,7 @@ th {
   min-width: 100px;
   width: 20%;
   word-break: break-all;
+  font-weight: bold;
 }
 .editViewContents .fieldValue {
   width: 30%;
@@ -7529,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/tools/style.css
+++ b/layouts/v7/skins/tools/style.css
@@ -57,7 +57,7 @@ html {
 body {
   margin: 0;
   padding: 0;
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   font-weight: normal;
   font-style: normal;
@@ -72,7 +72,7 @@ body > .mCSB_inside > .mCSB_container {
   height: inherit;
 }
 .select2-container .select2-choice {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar {
   background: #fff;
@@ -7530,7 +7530,7 @@ input:focus:-ms-input-placeholder {
   padding: 4px 10px 4px 5px !important;
 }
 .menu-item .custom-module {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-size: 12px;
   border-radius: 4px;
   padding: 2px;

--- a/layouts/v7/skins/vtiger/style.less
+++ b/layouts/v7/skins/vtiger/style.less
@@ -68,7 +68,7 @@ html{
 body{
     margin: 0;
     padding: 0;
-    font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+    font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
     font-size : 12px;
     font-weight: normal;
     font-style: normal;
@@ -83,7 +83,7 @@ body > .mCSB_inside > .mCSB_container{
     height: inherit;
 }
 .select2-container .select2-choice{
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar{
     background: #fff;
@@ -8443,7 +8443,7 @@ input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
 	padding: 4px 10px 4px 5px !important
 }
 .menu-item .custom-module {
-	font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+	font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 	font-size: 12px;
 	border-radius: 4px;
 	padding: 2px;

--- a/layouts/v7/skins/vtiger/style.less
+++ b/layouts/v7/skins/vtiger/style.less
@@ -68,7 +68,7 @@ html{
 body{
     margin: 0;
     padding: 0;
-    font-family: 'OpenSans-Regular', sans-serif;
+    font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
     font-size : 12px;
     font-weight: normal;
     font-style: normal;
@@ -83,7 +83,7 @@ body > .mCSB_inside > .mCSB_container{
     height: inherit;
 }
 .select2-container .select2-choice{
-  font-family: 'OpenSans-Regular', sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 }
 .app-fixed-navbar{
     background: #fff;
@@ -8443,7 +8443,7 @@ input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
 	padding: 4px 10px 4px 5px !important
 }
 .menu-item .custom-module {
-	font-family: 'OpenSans-Regular', sans-serif;
+	font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
 	font-size: 12px;
 	border-radius: 4px;
 	padding: 2px;

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -3,7 +3,7 @@
 }
 
 body {
-  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
   font-weight: 400;
 }
 

--- a/resources/styles.css
+++ b/resources/styles.css
@@ -2,6 +2,11 @@
   clear: both;
 }
 
+body {
+  font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Hiragino Kaku Gothic Pro", "Noto Sans JP", "Noto Sans CJK JP", "Meiryo", "MS PGothic", "MS Gothic", sans-serif;
+  font-weight: 400;
+}
+
 /* 
  *一覧画面の列幅可変機能追加に伴う修正
  */


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1243 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 意図しないほど細いフォントが一部利用される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Noto SansのWindows追加＋ChromeによるFont利用の変更

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. font-familyを定義

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
![image](https://github.com/user-attachments/assets/252cdce9-41e4-4ea4-80e7-07884fa557ab)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
表示に関連する場所全て

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
全ての影響範囲を追いきれているかは不安が残ります。
すぐわかる表示崩れは確認できませんでした。