### PR TITLE
#1161 Skype項目の新規追加を不可にする対応

### DIFF
--- a/modules/Settings/LayoutEditor/models/Module.php
+++ b/modules/Settings/LayoutEditor/models/Module.php
@@ -92,8 +92,9 @@ class Settings_LayoutEditor_Module_Model extends Vtiger_Module_Model {
 
 	public function getAddSupportedFieldTypes() {
 		return array(
+			//Skypeサービス終了のため、Skype項目を削除
 			'Text','Decimal','Integer','Percent','Currency','Date','Email','Phone','Picklist',
-			'URL','Checkbox','TextArea','MultiSelectCombo','Skype','Time','Reference','Blank'
+			'URL','Checkbox','TextArea','MultiSelectCombo','Time','Reference','Blank'
 		);
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1161 

##  不具合の内容 / Bug
1. 追加項目選択時に、サービスが終了したSkypeの項目が表示される

##  原因 / Cause
1. 未対応であったため

##  変更内容 / Details of Change
1. 追加項目のドロップダウンリストにバインドされる配列から、Skype項目を削除する。

## スクリーンショット / Screenshot
修正箇所
【修正前】
<img width="605" height="570" alt="スクリーンショッ" src="https://github.com/user-attachments/assets/5b9d5229-bfce-4914-9087-5844dc8a0464" />

【修正後】
<img width="614" height="572" alt="スクリーンショット 2025-09-05 114647" src="https://github.com/user-attachments/assets/4cc0e7ab-b665-405e-887a-8234084858a9" />

ほかの項目が従来どおり出力される
【修正前】
<img width="604" height="570" alt="スクリーンショット 2025-09-05 114345" src="https://github.com/user-attachments/assets/93e64b48-f58d-4549-a05d-efe770c462ac" />

<img width="605" height="570" alt="スクリーンショット 2025-09-05 114401" src="https://github.com/user-attachments/assets/23ec9d2e-4e42-4a0c-adf1-86af621ddd99" />

<img width="601" height="569" alt="スクリーンショット 2025-09-05 114411" src="https://github.com/user-attachments/assets/661f1160-d681-4f41-8911-25b41b2bc711" />

【修正後】
<img width="604" height="574" alt="スクリーンショット 2025-09-05 114604" src="https://github.com/user-attachments/assets/c075bd32-9b0e-4c76-9172-07e1370a5625" />

<img width="614" height="572" alt="スクリーンショット 2025-09-05 114647" src="https://github.com/user-attachments/assets/9328e65b-198e-4804-9b91-52179d43eef3" />

【英語対応】
<img width="606" height="568" alt="スクリーンショット 2025-09-05 133810" src="https://github.com/user-attachments/assets/e479834a-7c91-4613-be0f-4c696aa0c96f" />
<img width="606" height="566" alt="スクリーンショット 2025-09-05 133606" src="https://github.com/user-attachments/assets/a74d2527-3626-4dc3-baa5-eee52d99d995" />


## 影響範囲  / Affected Area
「カスタム項目の作成」モーダル

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks