### PR TITLE
1323　現在のページをエクスポートした際にダウンロードが完了しない不具合を修正

### DIFF
--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -98,9 +98,9 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			}
 
             if($request->getMode()== 'ExportCurrentPage'){
-                      break;
+                break;
             }
-			
+
 			$batchoffset = $batchoffset + $this->exportBatchLimit; // オフセットの更新
 		}
 	}

--- a/modules/Vtiger/actions/ExportData.php
+++ b/modules/Vtiger/actions/ExportData.php
@@ -96,6 +96,11 @@ class Vtiger_ExportData_Action extends Vtiger_Mass_Action {
 			}else{
 				$this->output($request, '', $entries);
 			}
+
+            if($request->getMode()== 'ExportCurrentPage'){
+                      break;
+            }
+			
 			$batchoffset = $batchoffset + $this->exportBatchLimit; // オフセットの更新
 		}
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1323 

##  不具合の内容 / Bug
1. 現在のページをエクスポートした際にダウンロードが完了しない。

##  原因 / Cause
1.全てエクスポート、選択したデータをエクスポートする場合、オフセットを設定して1万件ずつ出力する。
　レコードが出力されなくなったらループを終了する。
　現在のページをエクスポートする場合、20件を指定して出力するため、レコードが出力され続ける。

##  変更内容 / Details of Change
1. 現在のページをエクスポートする場合のみ、1度目のループで終了する記述を追加した。

## スクリーンショット / Screenshot
変更前
<img width="478" height="450" alt="スクリーンショット 2025-08-21 144542" src="https://github.com/user-attachments/assets/82a3eb64-7879-408a-8049-8b5f4630d537" />
<img width="173" height="117" alt="スクリーンショット 2025-08-21 144519" src="https://github.com/user-attachments/assets/0f51a5d2-29ec-4323-86e5-ac4f5f9c5110" />

変更後
<img width="324" height="246" alt="スクリーンショット 2025-08-21 151140" src="https://github.com/user-attachments/assets/fc161459-3812-4aae-9045-0475dd39fbc9" />




## 影響範囲  / Affected Area
全てエクスポート、選択したデータをエクスポートする場合も正常に出力されることを確認した。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
