### PR TITLE
#1259 ユーザー削除時、一度キャンセルすると再表示できないバグの修正

### DIFF
--- a/layouts/v7/modules/Users/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/Users/ListViewRecordActions.tpl
@@ -26,14 +26,14 @@
 				{if $IS_MODULE_DELETABLE && $LISTVIEW_ENTRY->getId() != $USER_MODEL->getId()}
 					{if $LISTVIEW_ENTRY->get('status') eq 'Active'}
 						<li>
-							<a href='javascript:Settings_Users_List_Js.triggerDeleteUser("{$LISTVIEW_ENTRY->getDeleteUrl()}")'>{vtranslate("LBL_REMOVE_USER",$MODULE)}</i></a>
+							<a onclick='Settings_Users_List_Js.triggerDeleteUser("{$LISTVIEW_ENTRY->getDeleteUrl()}")'>{vtranslate("LBL_REMOVE_USER",$MODULE)}</a>
 						</li>
 					{else}
 						<li>
 							<a onclick="Settings_Users_List_Js.restoreUser({$LISTVIEW_ENTRY->getId()}, event);">{vtranslate("LBL_RESTORE_USER",$MODULE)}</a>
 						</li>
 						<li>
-							<a href='javascript:Settings_Users_List_Js.triggerDeleteUser("{$LISTVIEW_ENTRY->getDeleteUrl()}", "true")'>{vtranslate("LBL_REMOVE_USER",$MODULE)}</i></a>
+							<a onclick='Settings_Users_List_Js.triggerDeleteUser("{$LISTVIEW_ENTRY->getDeleteUrl()}", "true")'>{vtranslate("LBL_REMOVE_USER",$MODULE)}</a>
 						</li>
 					{/if}
 				{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1259

##  不具合の内容 / Bug
発生手順
1. ユーザー詳細画面より、ユーザーの削除を選択する。
2. 「No」を選択し、削除をキャンセルする。
3. 改めて削除を選択する。

⇒メッセージボックスが表示されない。

##  原因 / Cause
1. onclickでイベントを設定するべき箇所をhrefで設定していたため。

##  変更内容 / Details of Change
1. 他の記述と揃えてonclickに変更する。

## スクリーンショット / Screenshot
【修正箇所】
<img width="778" height="526" alt="スクリーンショット 2025-09-08 115756" src="https://github.com/user-attachments/assets/e0158fda-2e4b-46f7-98a7-436ba9043853" />
<img width="822" height="558" alt="スクリーンショット 2025-09-08 115808" src="https://github.com/user-attachments/assets/b345251b-0b86-46e0-b76b-063baf083e1a" />

【通常通りに動作する】
1. 論理削除
<img width="606" height="274" alt="スクリーンショット 2025-09-08 115818" src="https://github.com/user-attachments/assets/4f978796-fea7-4a25-820c-cb83b00f4705" />
<img width="723" height="536" alt="スクリーンショット 2025-09-08 115831" src="https://github.com/user-attachments/assets/b17f1c31-2922-4d2e-aae3-74efe70f0131" />

2. 物理削除
<img width="625" height="285" alt="スクリーンショット 2025-09-08 115951" src="https://github.com/user-attachments/assets/2465389f-8e48-43a4-8fdb-83eb6aacf519" />
<img width="668" height="498" alt="スクリーンショット 2025-09-08 134941" src="https://github.com/user-attachments/assets/61449a77-b8f3-4847-85bf-d847bc9908ca" />

3. 論理削除後に物理削除
<img width="885" height="594" alt="スクリーンショット 2025-09-08 134829" src="https://github.com/user-attachments/assets/b3b90884-721d-41df-ae1f-d2284ac9a753" />
<img width="869" height="523" alt="スクリーンショット 2025-09-08 134900" src="https://github.com/user-attachments/assets/55410905-6294-4ca3-8083-a0a779cf35a0" />


## 影響範囲  / Affected Area
ユーザー削除機能

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
なし