### PR TITLE
#1250 [不具合]既存のリストを編集時「項目と並び順の選択」が必須項目が勝手に後ろに移動する

### DIFF
--- a/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -82,7 +82,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 			var option = selectedOptions.filter('[value="'+value+'"]');
 			choicesList.each(function(choiceListIndex,element){
 				var liElement = jQuery(element);
-				if(liElement.find('div').html() == option.html()){
+				if(liElement.find('div').text() == option.text()){
 					choicesContainer.prepend(liElement);
 					return false;
 				}


### PR DESCRIPTION
　修正

##  関連Issue / Related Issue
- fix #1250 [不具合]既存のリストを編集時「項目と並び順の選択」が必須項目が勝手に後ろに移動する

##  不具合の内容 / Bug
1. 既存のリストを編集時「項目と並び順の選択」が必須項目が勝手に後ろに移動する

##  原因 / Cause
1. 「'」を置換する際に選択肢の再セットを行っているが、必須項目はhtml部分が含まれ正しく判定されていなかった。

##  変更内容 / Details of Change
1.  html部分を除き正しく判定するように修正

## スクリーンショット / Screenshot
- リスト画面
![image](https://github.com/user-attachments/assets/83f20ff0-6eed-4a0a-9c11-22249bb696d6)
- 編集時
![image](https://github.com/user-attachments/assets/dfe02abd-2374-4c49-ae7b-66dcf82ee0ac)


## 影響範囲  / Affected Area
リストの編集時の「項目と並び順の選択」部分

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
