### PR TITLE
WIP: #1310 役割に基づいた選択肢が、一覧画面では絞られて表示されない不具合の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/uitypes/PickListFieldSearchView.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/PickListFieldSearchView.tpl
@@ -11,7 +11,7 @@
 -->*}
 {strip}
     {assign var=FIELD_INFO value=$FIELD_MODEL->getFieldInfo()}
-	{assign var=PICKLIST_VALUES value=$FIELD_INFO['picklistvalues']}
+	{assign var=PICKLIST_VALUES value=$FIELD_INFO['editablepicklistvalues']}
 	{assign var=FIELD_INFO value=Vtiger_Util_Helper::toSafeHTML(Zend_Json::encode($FIELD_INFO))}
     {assign var=SEARCH_VALUES value=explode(',',$SEARCH_INFO['searchValue'])}
     <div class="select2_search_div">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1310 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一覧画面で役割に基づいた選択肢が制御されず、全て表示されてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 一覧画面では、editablepiclistvaluesを利用していなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 一覧画面でのUI表示tplにて、 editablepicklistvaluesを利用するにように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
Admin
<img width="1109" height="466" alt="image" src="https://github.com/user-attachments/assets/aefe6006-b276-4ddc-a565-19cca14a6ca1" />

Manager
<img width="1033" height="494" alt="image" src="https://github.com/user-attachments/assets/7031c8a9-c51e-46ce-9444-8239ae690cf0" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
検索で利用する `PickListFieldSearchView.tpl` の範囲。
残： `StatusPicklistFieldSearchView.tpl` `ActrivityPicklistFieldSearchView.tpl` の確認

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->