### PR TITLE
CalendarのICSエクスポートでエラー落ちする不具合の修正

### DIFF
--- a/modules/Calendar/iCal/iCalendar_properties.php
+++ b/modules/Calendar/iCal/iCalendar_properties.php
@@ -236,7 +236,7 @@ class iCalendar_property_method extends iCalendar_property {
     function is_valid_value($value) {
         // This is case-sensitive
         // Methods from RFC 2446
-        $methods == array('PUBLISH', 'REQUEST', 'REPLY', 'ADD', 'CANCEL', 'REFRESH', 'COUNTER', 'DECLINECOUNTER');
+        $methods = array('PUBLISH', 'REQUEST', 'REPLY', 'ADD', 'CANCEL', 'REFRESH', 'COUNTER', 'DECLINECOUNTER');
         return in_array($value, $methods);
     }
 }
@@ -704,7 +704,7 @@ class iCalendar_property_duration extends iCalendar_property {
         }
 
         // Value must be positive
-        return ($value{0} != '-');
+        return ($value[0] != '-');
     }
 }
 
@@ -727,11 +727,11 @@ class iCalendar_property_freebusy extends iCalendar_property {
         }
 
         $pos = strpos($value, '/'); // We know there's only one / in there
-        if($value{$pos - 1} != 'Z') {
+        if($value[pos - 1] != 'Z') {
             // Start time MUST be in UTC
             return false;
         }
-        if($value{$pos + 1} != 'P' && $substr($value, -1) != 'Z') {
+        if($value[pos + 1] != 'P' && $value[-1] != 'Z') {
             // If the second part is not a period, it MUST be in UTC
             return false;
         }
@@ -1164,13 +1164,13 @@ class iCalendar_property_request_status extends iCalendar_property {
         $escch = false;
 
         for($i = 0; $i < $len; ++$i) {
-            if($value{$i} == ';' && !$escch) {
+            if($value[$i] == ';' && !$escch) {
                 // Token completed
                 $parts[] = substr($value, $from, $i - $from);
                 $from = $i + 1;
                 continue;
             }
-            $escch = ($value{$i} == '\\');
+            $escch = ($value[$i] == '\\');
         }
         // Add one last token with the remaining text; if the value
         // ended with a ';' it was illegal, so check that this token
@@ -1191,23 +1191,23 @@ class iCalendar_property_request_status extends iCalendar_property {
             return false;
         }
 
-        if($parts[0]{0} < '1' || $parts[0]{0} > '4') {
+        if($parts[0][0] < '1' || $parts[0][0] > '4') {
             return false;
         }
 
         $len = strlen($parts[0]);
 
         // Max 3 levels, and can't end with a period
-        if($len > 5 || $parts[0]{$len - 1} == '.') {
+        if($len > 5 || $parts[0][$len - 1] == '.') {
             return false;
         }
 
         for($i = 1; $i < $len; ++$i) {
-            if(($i & 1) == 1 && $parts[0]{$i} != '.') {
+            if(($i & 1) == 1 && $parts[0][$i] != '.') {
                 // Even-indexed chars must be periods
                 return false;
             }
-            else if(($i & 1) == 0 && ($parts[0]{$i} < '0' || $parts[0]{$i} > '9')) {
+            else if(($i & 1) == 0 && ($parts[0][$i] < '0' || $parts[0][$i] > '9')) {
                 // Odd-indexed chars must be numbers
                 return false;
             }
@@ -1231,8 +1231,8 @@ class iCalendar_property_request_status extends iCalendar_property {
             $parts[$i] .= '#'; // This guard token saves some conditionals in the loop
 
             for($j = 0; $j < $len; ++$j) {
-                $thischar = $parts[$i]{$j};
-                $nextchar = $parts[$i]{$j + 1};
+                $thischar = $parts[$i][$j];
+                $nextchar = $parts[$i][$j + 1];
                 if($thischar == '\\') {
                     // Next char must now be one of ";,\nN"
                     if($nextchar != ';' && $nextchar != ',' && $nextchar != '\\' &&


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1237 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーエクスポートでICSファイルを選択したとき、FatalErrorで落ちる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. PHP7.4以降、curly braceを使った配列アクセスが不可となっていた為

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 該当コードのcurly brace部分を変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーエクスポートの範囲のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->