### PR TITLE
1323　現在のページをエクスポートしたとき無限ダウンロードするバグを修正

### DIFF
--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -96,6 +96,11 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			}else{
 				$this->output($request, '', $entries);
 			}
+
+            if($request->getMode()== 'ExportCurrentPage'){
+                      break;
+            }
+			
 			$batchoffset = $batchoffset + $this->exportBatchLimit; // オフセットの更新
 		}
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1323

##  不具合の内容 / Bug
1.エクスポート機能で現在のページを指定したとき、ダウンロードが無限に続く。

##  原因 / Cause
1. 全てエクスポート、選択したデータをエクスポートを選択した場合、オフセットを使用して１万件ずつ出力する。
　レコードが0件になったときループが終了する。
　現在のページをエクスポートする場合はオフセットを使用しないため、常にレコードが出力され、　ループが終了しない。

##  変更内容 / Details of Change
1. 現在のページをエクスポートする場合は一度目のループで終了する。

## スクリーンショット / Screenshot
変更前
<img width="478" height="450" alt="スクリーンショット 2025-08-21 144542" src="https://github.com/user-attachments/assets/524275d4-24bf-4dc3-93e9-f42c939d8c03" />
<img width="173" height="117" alt="スクリーンショット 2025-08-21 144519" src="https://github.com/user-attachments/assets/50a3d427-3c49-4fcb-902d-ed97e2ac6369" />


変更後
<img width="324" height="246" alt="スクリーンショット 2025-08-21 151140" src="https://github.com/user-attachments/assets/89fe6763-b312-4a55-98ab-ab11f2952ff3" />


## 影響範囲  / Affected Area
全てエクスポート、選択したデータをエクスポートを選択した場合、正常に出力されることを確認済み。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
