### PR TITLE
活動の重複検出アラートのメッセージに表示「非公開」設定が適用されない

### DIFF
--- a/languages/en_us/Events.php
+++ b/languages/en_us/Events.php
@@ -110,6 +110,6 @@ $languageStrings = array(
 
 	'OVERLAPPING_EXISTS' => 'Activities with overlapping periods are registered',
 	'OVERLAPPING_CONFIRME_MSG' => 'Do you want to save this activity?',
-	'OVERLAPPING_EVENTS' => 'Activities with overlapping periods (showing up to %s)',
-	'OVERLAPPING_EVENT_USERS' => 'Users and participants of overlapping activities',
+	'OVERLAPPING_EVENTS' => 'Overlapping activities (up to %s shown)',
+	'OVERLAPPING_EVENT_USERS' => 'Assignees and participants of overlapping activities',
 );


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1291 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
活動レコード保存時の重複検出アラートのメッセージ内に、表示を「非公開」に設定した活動レコードのタイトルが表示されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
表示が「非公開」に設定されている場合の考慮がされていなかったため、重複検出アラートのメッセージにタイトルがそのまま表示されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
表示が「非公開」に設定されている場合は、表示内容を以下のように変更する
- タイトルを「予定あり」に置換
- リンクによる遷移ができないように変更
- 活動のカレンダーや一覧表示に準拠するため、開始日時、終了日時、担当者項目の値は非表示にしない

ただし、以下の場合おいては「非公開」にしても「公開」と同じ扱いとする（活動の表示条件に準拠）
- ログイン中のユーザーが活動レコードの担当者に設定されているユーザーである（参加者として登録されている場合も含む）
- ログイン中のユーザーが「システム管理者権限」を持つユーザである
- ユーザーに設定されているプロファイルが「管理者」かつ、プロファイル設定にて「すべて表示」または「すべて編集」のどちらかが有効な場合

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
- 予定登録者またはシステム管理者など「非公開」でも予定が見られる場合
![image](https://github.com/user-attachments/assets/2ad6b1a9-657f-4e4f-8ba3-ecfa5d034b87)

- 「非公開」設定が適用されるユーザの場合 
![image](https://github.com/user-attachments/assets/c158c4bc-7ee1-4523-9fad-18b247d00a89)

画像内の活動レコードは以下の設定で登録（テスト2を変更することでアラートを発生させている）
-  テスト1
　担当と参加者：システム管理者、テスト太郎
　表示：非公開
- テスト2　
　担当と参加者：システム管理者、テスト太郎、テスト次郎
　表示：公開
- テスト3
　担当と参加者：システム管理者、テスト太郎、テスト次郎
　表示：公開

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
活動レコードの重複チェック機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った