### PR TITLE
#1351 カレンダー一覧レイアウト修正

### DIFF
--- a/layouts/v7/modules/Calendar/ListViewPostProcess.tpl
+++ b/layouts/v7/modules/Calendar/ListViewPostProcess.tpl
@@ -1,0 +1,15 @@
+{*+**********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.1
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ ************************************************************************************}
+		<div id="modnavigator" class="module-nav calendar-navigator clearfix">
+			<div class="mod-switcher-container">
+				{include file="modules/Calendar/partials/Sidebar.tpl"}
+			</div>
+		</div>
+	</div>
+</div>

--- a/layouts/v7/modules/Calendar/ListViewPreProcess.tpl
+++ b/layouts/v7/modules/Calendar/ListViewPreProcess.tpl
@@ -1,0 +1,31 @@
+{*+**********************************************************************************
+* The contents of this file are subject to the vtiger CRM Public License Version 1.1
+* ("License"); You may not use this file except in compliance with the License
+* The Original Code is: vtiger CRM Open Source
+* The Initial Developer of the Original Code is vtiger.
+* Portions created by vtiger are Copyright (C) vtiger.
+* All Rights Reserved.
+************************************************************************************}
+
+{include file="modules/Vtiger/partials/Topbar.tpl"}
+
+<div class="container-fluid app-nav">
+	<div class="row">
+		{include file="partials/SidebarHeader.tpl"|vtemplate_path:$MODULE}
+		{include file="ModuleHeader.tpl"|vtemplate_path:$MODULE}
+	</div>
+</div>
+</nav>
+<div id='overlayPageContent' class='fade modal overlayPageContent content-area overlay-container-60' tabindex='-1' role='dialog' aria-hidden='true'>
+	<div class="data">
+	</div>
+	<div class="modal-dialog">
+	</div>
+</div>  
+<div class="main-container main-container-{$MODULE}">
+		{assign var=LEFTPANELHIDE value=$CURRENT_USER_MODEL->get('leftpanelhide')}
+		<div id="sidebar-essentials" class="sidebar-essentials {if $LEFTPANELHIDE eq '1'} hide {/if}">
+			{include file="partials/SidebarEssentials.tpl"|vtemplate_path:$MODULE}
+		</div>
+		<div class="listViewPageDiv content-area {if $LEFTPANELHIDE eq '1'} full-width {/if}" id="listViewContent">
+

--- a/layouts/v7/modules/Calendar/ModuleHeader.tpl
+++ b/layouts/v7/modules/Calendar/ModuleHeader.tpl
@@ -49,59 +49,72 @@
 					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{$RECORD->get('label')}&nbsp;</a></p>
 				{/if}
 			</div>
-			<div class="col-lg-8 col-md-8 pull-right">
+			<div class="col-lg-5 col-md-6 col-sm-7 col-xs-1 padding0 pull-right">
 				<div id="appnav" class="navbar-right">
-					<ul class="nav navbar-nav">
-						{foreach item=BASIC_ACTION from=$MODULE_BASIC_ACTIONS}
-							{if $BASIC_ACTION->getLabel() == 'LBL_IMPORT'}
-								<li>
-									<button id="{$MODULE}_basicAction_{Vtiger_Util_Helper::replaceSpaceWithUnderScores($BASIC_ACTION->getLabel())}" type="button" class="btn addButton btn-default module-buttons" 
-										{if stripos($BASIC_ACTION->getUrl(), 'javascript:')===0}
-											onclick='{$BASIC_ACTION->getUrl()|substr:strlen("javascript:")};'
+					<nav class="navbar navbar-inverse border0 margin0">
+						{if $MODULE_BASIC_ACTIONS|@count gt 0}
+						<div class="container-fluid">
+							<div class="navbar-header bg-white marginTop5px">
+								<button type="button" class="navbar-toggle collapsed margin0" data-toggle="collapse" data-target="#appnavcontent" aria-expanded="false">
+									<i class="fa fa-ellipsis-v"></i>
+								</button>
+							</div>
+							<div class="navbar-collapse collapse" id="appnavcontent" aria-expanded="false" style="height: 1px;">
+								<ul class="nav navbar-nav">
+									{foreach item=BASIC_ACTION from=$MODULE_BASIC_ACTIONS}
+										{if $BASIC_ACTION->getLabel() == 'LBL_IMPORT'}
+											<li>
+												<button id="{$MODULE}_basicAction_{Vtiger_Util_Helper::replaceSpaceWithUnderScores($BASIC_ACTION->getLabel())}" type="button" class="btn addButton btn-default module-buttons" 
+													{if stripos($BASIC_ACTION->getUrl(), 'javascript:')===0}
+														onclick='{$BASIC_ACTION->getUrl()|substr:strlen("javascript:")};'
+													{else}
+														onclick="Vtiger_Import_Js.triggerImportAction('{$BASIC_ACTION->getUrl()}')"
+													{/if}>
+													<div class="fa {$BASIC_ACTION->getIcon()}" aria-hidden="true"></div>&nbsp;
+													{vtranslate($BASIC_ACTION->getLabel(), $MODULE)}
+												</button>
+											</li>
 										{else}
-											onclick="Vtiger_Import_Js.triggerImportAction('{$BASIC_ACTION->getUrl()}')"
-										{/if}>
-										<div class="fa {$BASIC_ACTION->getIcon()}" aria-hidden="true"></div>&nbsp;
-										{vtranslate($BASIC_ACTION->getLabel(), $MODULE)}
-									</button>
-								</li>
-							{else}
-								<li>
-									<button id="{$MODULE}_listView_basicAction_{Vtiger_Util_Helper::replaceSpaceWithUnderScores($BASIC_ACTION->getLabel())}" type="button" class="btn addButton btn-default module-buttons" 
-										{if stripos($BASIC_ACTION->getUrl(), 'javascript:')===0}
-											onclick='{$BASIC_ACTION->getUrl()|substr:strlen("javascript:")};'
-										{else} 
-											onclick='window.location.href="{$BASIC_ACTION->getUrl()}&app={$SELECTED_MENU_CATEGORY}"'
-										{/if}>
-										<div class="fa {$BASIC_ACTION->getIcon()}" aria-hidden="true"></div>&nbsp;
-										{vtranslate($BASIC_ACTION->getLabel(), $MODULE)}
-									</button>
-								</li>
-							{/if}
-						{/foreach}
-						{if $MODULE_SETTING_ACTIONS|@count gt 0}
-							<li>
-								<div class="settingsIcon">
-									<button type="button" class="btn btn-default module-buttons dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-										<span class="fa fa-wrench" aria-hidden="true" title="{vtranslate('LBL_SETTINGS', $MODULE)}"></span>&nbsp;{vtranslate('LBL_CUSTOMIZE', 'Reports')}&nbsp; <span class="caret"></span>
-									</button>
-									<ul class="detailViewSetting dropdown-menu">
-										{foreach item=SETTING from=$MODULE_SETTING_ACTIONS}
-											{if $SETTING->getLabel() eq 'LBL_EDIT_FIELDS'}
-												<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_Events"><a href="{$SETTING->getUrl()}&sourceModule=Events">{vtranslate($SETTING->getLabel(), $MODULE_NAME,vtranslate('LBL_EVENTS',$MODULE_NAME))}</a></li>
-												<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_Calendar"><a href="{$SETTING->getUrl()}&sourceModule=Calendar">{vtranslate($SETTING->getLabel(), $MODULE_NAME,vtranslate('LBL_TASKS','Calendar'))}</a></li>
-											{else if $SETTING->getLabel() eq 'LBL_EDIT_WORKFLOWS'} 
-												<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_WORKFLOWS"><a href="{$SETTING->getUrl()}&sourceModule=Events">{vtranslate('LBL_EVENTS', $MODULE_NAME)} {vtranslate('LBL_WORKFLOWS',$MODULE_NAME)}</a></li>	
-												<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_WORKFLOWS"><a href="{$SETTING->getUrl()}&sourceModule=Calendar">{vtranslate('LBL_TASKS', 'Calendar')} {vtranslate('LBL_WORKFLOWS',$MODULE_NAME)}</a></li>
-											{else}
-												<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}"><a href={$SETTING->getUrl()}>{vtranslate($SETTING->getLabel(), $MODULE_NAME, vtranslate($MODULE_NAME, $MODULE_NAME))}</a></li>
-											{/if}
-										{/foreach}
-									</ul>
-								</div>
-							</li>
+											<li>
+												<button id="{$MODULE}_listView_basicAction_{Vtiger_Util_Helper::replaceSpaceWithUnderScores($BASIC_ACTION->getLabel())}" type="button" class="btn addButton btn-default module-buttons" 
+													{if stripos($BASIC_ACTION->getUrl(), 'javascript:')===0}
+														onclick='{$BASIC_ACTION->getUrl()|substr:strlen("javascript:")};'
+													{else} 
+														onclick='window.location.href="{$BASIC_ACTION->getUrl()}&app={$SELECTED_MENU_CATEGORY}"'
+													{/if}>
+													<div class="fa {$BASIC_ACTION->getIcon()}" aria-hidden="true"></div>&nbsp;
+													{vtranslate($BASIC_ACTION->getLabel(), $MODULE)}
+												</button>
+											</li>
+										{/if}
+									{/foreach}
+									{if $MODULE_SETTING_ACTIONS|@count gt 0}
+										<li>
+											<div class="settingsIcon">
+												<button type="button" class="btn btn-default module-buttons dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+													<span class="fa fa-wrench" aria-hidden="true" title="{vtranslate('LBL_SETTINGS', $MODULE)}"></span>&nbsp;{vtranslate('LBL_CUSTOMIZE', 'Reports')}&nbsp; <span class="caret"></span>
+												</button>
+												<ul class="detailViewSetting dropdown-menu">
+													{foreach item=SETTING from=$MODULE_SETTING_ACTIONS}
+														{if $SETTING->getLabel() eq 'LBL_EDIT_FIELDS'}
+															<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_Events"><a href="{$SETTING->getUrl()}&sourceModule=Events">{vtranslate($SETTING->getLabel(), $MODULE_NAME,vtranslate('LBL_EVENTS',$MODULE_NAME))}</a></li>
+															<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_Calendar"><a href="{$SETTING->getUrl()}&sourceModule=Calendar">{vtranslate($SETTING->getLabel(), $MODULE_NAME,vtranslate('LBL_TASKS','Calendar'))}</a></li>
+														{else if $SETTING->getLabel() eq 'LBL_EDIT_WORKFLOWS'} 
+															<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_WORKFLOWS"><a href="{$SETTING->getUrl()}&sourceModule=Events">{vtranslate('LBL_EVENTS', $MODULE_NAME)} {vtranslate('LBL_WORKFLOWS',$MODULE_NAME)}</a></li>	
+															<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}_WORKFLOWS"><a href="{$SETTING->getUrl()}&sourceModule=Calendar">{vtranslate('LBL_TASKS', 'Calendar')} {vtranslate('LBL_WORKFLOWS',$MODULE_NAME)}</a></li>
+														{else}
+															<li id="{$MODULE_NAME}_listview_advancedAction_{$SETTING->getLabel()}"><a href={$SETTING->getUrl()}>{vtranslate($SETTING->getLabel(), $MODULE_NAME, vtranslate($MODULE_NAME, $MODULE_NAME))}</a></li>
+														{/if}
+													{/foreach}
+												</ul>
+											</div>
+										</li>
+									{/if}
+								</ul>
+							</div><!-- /.navbar-collapse -->
+						</div><!-- /.container-fluid -->
 						{/if}
-					</ul>
+					</nav>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1351 

##  不具合の内容 / Bug
1. 画面上部のナビバーから「インポート」がはみ出している。
2. リストの「その他」ボタンが上部に見切れている。
3. モジュールナビバーが不可視で、他のカレンダー画面に遷移ができない。

##  原因 / Cause
1. 画面上部のナビバーから「インポート」がはみ出している。
　→カレンダーモジュールのModuleHeaderを使用しているため
   　vtigerのModuleHeaderと異なり、ナビバートグルに格納されていなかった。
　　（ほかのカレンダーモジュールはCalendarHeaderのため、今回の修正の影響なし）

2. リストの「その他」ボタンが上部に見切れている。
　→他のカレンダー画面は、カレンダー用のCSSによって上部にマージンをとっていたが、一覧はリストのCSSを使用していたため、マージンがとられていなかった。

3. モジュールナビバーが不可視で、他のカレンダー画面に遷移ができない。
　→他のリストと同様のtplを使用していたため、不可視化されていた。

##  変更内容 / Details of Change
1. 画面上部のナビバーから「インポート」がはみ出している。
　→ナビバートグルに格納した。

2. リストの「その他」ボタンが上部に見切れている。
　→上部をナビバートグルに格納したことで、マージンが不要となった。

4. モジュールナビバーが不可視で、他のカレンダー画面に遷移ができない。
　→不可視の記述を削除した。

## スクリーンショット / Screenshot
レイアウト修正前（上部）
<img width="567" height="1015" alt="スクリーンショット 2025-09-24 152140" src="https://github.com/user-attachments/assets/cdbcfe1d-ba4d-47b1-a29d-c8af6aaf206c" />
レイアウト修正前（下部）
<img width="575" height="1017" alt="スクリーンショット 2025-09-24 152353" src="https://github.com/user-attachments/assets/75953c00-6d64-4900-9709-82d7ae0b3db0" />

レイアウト修正後（上部）
<img width="581" height="1032" alt="スクリーンショット 2025-09-24 152514" src="https://github.com/user-attachments/assets/97dd8ac3-895e-4c77-9933-aa2fe3e811ad" />
レイアウト修正後（下部）
<img width="590" height="1026" alt="スクリーンショット 2025-09-24 152522" src="https://github.com/user-attachments/assets/375acf66-0b5e-4fdf-aafe-aa8f3067ac2c" />

画面遷移ができることを確認
および、他カレンダー画面のレイアウトが乱れていないことを確認（上部）
<img width="593" height="1023" alt="スクリーンショット 2025-09-24 152656" src="https://github.com/user-attachments/assets/03a307ad-9634-4ff5-a246-f91d0801254c" />
他カレンダー画面のレイアウトが乱れていないことを確認（下部）
<img width="582" height="1038" alt="スクリーンショット 2025-09-24 154458" src="https://github.com/user-attachments/assets/6d3c6574-953c-414b-8dac-74980372747c" />

トグル内のボタンから活動の追加ができることを確認
<img width="590" height="1029" alt="スクリーンショット 2025-09-24 153250" src="https://github.com/user-attachments/assets/a26c62c6-d33e-4097-af5a-c3f4812ba0d1" />

## 影響範囲  / Affected Area
カレンダー一覧画面

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
なし