### PR TITLE
関連の一覧で関連項目の検索を行えるように修正

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -758,6 +758,7 @@ class QueryGenerator {
 							}
 							if(php7_count($columnList) > 1) {
 								$columnSql = getSqlForNameInDisplayFormat(array('last_name'=>$columnList[1],'first_name'=>$columnList[0],),'Users');
+								$columnSql = str_replace('userlabel', 'label', $columnSql);
 							} else {
 								$columnSql = implode('', $columnList);
 							}

--- a/layouts/v7/modules/Vtiger/RelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedList.tpl
@@ -72,7 +72,7 @@
 							</th>
 							{foreach item=HEADER_FIELD from=$RELATED_HEADERS}
 								<th>
-									{if $HEADER_FIELD->get('column') eq 'time_start' or $HEADER_FIELD->get('column') eq 'time_end' or $HEADER_FIELD->getFieldDataType() eq 'reference'}
+									{if $HEADER_FIELD->get('column') eq 'time_start' or $HEADER_FIELD->get('column') eq 'time_end'}
 									{else}
 										{assign var=FIELD_UI_TYPE_MODEL value=$HEADER_FIELD->getUITypeModel()}
 										{include file=vtemplate_path($FIELD_UI_TYPE_MODEL->getListSearchTemplateName(),$RELATED_MODULE_NAME) FIELD_MODEL= $HEADER_FIELD SEARCH_INFO=$SEARCH_DETAILS[$HEADER_FIELD->getName()] USER_MODEL=$USER_MODEL}

--- a/modules/Accounts/Accounts.php
+++ b/modules/Accounts/Accounts.php
@@ -619,6 +619,9 @@ class Accounts extends CRMEntity {
 				LEFT JOIN vtiger_quotesbillads ON vtiger_quotesbillads.quotebilladdressid = vtiger_quotes.quoteid
 				LEFT JOIN vtiger_quotesshipads ON vtiger_quotesshipads.quoteshipaddressid = vtiger_quotes.quoteid
 				LEFT JOIN vtiger_users ON vtiger_crmentity.smownerid = vtiger_users.id
+				LEFT JOIN vtiger_contactdetails AS vtiger_contactdetailscontact_id ON vtiger_contactdetailscontact_id.contactid = vtiger_quotes.contactid
+				LEFT JOIN vtiger_account AS vtiger_accountaccount_id ON vtiger_accountaccount_id.accountid = vtiger_quotes.accountid
+				LEFT JOIN vtiger_potential AS vtiger_potentialpotential_id ON vtiger_potentialpotential_id.potentialid = vtiger_quotes.potentialid
 				WHERE vtiger_crmentity.deleted = 0 AND (vtiger_account.accountid = $id";
 
 		if(!empty ($entityIds)){

--- a/modules/Vtiger/models/RelationListView.php
+++ b/modules/Vtiger/models/RelationListView.php
@@ -313,7 +313,7 @@ class Vtiger_RelationListView_Model extends Vtiger_Base_Model {
 		if($orderBy) {
 
 			$orderByFieldModuleModel = $relationModule->getFieldByColumn($orderBy);
-			if($orderByFieldModuleModel && $orderByFieldModuleModel->isReferenceField()) {
+			if($orderByFieldModuleModel) {
 				//If reference field then we need to perform a join with crmentity with the related to field
 				$queryComponents = $split = preg_split('/ where /i', $query);
 				$selectAndFromClause = $queryComponents[0];


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1185

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 関連一覧から関連項目の検索の入力BOXが表示されず、検索ができない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. fieldがreferenceの項目は入力ボックスが非表示になる。
2. 検索時に発行されるクエリがget_quotesメソッドで書き換えられるため必要テーブルのjoinがされず、検索処理が機能しなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 画面側のfieldがreferenceかどうかをチェックしている処理を削除。
2. get_quotesメソッド内で書き換えられてるクエリを直接修正。（必要なテーブルをjoin）

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="2558" height="1268" alt="image" src="https://github.com/user-attachments/assets/05e21e7d-7c8f-4bff-b8ff-91426fcefa12" />
<img width="2558" height="1267" alt="image" src="https://github.com/user-attachments/assets/4d47da08-0b79-44c2-8328-8b1eda4e7b85" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->