### PR TITLE
#1186 システム管理者が他ユーザーのカレンダー設定を変更できるよう対応

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
@@ -40,6 +40,24 @@
 						{/if}
 						<span class="current-filter-name settingModuleName filter-name pull-left">
 							{if $REQ.view eq 'Calendar'}
+
+								<!--ユーザー詳細から他ユーザーのカレンダーを開いた場合-->
+								{if $RECORD->getId() neq $USER_MODEL->getId()}
+									<a href="{$URL}">
+										{if $REQ.extensionModule}{$REQ.extensionModule}{else}{vtranslate({$PAGETITLE}, $QUALIFIED_MODULE)}{/if}
+										&nbsp;<span class="fa fa-angle-right" aria-hidden="true"></span>&nbsp;
+									</a>
+                                    <a  href="{"index.php?module="|cat:$REQ.module|cat:'&parent='|cat:$REQ.parent|cat:'&view=Detail&record='|cat:$REQ.record}">
+                                        {if $RECORD}
+                                            {if $REQ.view eq 'Edit'}
+                                                {vtranslate('LBL_EDITING', $MODULE)} :&nbsp;
+                                            {/if}
+                                        	{$RECORD->getName()}
+											&nbsp;<span class="fa fa-angle-right" aria-hidden="true"></span>&nbsp;
+                                        {/if}
+									</a>
+                                    {/if}
+
 								{if $REQ.mode eq 'Edit'}
 									<a href="{"index.php?module="|cat:$REQ.module|cat:'&parent='|cat:$REQ.parent|cat:'&view='|cat:$REQ.view}">
 										{vtranslate({$PAGETITLE}, $QUALIFIED_MODULE)}
@@ -49,7 +67,7 @@
                                                                             {vtranslate('LBL_EDITING', $MODULE)} :&nbsp;{vtranslate({$PAGETITLE}, $QUALIFIED_MODULE)}&nbsp;{vtranslate('LBL_OF',$QUALIFIED_MODULE)}&nbsp;{$USER_MODEL->getName()}
                                                                         </a>
 								{else}
-                                                                    <a href="">{vtranslate({$PAGETITLE}, $QUALIFIED_MODULE)}&nbsp;<span class="fa fa-angle-right" aria-hidden="true"></span>&nbsp;{$USER_MODEL->getName()}</a>
+                                                                    <a href="">{vtranslate({$PAGETITLE}, $QUALIFIED_MODULE)}:&nbsp;{$USER_MODEL->getName()}</a>
 								{/if}
 							{else if $REQ.view neq 'List' and $REQ.module eq 'Users'}
 								{if $REQ.view eq 'PreferenceEdit'}

--- a/layouts/v7/modules/Users/CalendarDetailViewHeader.tpl
+++ b/layouts/v7/modules/Users/CalendarDetailViewHeader.tpl
@@ -13,7 +13,39 @@
     {assign var="MODULE_NAME" value=$MODULE_MODEL->get('name')}
     <input id="recordId" type="hidden" value="{$RECORD->getId()}" />
     <div class="detailViewContainer">
+    <div class="col-sm-12 col-xs-12">
         <div class="detailViewTitle" id="prefPageHeader">
+            <div class = "row">
+                <div class="col-md-5" style="margin-top: 18px;">
+                    <div class="col-md-5 recordImage" style="height: 50px;width: 50px;">
+                        {assign var=NOIMAGE value=0}
+                        {foreach key=ITER item=IMAGE_INFO from=$RECORD->getImageDetails()}
+                            {if !empty($IMAGE_INFO.url)}
+                                <img height="100%" width="100%" src="{$IMAGE_INFO.url}" alt="{$IMAGE_INFO.orgname}" title="{$IMAGE_INFO.orgname}" data-image-id="{$IMAGE_INFO.id}">
+                            {else}
+                                {assign var=NOIMAGE value=1}
+                            {/if}
+                        {/foreach}
+                        {if $NOIMAGE eq 1}
+                            <div class="name">
+                                <span style="font-size:24px;">
+                                    <strong> {$RECORD->getName()|substr:0:2} </strong>
+                                </span>
+                            </div>
+                        {/if}
+                    </div>
+                    <span class="font-x-x-large" style="margin:5px;font-size:24px">
+                        {$RECORD->getName()}
+                    </span>
+                </div>
+                <div class=" pull-right col-md-7 detailViewButtoncontainer">
+                    <div class="btn-group  pull-right">
+                        <a class="btn btn-default" href="{$RECORD->getCalendarSettingsEditViewUrl()}">{vtranslate('LBL_EDIT', $MODULE_NAME)}</a>
+                    </div>  
+                </div>
+            </div>
+        </div>
+        <hr />
         </div>
         <div class="detailViewInfo userPreferences row-fluid">
             <div class="details col-xs-12">

--- a/layouts/v7/modules/Users/CalendarEditViewPreProcess.tpl
+++ b/layouts/v7/modules/Users/CalendarEditViewPreProcess.tpl
@@ -1,0 +1,20 @@
+{*<!--
+/*********************************************************************************
+** The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+*
+ ********************************************************************************/
+-->*}
+
+{strip}
+{assign var=QUALIFIED_MODULE value='Settings:User'}
+{include file="SettingsMenuStart.tpl"|vtemplate_path:$QUALIFIED_MODULE}
+
+<div class="bodyContents">
+	<div class="mainContainer row-fluid">
+		
+{/strip}

--- a/layouts/v7/modules/Users/CalendarSettingsDetailView.tpl
+++ b/layouts/v7/modules/Users/CalendarSettingsDetailView.tpl
@@ -21,13 +21,6 @@
                 <input type=hidden name="timeFormatOptions" data-value='{$DAY_STARTS}' />
                 <div class="row">
                     <h4 class="col-xs-8">{vtranslate({$BLOCK_LABEL_KEY},{$MODULE_NAME})}</h4>
-                    <div class="col-xs-4 marginTop5px">
-                        <div class=" pull-right detailViewButtoncontainer">
-                            <div class="btn-group  pull-right">
-                                <a class="btn btn-default" href="{$RECORD->getCalendarSettingsEditViewUrl()}">{vtranslate('LBL_EDIT', $MODULE_NAME)}</a>
-                            </div>  
-                        </div>
-                    </div>
                 </div>
                 <hr>
                 <div class="blockData row">

--- a/layouts/v7/modules/Users/CalendarSettingsEditView.tpl
+++ b/layouts/v7/modules/Users/CalendarSettingsEditView.tpl
@@ -7,10 +7,19 @@
 * All Rights Reserved.
 ************************************************************************************}
 
-<div class="editViewPageDiv row">
-    <div class="col-sm-12 col-xs-12">
+<div class="editViewPageDiv detailViewContainer">
+    <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <form class="form-horizontal recordEditView" id="EditView" name="EditView" method="post" action="index.php" enctype="multipart/form-data">
-            <div class="editViewBody">
+        <div class="editViewHeader">
+            <div class='row'>
+                <div class="col-lg-12 col-md-12 col-sm-12 ">
+                    {assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
+                    <h4 class="editHeader"  title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD_STRUCTURE_MODEL->getRecordName()}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD_STRUCTURE_MODEL->getRecordName()}</h4>
+                </div>
+            </div>
+        </div>
+        <hr> 
+        <div class="editViewBody">
                 <div class="editViewContents">
                     {assign var=WIDTHTYPE value=$USER_MODEL->get('rowheight')}
                     {assign var=QUALIFIED_MODULE_NAME value={$MODULE}}

--- a/modules/Settings/Vtiger/models/Module.php
+++ b/modules/Settings/Vtiger/models/Module.php
@@ -189,6 +189,12 @@ class Settings_Vtiger_Module_Model extends Vtiger_Base_Model {
 			}
 			$finalResult = $moduleModel->getSettingsActiveBlock($view);
 		}
+		
+		$currentUserModel = Users_Record_Model::getCurrentUserModel();
+		if($moduleName === 'Users' && $view == 'Calendar' && $request->get('record') != $currentUserModel->id) {
+			$finalResult = array('block' => 'LBL_USER_MANAGEMENT', 'menu' => 'LBL_USERS');
+		}
+
 		return $finalResult;
 	}
 

--- a/modules/Users/models/DetailView.php
+++ b/modules/Users/models/DetailView.php
@@ -83,6 +83,12 @@ class Users_DetailView_Model extends Vtiger_DetailView_Model {
 										'linkurl'	=> "javascript:Users_Detail_Js.triggerChangeAccessKey('index.php?module=Users&action=SaveAjax&mode=changeAccessKey&record=$recordId')",
 										'linkicon'	=> ''
 									);
+			$detailViewActionLinks[] = array(
+										'linktype' => 'DETAILVIEW',
+										'linklabel' => 'LBL_CALENDAR_SETTINGS',
+										'linkurl' => "index.php?module=Users&parent=Settings&view=Calendar&record=$recordId",
+										'linkicon' => ''
+			);
 			if($currentUserModel->get('id') === $recordId){
 				$detailViewActionLinks[] = array(
 											'linktype'	=> 'DETAILVIEW',

--- a/modules/Users/views/Calendar.php
+++ b/modules/Users/views/Calendar.php
@@ -36,6 +36,10 @@ class Users_Calendar_View extends Vtiger_Detail_View {
 	 * @return <String>
 	 */
 	public function preProcessTplName(Vtiger_Request $request) {
+		// 編集画面ではヘッダーを表示しない
+		if ($request->getMode() === 'Edit') {
+        	return 'CalendarEditViewPreProcess.tpl';
+    	}
 		return 'CalendarDetailViewPreProcess.tpl';
 	}
 
@@ -171,7 +175,7 @@ class Users_Calendar_View extends Vtiger_Detail_View {
 		$recordId = $request->get('record');
 		$currentUserModel = Users_Record_Model::getCurrentUserModel();
 		$module = $request->getModule();
-		$detailViewModel = Vtiger_DetailView_Model::getInstance('Users', $currentUserModel->id);
+		$detailViewModel = Vtiger_DetailView_Model::getInstance('Users', $recordId);
 		$userRecordStructure = Vtiger_RecordStructure_Model::getInstanceFromRecordModel($detailViewModel->getRecord(), Vtiger_RecordStructure_Model::RECORD_STRUCTURE_MODE_EDIT);
 		$recordStructure = $userRecordStructure->getStructure();
 //		$allUsers = Users_Record_Model::getAll(true);
@@ -202,6 +206,14 @@ class Users_Calendar_View extends Vtiger_Detail_View {
 	
 	public function calendarSettingsEdit(Vtiger_Request $request){
 		$viewer = $this->getViewer($request);
+
+		//　対象者の情報を取得
+		$moduleName = $request->getModule();
+		$record = $request->get('record');
+		$recordModel = $this->record?$this->record:Vtiger_Record_Model::getInstanceById($record, $moduleName);
+		$recordStructureInstance = Vtiger_RecordStructure_Model::getInstanceFromRecordModel($recordModel, Vtiger_RecordStructure_Model::RECORD_STRUCTURE_MODE_EDIT);
+		$viewer->assign('RECORD_STRUCTURE_MODEL', $recordStructureInstance);
+
 		$this->initializeView($viewer,$request);
 		$viewer->view('CalendarSettingsEditView.tpl', $request->getModule());
 	}
@@ -210,6 +222,14 @@ class Users_Calendar_View extends Vtiger_Detail_View {
 	
 	public function calendarSettingsDetail(Vtiger_Request $request){
 		$viewer = $this->getViewer($request);
+
+		//　対象者の情報を取得
+		$moduleName = $request->getModule();
+		$record = $request->get('record');
+		$recordModel = $this->record?$this->record:Vtiger_Record_Model::getInstanceById($record, $moduleName);
+		$recordStructureInstance = Vtiger_RecordStructure_Model::getInstanceFromRecordModel($recordModel, Vtiger_RecordStructure_Model::RECORD_STRUCTURE_MODE_EDIT);
+		$viewer->assign('RECORD_STRUCTURE_MODEL', $recordStructureInstance);
+
 		$this->initializeView($viewer,$request);
 		$viewer->view('CalendarSettingsDetailView.tpl', $request->getModule());
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1186 

##  不具合の内容 / Bug
1. 他ユーザーが誤ってカレンダー設定を行った際、管理者が修正することができない。

##  原因 / Cause
1. F-Revoバージョン6では、ユーザー詳細にカレンダー設定も存在したが、バージョンアップでカレンダー設定が独立したため
　従来の操作で設定できなくなった。

##  変更内容 / Details of Change
1. ユーザー詳細
　①ドロップダウンリスト「その他」にカレンダー設定欄を追加

2. カレンダー設定
　①ヘッダーにどのユーザーを開いているのかを表示
　②編集ボタンをヘッダーに移動（ユーザー詳細画面とレイアウトをそろえるため）
　③パンくずリスト、サイドバーをユーザー詳細から遷移した振る舞いに変更（操作ユーザーと選択ユーザーが異なる場合）
　④使用するユーザー情報をカレントユーザーから選択したユーザーに変更
　⑤パンくずリストで　「ユーザー>システム管理者」（ユーザーには遷移できない）となっていた記述を
　　「ユーザー：システム管理者」に修正（操作ユーザーが選択ユーザーである場合も含む）
　　補足：「ユーザー>」ユーザー画面からの遷移ではなくモジュール名を意味している。

3.カレンダー編集
　①ヘッダーにどのユーザーを開いているのか表示

## スクリーンショット / Screenshot
【修正箇所】
<img width="769" height="574" alt="スクリーンショット 2025-08-28 111142" src="https://github.com/user-attachments/assets/eee9cd46-0664-4371-8be7-71931b3f3433" />

<img width="860" height="538" alt="スクリーンショット 2025-08-28 111212" src="https://github.com/user-attachments/assets/32ab5f42-60b4-410e-93e9-5a61fb739685" />

<img width="756" height="533" alt="スクリーンショット 2025-08-28 111259" src="https://github.com/user-attachments/assets/c25120e8-1def-473c-ae45-127de0f7f93e" />

変更できることを確認
システム管理者から確認
<img width="755" height="570" alt="スクリーンショット 2025-08-28 111331" src="https://github.com/user-attachments/assets/a0235172-7d5e-4e06-adbe-de0d0315c110" />

変更されたユーザーから確認
<img width="795" height="448" alt="スクリーンショット 2025-08-28 111602" src="https://github.com/user-attachments/assets/38b975a1-67e4-4301-88b1-9ef638408735" />


【変更されない箇所】
<img width="757" height="473" alt="スクリーンショット 2025-08-28 111402" src="https://github.com/user-attachments/assets/5ce4b21c-9057-4dce-a249-148e6ea5bf8c" />

【言語対応】
<img width="1137" height="871" alt="スクリーンショット 2025-08-28 113818" src="https://github.com/user-attachments/assets/b5154213-28c6-4925-be9d-fda9d7ad97df" />
<img width="1133" height="816" alt="スクリーンショット 2025-08-28 113829" src="https://github.com/user-attachments/assets/9785843b-3eef-43c0-9bf9-f376250ddb76" />
<img width="1077" height="1026" alt="スクリーンショット 2025-08-28 113837" src="https://github.com/user-attachments/assets/94edec13-5eaa-4a8e-9163-c52e2766f8f2" />



## 影響範囲  / Affected Area
・ユーザーモジュールのカレンダー詳細、編集
・ユーザー詳細のドロップダウンリスト「その他」
・設定機能のサイドバー、パンくずリスト

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
