### PR TITLE
1225 ごみ箱削除時に関係のないレコードが消える不具合を修正

### DIFF
--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -242,7 +242,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 
 		$listQuery = $queryGenerator->getQuery();
 		if($module == 'RecycleBin'){
-			$listQuery = preg_replace("/vtiger_crmentity.deleted\s*=\s*0/i", 'vtiger_crmentity.deleted = 1', $listQuery);
+			$listQuery = preg_replace("/$baseTableName.deleted\s*=\s*0/i", "$baseTableName.deleted = 1", $listQuery);
 		}
 
 		if($skipRecords && !empty($skipRecords) && is_array($skipRecords) && php7_count($skipRecords) > 0) {

--- a/modules/RecycleBin/models/Module.php
+++ b/modules/RecycleBin/models/Module.php
@@ -268,13 +268,26 @@ class RecycleBin_Module_Model extends Vtiger_Module_Model {
 		 *  we have to delete emails if email is related to any $recordIds and same email is 
 		 *  not related to another record
 		 */
-		$query = "DELETE vtiger_crmentity.* FROM vtiger_crmentity INNER JOIN "
-				. "(SELECT vtiger_crmentity.crmid AS actid,vtiger_seactivityrel.crmid AS relid "
-				. "FROM vtiger_crmentity INNER JOIN vtiger_seactivityrel ON "
-				. "vtiger_seactivityrel.activityid=vtiger_crmentity.crmid "
-				. "GROUP BY vtiger_seactivityrel.activityid HAVING count(vtiger_seactivityrel.activityid) = 1)"
-				. " AS relationdata ON relationdata.actid=vtiger_crmentity.crmid "
-				. "WHERE relationdata.relid IN (" . generateQuestionMarks($recordIds) . ")";
+		$query = "DELETE 
+					  vtiger_crmentity, 
+					  vtiger_activity, 
+					  vtiger_emaildetails 
+				  FROM vtiger_crmentity 
+					  LEFT JOIN vtiger_activity
+						  ON vtiger_activity.activityid = vtiger_crmentity.crmid
+					  LEFT JOIN vtiger_emaildetails
+						  ON vtiger_emaildetails.emailid = vtiger_crmentity.crmid
+					  INNER JOIN (SELECT 
+									vtiger_crmentity.crmid AS actid,
+									vtiger_seactivityrel.crmid AS relid 
+								  FROM vtiger_crmentity 
+									  INNER JOIN vtiger_seactivityrel 
+										  ON vtiger_seactivityrel.activityid = vtiger_crmentity.crmid 
+								  GROUP BY vtiger_seactivityrel.activityid 
+								  HAVING count(vtiger_seactivityrel.activityid) = 1) AS relationdata 
+						  ON relationdata.actid = vtiger_crmentity.crmid 
+				  WHERE setype = 'Emails' 
+				  AND relationdata.relid IN (" . generateQuestionMarks($recordIds) . ")";
 
 		$db->pquery($query, array($recordIds));
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1225

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
案件件等の活動が紐づくレコードについて、一度詳細画面等から削除を行い
ゴミ箱を開き、そこから完全に削除を行うと、完全に削除したレコードと関係ない活動が削除される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 内部データの構造変更によるパフォーマンスチューニングの適用時にゴミ箱のリストのみ修正が漏れていた。そのため削除対象のレコードが正常に取得できていなかった。
2. 関連付く親のレコードを削除した際にメールのみを削除するはずが、活動などの他のレコードも対象になっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 条件に利用するテーブルの指定が正しく行われるように修正
2. メールのみに絞る条件を追加

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ゴミ箱での削除処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
