### PR TITLE
#1355 パーセント項目の表示修正

### DIFF
--- a/modules/Vtiger/uitypes/Percentage.php
+++ b/modules/Vtiger/uitypes/Percentage.php
@@ -21,7 +21,8 @@ class Vtiger_Percentage_UIType extends Vtiger_Base_UIType {
 	public function getDisplayValue($value, $record = false, $recordInstance = false) {
 		$fldvalue = str_replace(",", ".", $value);
 		$value = (is_numeric($fldvalue)) ? $fldvalue : null;
-		return CurrencyField::convertToUserFormat($value, null, true);
+		$value = decimalFormat($value);
+		return $value;
 	}
 
 	public function getEditViewDisplayValue($value) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1355 

##  不具合の内容 / Bug
1. リスト画面と詳細画面でパーセント項目の表示が異なる

##  原因 / Cause
1. パーセント項目のgetDisplayValueで通貨項目のフォーマットが行われていた。

##  変更内容 / Details of Change
1. 通貨のフォーマット処理を削除
2. リスト出力前に行われている、小数点以下の0をトリムする処理を追加

## スクリーンショット / Screenshot
小数点以下0の場合
<img width="767" height="158" alt="スクリーンショット 2025-09-30 115737" src="https://github.com/user-attachments/assets/1e66110a-da88-44ec-8f90-1c3a97837bdb" />
<img width="498" height="136" alt="スクリーンショット 2025-09-30 115744" src="https://github.com/user-attachments/assets/8fc5c37d-fd7d-4dff-b073-3aa70fa78240" />

小数点以下01の場合
<img width="748" height="135" alt="スクリーンショット 2025-09-30 115755" src="https://github.com/user-attachments/assets/c1b5d1f1-51f3-4c7e-ac96-7be6596c7a52" />
<img width="563" height="128" alt="スクリーンショット 2025-09-30 115803" src="https://github.com/user-attachments/assets/bc0c316c-5e61-4a43-8bef-25cb657e675a" />

小数点以下10の場合
<img width="1311" height="190" alt="スクリーンショット 2025-09-30 131513" src="https://github.com/user-attachments/assets/9aaf3355-0c27-48f4-9b15-a23d2e661735" />
<img width="520" height="129" alt="スクリーンショット 2025-09-30 115818" src="https://github.com/user-attachments/assets/e22fb514-c39e-4111-bf1d-d03ecbbe169b" />

小数点なし
<img width="941" height="226" alt="スクリーンショット 2025-09-30 131659" src="https://github.com/user-attachments/assets/4e1a6ca3-f4c0-4d51-8793-69aeb52b5a2c" />
<img width="522" height="125" alt="スクリーンショット 2025-09-30 115832" src="https://github.com/user-attachments/assets/9601deb1-2e4c-4df3-8ea4-55691fc3cba7" />

## 影響範囲  / Affected Area
パーセント項目のgetDisplayValue出力

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks