### PR TITLE
#1222　クイック入力の日報アイコンの乱れを修正

### DIFF
--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -2051,7 +2051,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 
 		$moduleIcon = "<i class='vicon-$lowerModuleName' title='$title'></i>";
 		if ($this->source == 'custom') {
-			$moduleShortName = mb_substr(trim($title), 0, 2);
+			$moduleShortName = mb_substr(trim($title), 0, 1);
 			$moduleIcon = "<span class='custom-module' title='$title'>$moduleShortName</span>";
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1222 

##  不具合の内容 / Bug
1. クイック入力の日報の箇所でレイアウトが乱れる。

##  原因 / Cause
1. [コミット#069e68a](https://github.com/thinkingreed-inc/F-RevoCRM/commit/069e98a4c306f68d93df41e2df49e38e2b388d0f) にてアイコンを表示するメソッドが修正されていることが原因。
　1文字出力であった箇所を、2文字出力する仕様にしている。

##  変更内容 / Details of Change
1. 1文字出力に戻す。

## スクリーンショット / Screenshot
修正前
<img width="1084" height="655" alt="スクリーンショット 2025-08-20 155542" src="https://github.com/user-attachments/assets/4196ba0a-1ebd-43e4-9393-5c8079ecdb37" />

修正後
<img width="1025" height="676" alt="スクリーンショット 2025-08-20 163550" src="https://github.com/user-attachments/assets/b335fa45-af4a-4dcb-b062-482fc4393d42" />


## 影響範囲  / Affected Area
エンプラ版で同様の記述にしているため不要と判断する。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
