### PR TITLE
#1347 FPLoginレイアウト乱れ修正

### DIFF
--- a/languages/en_us/Users.php
+++ b/languages/en_us/Users.php
@@ -208,6 +208,7 @@ $languageStrings = array(
 	'ForgotPassword' => 'Forgot Password',
 	'LBL_CONNECT_WITH_US' => 'Connect with US',
 	'LBL_GET_MORE' => 'Get more out of Vtiger',
+	'LBL_SEND_PASSWORD' => 'Send password by email',
 
 	'LBL_TRANSFER_RECORDS_TO_USER' => 'Transfer records to user',
 	'LBL_USER_TO_BE_DELETED' => 'User to be Deleted',

--- a/languages/ja_jp/Users.php
+++ b/languages/ja_jp/Users.php
@@ -208,6 +208,7 @@ $languageStrings = array(
 	'ForgotPassword' => 'パスワードをお忘れですか？',
 	'LBL_CONNECT_WITH_US' => 'F-RevoCRM Facebook',
 	'LBL_GET_MORE' => 'F-RevoCRMをもっと使い込む',
+	'LBL_SEND_PASSWORD' => 'パスワードをメールで送信します',
 
 	'LBL_TRANSFER_RECORDS_TO_USER' => 'レコードの担当を変更',
 	'LBL_USER_TO_BE_DELETED' => '削除されるユーザー',

--- a/layouts/v7/modules/Users/Login.tpl
+++ b/layouts/v7/modules/Users/Login.tpl
@@ -89,18 +89,18 @@
 				<div id="forgotPasswordDiv" class="hide">
 					<form class="form-horizontal" action="forgotPassword.php" method="POST">
 						<div class="group">
-							<input class="login-input" id="fusername" type="text" name="username" placeholder="{vtranslate('User Name','Users')}<" >
+							<input class="login-input" id="fusername" type="text" name="username" placeholder="{vtranslate('User Name','Users')}" >
 							<span class="bar"></span>
 							<label class="login-label">{vtranslate('User Name','Users')}</label>
 						</div>
 						<div class="group">
-							<input class="login-input" id="email" type="email" name="emailId" placeholder="{vtranslate('LBL_MAILADDRESS','Users')}<" >
+							<input class="login-input" id="email" type="email" name="emailId" placeholder="{vtranslate('LBL_MAILADDRESS','Users')}" >
 							<span class="bar"></span>
 							<label class="login-label">{vtranslate('LBL_MAILADDRESS','Users')}</label>
 						</div>
 						<div class="group">
-							<button type="submit" class="login-button login-buttonBlue forgot-submit-btn">{vtranslate('LBL_MAILADDRESS','Users')}</button><br>
-							<span>パスワードをメールで送信します<a class="forgotPasswordLink pull-right" style="color: #15c;">戻る</a></span>
+							<button type="submit" class="login-button login-buttonBlue forgot-submit-btn">{vtranslate('LBL_SUBMIT','Users')}</button><br>
+							<span>{vtranslate('LBL_SEND_PASSWORD','Users')}<a class="forgotPasswordLink pull-right" style="color: #15c;">{vtranslate('LBL_BACK_TO_LOGIN','Users')}</a></span>
 						</div>
 					</form>
 				</div>


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1347

##  不具合の内容 / Bug
1. 表示する文言が不適当であった。

##  原因 / Cause
1. 構文のミスで"<"が入っていた。
2. 入力間違いで送信ボタンの表示が「メールアドレス」になっていた。
3. 一部他言語が未対応であった。

##  変更内容 / Details of Change
1. 不要な"<"を削除
2. 送信ボタンの表示を「メールアドレス」から「送信」に変更
4. 「戻る」と「パスワードをメールで送信します」の多言語対応

## スクリーンショット / Screenshot
修正前
<img width="584" height="626" alt="スクリーンショット 2025-09-09 112727" src="https://github.com/user-attachments/assets/230458e8-4bbd-4044-b54b-56451d9d40d1" />

修正後
<img width="394" height="426" alt="スクリーンショット 2025-09-09 135235" src="https://github.com/user-attachments/assets/6fe2bb7a-dc40-4423-a386-818e06c0634d" />

英語対応
<img width="382" height="422" alt="スクリーンショット 2025-09-09 143659" src="https://github.com/user-attachments/assets/e1d647ab-54d5-46f1-9f0d-3865cd037582" />

## 影響範囲  / Affected Area
ログイン画面

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
