### PR TITLE
1187 datePickerが見切れる不具合を修正

### DIFF
--- a/layouts/v7/modules/Vtiger/resources/Utils.js
+++ b/layouts/v7/modules/Vtiger/resources/Utils.js
@@ -151,6 +151,50 @@ var vtUtils = {
                         autoClose : false,
                         duration : 500
                     });
+
+					element.on('datepicker-open', function(event, element) {
+						// 日付選択ボックス
+						var target = element.relatedTarget;
+						// 日付選択ボックスの現在の表示位置
+						var offset = target.offset();
+						var offsetLeft = offset.left;
+
+						// クリックされたテキストエリアの横幅
+						var inputSize = jQuery(event.currentTarget).outerWidth();
+						// 日付選択ボックスの横幅
+						var targetWidth = target.outerWidth();
+						// ウィンドウの横幅
+						var windowWidth = window.innerWidth;
+
+						// ウィンドウの横幅が日付選択ボックスの横幅以下の場合や、現在の表示位置が画面外の場合は常に0pxを起点に日付選択ボックスを表示する
+						if (windowWidth < targetWidth || offsetLeft < 0) {
+							offsetLeft = 0;
+						} else {
+							// 日付選択ボックスの現在の表示位置 + 横幅（＝終端）がウィンドウサイズを超える場合は日付選択ボックスの表示位置をずらす
+							if (offsetLeft + targetWidth > windowWidth) {
+								// 基本はクリックされたテキストエリアの右端に日付選択ボックスの右端を合わせる
+								// 日付選択ボックスの現在の表示位置を横幅ぶん、左にスライド→テキストエリア分、右にスライド
+								offsetLeft = offsetLeft - targetWidth + inputSize;
+
+								// クリックされたテキストエリアが見切れている場合はそれでも外に出てしまうので
+								// ウィンドウの右端と日付選択ボックスの終端を合わせる（ただしマージンを考慮）
+								if (offsetLeft + targetWidth > windowWidth) {
+									var marginRight = 20;
+									offsetLeft = windowWidth - targetWidth - marginRight;
+								}
+
+								// ただし、ずらした結果がウィンドウ外に出てしまう場合は強制的にウィンドウの左端を起点として表示する
+								if (offsetLeft < 0) {
+									offsetLeft = 0;
+								}
+							}
+						}
+
+						target.css({
+							top: offset.top,
+							left: offsetLeft
+						});
+					});	
                 }else{
                     var elementDateFormat = element.data('dateFormat');
                     if(typeof elementDateFormat !== 'undefined') {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1187 

##  不具合の内容 / Bug
1.リスト画面において、日付項目を右端に設定した状態で日付入力欄を選択したとき、datePickerが見切れる。

##  原因 / Cause
1. 状況を想定した記述がなかったため。

##  変更内容 / Details of Change
1. 以下の仕様を追加した。
　①ウィンドウの横幅が日付選択ボックスの横幅以下の場合や、現在の表示位置が画面外の場合は常に0pxを起点に日付選択ボックスを表示する。
　②日付選択ボックスの現在の表示位置 + 横幅（＝終端）がウィンドウサイズを超える場合は日付選択ボックスの表示位置をずらす。
　③基本はクリックされたテキストエリアの右端に日付選択ボックスの右端を合わせる。日付選択ボックスの現在の表示位置を横幅分、左にスライド、テキストエリア分、右にスライドする。
　④クリックされたテキストエリアが見切れている場合はそれでも外に出てしまうので、ウィンドウの右端と日付選択ボックスの終端を合わせる。

## スクリーンショット / Screenshot
変更前
<img width="416" height="703" alt="スクリーンショット 2025-08-21 180645" src="https://github.com/user-attachments/assets/119bfce3-f6c1-41f2-b046-b9e03aaba6ec" />

変更後
<img width="664" height="585" alt="スクリーンショット 2025-08-22 113856" src="https://github.com/user-attachments/assets/a8004d72-5c38-45fd-ad89-230ecf224bae" />


## 影響範囲  / Affected Area
既に一部顧客で対応済みのため、不要と判断する。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
既に対応済みの顧客の仕様より、以下の仕様を追加しました。
クリックされたテキストエリアが見切れている場合、ウィンドウの右端と日付選択ボックスの終端を合わせるが、右側のマージンを20px分とる（Datepickerの枠がスクロールバー等と重なるため）。
