### PR TITLE
#864 参加者なら他者の活動も削除できる対応

### DIFF
--- a/include/utils/UserInfoUtil.php
+++ b/include/utils/UserInfoUtil.php
@@ -424,7 +424,7 @@ function isPermitted($module,$actionname,$record_id='')
 				return $permission;
 			}
 			//共有されたカレンダーは編集可能にする。
-			if(isCalendarParticipantPermittedBySharing($module, $record_id)){
+			if(isCalendarPermittedForInvitee($module, $record_id)){
 				$permission = "yes";
 				$log->debug("Exiting isPermitted method ...");
 				return $permission;
@@ -461,7 +461,7 @@ function isPermitted($module,$actionname,$record_id='')
 				return $permission;
 			}
 			//共有されたカレンダーは編集可能にする。
-			if(isCalendarParticipantPermittedBySharing($module, $record_id)){
+			if(isCalendarPermittedForInvitee($module, $record_id)){
 				$permission = "yes";
 				$log->debug("Exiting isPermitted method ...");
 				return $permission;
@@ -2295,7 +2295,7 @@ function isCalendarPermittedBySharing($recordId)
 	return $permission;
 }
 
-function isCalendarParticipantPermittedBySharing($module, $recordId)
+function isCalendarPermittedForInvitee($module, $recordId)
 {
 
 	$activityType = vtws_getCalendarEntityType($recordId);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #864 

##  不具合の内容 / Bug
1. MTGなどの活動に参加したとき、他者の活動は削除できないが、自分の活動は削除できる。
　自分の活動を削除したとき、他者の活動も同時に削除される仕様のため、本来なら他者の活動も削除できるべき。

##  原因 / Cause
1. 参加者がいる活動には、個人に紐づけられる子活動と同時に、子活動がどの親活動に紐づいているか管理されている。
　権限チェックの際に、子活動の権限のみ参照しているため、自分の活動しか変更できない。

##  変更内容 / Details of Change
1. 権限チェックの際に、親活動に紐づいたすべての子活動の変更ができるようにする。

## スクリーンショット / Screenshot


## 影響範囲  / Affected Area
編集するユーザー
<img width="529" height="286" alt="スクリーンショット 2025-09-26 112117" src="https://github.com/user-attachments/assets/2aa00b06-aed5-43d9-9bd5-acc1a8463e70" />

他者個人が担当＆自分が参加
<img width="501" height="279" alt="スクリーンショット 2025-09-26 112126" src="https://github.com/user-attachments/assets/11e0046d-a0c7-40ff-8888-8ec31210ff83" />

編集を保存できる。
<img width="470" height="277" alt="スクリーンショット 2025-09-26 112150" src="https://github.com/user-attachments/assets/5372320d-759d-44c9-aad7-81976ac4e511" />

削除できる。
<img width="743" height="1341" alt="スクリーンショット 2025-09-26 112351" src="https://github.com/user-attachments/assets/609ca071-c294-4692-a899-3f6197ae2a66" />

他者グループが担当＆自分が参加
<img width="462" height="380" alt="スクリーンショット 2025-09-26 112627" src="https://github.com/user-attachments/assets/908265e5-68fc-4dad-8873-6dbeeadb3c65" />

編集を保存できる。
<img width="390" height="350" alt="スクリーンショット 2025-09-26 112655" src="https://github.com/user-attachments/assets/be1cfd3f-a0d9-4609-a49b-7b16a0e1d432" />

削除できる。
<img width="612" height="1182" alt="スクリーンショット 2025-09-26 112808" src="https://github.com/user-attachments/assets/e946ba70-2bf3-44a1-af14-3f0eb4a97bf7" />

他者の非公開のTODOがみえない。
<img width="1478" height="813" alt="スクリーンショット 2025-09-26 120240" src="https://github.com/user-attachments/assets/7888734f-0602-44f7-b248-1027e44a0fb1" />

<img width="609" height="393" alt="スクリーンショット 2025-09-26 120246" src="https://github.com/user-attachments/assets/792b0911-d195-439a-9ec7-9aa3f614a27b" />

自分が参加していない非公開カレンダーが見えない
<img width="842" height="198" alt="スクリーンショット 2025-09-26 120306" src="https://github.com/user-attachments/assets/b1980cd0-a65c-48e8-8d5d-886621e49dfa" />

<img width="687" height="383" alt="スクリーンショット 2025-09-26 120314" src="https://github.com/user-attachments/assets/c7f409f3-5241-472b-9db3-e271f610169c" />

公開中のユーザーの予定のみ表示される。
<img width="352" height="1031" alt="スクリーンショット 2025-09-26 120346" src="https://github.com/user-attachments/assets/357086f1-4b49-4943-a07c-19542b0ac514" />

自分が参加していない公開カレンダーが削除できない。
<img width="382" height="313" alt="スクリーンショット 2025-09-26 130535" src="https://github.com/user-attachments/assets/3ec25982-b79a-4de4-8bd5-7f39ffec0cfd" />

<img width="883" height="792" alt="スクリーンショット 2025-09-26 130558" src="https://github.com/user-attachments/assets/7df90cb7-97c5-47c1-98d4-bd1230e62cfe" />

削除不可のモジュールを削除できない
<img width="558" height="144" alt="スクリーンショット 2025-09-26 133634" src="https://github.com/user-attachments/assets/94c871e8-f957-4290-82ed-ff9ed3e6ea02" />
<img width="811" height="281" alt="スクリーンショット 2025-09-26 133745" src="https://github.com/user-attachments/assets/633fd54e-17a3-4b8a-85a3-54ca45ec33e5" />


## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
望ましくないですが、既存のコードに合わせてUtilを修正しました。