### PR TITLE
fix #1278 cronタスクが同時実行されないように修正

### DIFF
--- a/modules/Settings/CronTasks/models/Record.php
+++ b/modules/Settings/CronTasks/models/Record.php
@@ -81,9 +81,15 @@ class Settings_CronTasks_Record_Model extends Settings_Vtiger_Record_Model {
      * Detect if the task was started by never finished.
      */
     function hadTimedout() {
-        if($this->get('lastend') === 0 && $this->get('laststart') != 0)
-        return intval($this->get('lastend'));
-    }
+		$laststart = intval($this->get('laststart'));
+		$lastend = intval($this->get('lastend'));
+		$retryTimeout = intval($this->get('retry_timeout'));
+		$currentTime = time();
+		if($laststart > 0 && $lastend === 0 && $currentTime - $laststart > $retryTimeout) {
+			return true;
+		}
+		return false;
+	}
     
     /**
      * Get the user datetimefeild

--- a/setup/scripts/80_Add_CronRetryTimeout.php
+++ b/setup/scripts/80_Add_CronRetryTimeout.php
@@ -16,12 +16,12 @@ if ($adb->num_rows($result) == 0) {
 }
 // 各タスクに対するリトライタイムアウトを設定
 $tasks = array(
-    'Workflow' => 60*60,
-    'RecurringInvoice' => 5*60*60,
-    'SendReminder' => 60*60,
-    'MailScanner' => 60*60,
-    'Scheduled Import' => 24*60*60,
-    'ScheduleReports' => 3*60*60,
+    'Workflow' => 60*60,            // 1 hour
+    'RecurringInvoice' => 24*60*60, // 24 hours
+    'SendReminder' => 60*60,        // 1 hour
+    'MailScanner' => 60*60,         // 1 hour
+    'Scheduled Import' => 6*60*60,  // 6 hours
+    'ScheduleReports' => 3*60*60,   // 3 hours
 );
 foreach ($tasks as $task => $timeout) {
     $adb->pquery('UPDATE vtiger_cron_task SET retry_timeout = ? WHERE name = ?', array($timeout, $task));

--- a/setup/scripts/80_Add_CronRetryTimeout.php
+++ b/setup/scripts/80_Add_CronRetryTimeout.php
@@ -1,0 +1,29 @@
+<?php
+$Vtiger_Utils_Log = true;
+include_once('vtlib/Vtiger/Menu.php');
+include_once('vtlib/Vtiger/Module.php');
+include_once('modules/PickList/DependentPickListUtils.php');
+include_once('modules/ModTracker/ModTracker.php');
+include_once('include/utils/CommonUtils.php');
+require_once('setup/utils/FRFilterSetting.php');
+$log->debug("[START] Add cron retry timeout column.\n");
+global $adb;
+// vtiger_cron_taskテーブルにretry_timeoutカラムが存在しているかチェック
+$result = $adb->pquery('SHOW COLUMNS FROM vtiger_cron_task LIKE ?', array('retry_timeout'));
+if ($adb->num_rows($result) == 0) {
+    // 存在していない場合は追加
+    $adb->query('ALTER TABLE vtiger_cron_task ADD COLUMN retry_timeout INT DEFAULT 0');
+}
+// 各タスクに対するリトライタイムアウトを設定
+$tasks = array(
+    'Workflow' => 60*60,
+    'RecurringInvoice' => 5*60*60,
+    'SendReminder' => 60*60,
+    'MailScanner' => 60*60,
+    'Scheduled Import' => 24*60*60,
+    'ScheduleReports' => 3*60*60,
+);
+foreach ($tasks as $task => $timeout) {
+    $adb->pquery('UPDATE vtiger_cron_task SET retry_timeout = ? WHERE name = ?', array($timeout, $task));
+}
+$log->debug("[END] Add cron retry timeout column.\n");

--- a/vtlib/Vtiger/Cron.php
+++ b/vtlib/Vtiger/Cron.php
@@ -253,8 +253,14 @@ class Vtiger_Cron {
 	 * Detect if the task was started by never finished.
 	 */
 	function hadTimedout() {
-		if($this->data['lastend'] === 0 && $this->data['laststart'] != 0)
-		return intval($this->data['lastend']);
+		$laststart = intval($this->data['laststart']);
+		$lastend = intval($this->data['lastend']);
+		$retryTimeout = intval($this->data['retry_timeout']);
+		$currentTime = time();
+		if($laststart > 0 && $lastend === 0 && $currentTime - $laststart > $retryTimeout) {
+			return true;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1278 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. スケジューラの周期をDB修正で短時間（1分等）に設定する
2. vtigercron.shの周期を短時間（1分等）に設定する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. スケジューラの周期は最低15分で制御が入っているが、DB修正等で短時間にすると、cronが多重実行されてしまう。
2. 最低周期である15分の場合でもスケジュールインポート等で時間がかかってしまう場合にも発生してしまう。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. スケジューラが実行中ステータスの場合は同様のスケジューラを実行しないよう修正
2. 何らかの影響で前回処理が実行中ステータスのまま終了してしまった場合を考慮し、リトライタイムアウト時間をスケジューラの設定用DBに追加

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
スケジューラ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->