### PR TITLE
Emailに複数ファイルを添付できない不具合の修正

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -220,7 +220,8 @@ class CRMEntity {
 		// temporary file will be deleted at the end of request
                 $log->debug("Upload status of file => $upload_status");
 		if ($save_file == true && $upload_status == true) {
-			if($attachmentType != 'Image' && $this->mode == 'edit') {
+			// Emailsモジュールでは複数の添付ファイルを付けることが可能なので、明示的削除したもの以外は消さない
+			if($attachmentType != 'Image' && $this->mode == 'edit' && $module !== 'Emails') {
 				//Only one Attachment per entity delete previous attachments
 				$res = $adb->pquery('SELECT vtiger_seattachmentsrel.attachmentsid FROM vtiger_seattachmentsrel 
 									INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = vtiger_seattachmentsrel.attachmentsid AND vtiger_crmentity.setype = ? 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1295 

##  不具合の内容 / Bug
メールを2回以上下書き保存すると、複数の添付ファイルを登録して保存できない不具合が発生する。

##  原因 / Cause
<!-- バグの原因を記述 -->
添付ファイルの保存に使用する共通のメソッドが、ドキュメントなど1対1の紐づき（ドキュメントレコード1に対して、ファイルが1 ）しか考慮していない実装だった。（UPSERT的な考え方）
このため、メールレコード編集時に元々添付されていたファイルや同時に複数添付された複数のファイルにおいて、紐づけが解除されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
関連するモジュールがEmailsの場合、すでに添付済みのファイルがあっても添付ファイル保存時に削除しないように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
 - 1回目の下書き保存後（添付ファイルは2個） 
![image](https://github.com/user-attachments/assets/ae5c07ba-e330-4228-904f-2871e007d836)
 - 2回目の下書き保存後（添付ファイルを1つ追加）
![image](https://github.com/user-attachments/assets/d5c6090b-4f30-4ca5-a4cf-86f7f35a82d1)
- 3回目の下書き保存後（添付ファイルを1つ削除）
![image](https://github.com/user-attachments/assets/666a71ce-a4d6-417a-8a99-e95256092a28)
 - 4回目の下書き保存後（添付ファイルを２つ追加）
![image](https://github.com/user-attachments/assets/e18fca7f-0062-4b12-bbbf-f62d906463ad)

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
Emailの添付ファイル更新処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った