### PR TITLE
インポートの項目設定時に最初の項目名の自動選択がされない不具合の修正

### DIFF
--- a/modules/Import/readers/CSVReader.php
+++ b/modules/Import/readers/CSVReader.php
@@ -24,10 +24,19 @@ class Import_CSVReader_Reader extends Import_FileReader_Reader {
 		return $combine; 
 	}
 
+	protected function cleanUpCsvValue(string $value, bool $isStripHtml = false): string
+    {
+        $value = preg_replace("/^\xEF\xBB\xBF/", "", $value);
+        $value = str_replace("\"", "", $value);
+        
+        return $isStripHtml ? trim(strip_tags(decode_html($value))) :  $value;
+    }
+
 	public function getFirstRowData($hasHeader=true) {
 		global $default_charset;
 
 		$fileHandler = $this->getFileHandler();
+		$fileEncoding = $this->request->get('file_encoding');
 
 		$headers = array();
 		$firstRowData = array();
@@ -36,11 +45,11 @@ class Import_CSVReader_Reader extends Import_FileReader_Reader {
 			if($currentRow == 0 || ($currentRow == 1 && $hasHeader)) {
 				if($hasHeader && $currentRow == 0) {
 					foreach($data as $key => $value) {
-						$headers[$key] = trim($this->convertCharacterEncoding(strip_tags(decode_html($value)), $this->request->get('file_encoding'), $default_charset));
+						$headers[$key] = $this->convertCharacterEncoding($this->cleanUpCsvValue($value, true), $fileEncoding, $default_charset);
 					}
 				} else {
 					foreach($data as $key => $value) {
-						$firstRowData[$key] = trim($this->convertCharacterEncoding(strip_tags(decode_html($value)), $this->request->get('file_encoding'), $default_charset));
+						$firstRowData[$key] = $this->convertCharacterEncoding($this->cleanUpCsvValue($value, true), $fileEncoding, $default_charset);
 					}
 					break;
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1306

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
インポート時の設定の「項目マッピング」で、CSVのヘッダー項目名とF-RevoCRMの項目名が一致している場合でも、最初の項目のみF-RevoCRMの項目名が自動選択されない場合がある。

##  原因 / Cause
<!-- バグの原因を記述 -->
インポートするCSVファイルの文字コードがBOM付きUTF-8の場合、最初の項目名にBOMが含まれており、F-RevoCRMの項目の選択肢と完全一致しなかったため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
インポート設定時に使われるCSVファイルから読み込んだ項目名からBOMを取り除く処理を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1443" height="576" alt="image" src="https://github.com/user-attachments/assets/8751c220-a7ba-4e02-9bd9-85cfad6719b1" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
インポート設定画面の項目マッチングの画面表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->