### PR TITLE
#1180 チケットモジュールでリストを作成する際に「顧客企業名」でフィルタをかけようとするとエラーが出る問題の修正

### DIFF
--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -151,8 +151,28 @@ jQuery.Class("Vtiger_CustomView_Js",{
 	saveFilter : function() {
 		var aDeferred = jQuery.Deferred();
 		var formElement = jQuery("#CustomView");
+
+		// Temporarily disable filter value inputs to prevent them from being serialized
+		var filterValueInputs = formElement.find('.filterConditionsDiv [data-value="value"]');
+		filterValueInputs.each(function() {
+			var input = jQuery(this);
+			if (input.attr('name')) {
+				input.data('temp-name', input.attr('name'));
+				input.removeAttr('name');
+			}
+		});
+
 		var formData = formElement.serializeFormData();
-        
+
+		// Restore name attributes
+		filterValueInputs.each(function() {
+			var input = jQuery(this);
+			if (input.data('temp-name')) {
+				input.attr('name', input.data('temp-name'));
+				input.removeData('temp-name');
+			}
+		});
+
 		app.helper.showProgress();
 
 		app.request.post({'data':formData}).then(


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1180 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. チケットモジュールでリストを作成する際に「顧客企業名」でフィルタをかけようとするとエラーが出る問題があった

##  原因 / Cause
<!-- バグの原因を記述 -->
  1. フィルタ条件の入力欄にname属性が設定されていた問題
    - AdvanceFilterCondition.tplのテンプレートで、フィルタ値の入力欄にname="parent_id"などの属性が設定されていた
    - フォームをシリアライズすると、これらの入力欄の値がparent_id=顧客のようにトップレベルパラメータとして送信されてしまった
  2. チケットモジュール特有の問題
    - チケットモジュールの「顧客企業名」フィールドは内部的にparent_idという名前
    - parent_idはセキュリティバリデーションの対象で、数値のIDのみが許可される
    - フィルタ条件に「顧客」などの日本語テキストを入力すると、parent_id=顧客として送信され、バリデーションエラー（400 Bad Request）が発生

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
  1. CustomView.jsのsaveFilter()関数を修正
    - フォームをシリアライズする直前に、フィルタ条件の入力欄（.filterConditionsDiv [data-value="value"]）からname属性を一時的に削除
    - シリアライズ完了後、すぐにname属性を元に戻す
  2. この修正が安全な理由
    - サーバー側（Save.php）では、フィルタ条件はadvfilterlistパラメータ（JSON形式）で受け取っており、個別の入力欄のname属性は使用していない
    - name属性は削除後すぐに復元されるため、他のJavaScript処理（通貨フィールドの処理など）には影響しない
    - シリアライズの瞬間だけnameを除外することで、不要なパラメータの送信を防ぐ


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1760" height="1371" alt="image" src="https://github.com/user-attachments/assets/f93132b6-3c58-44cf-9292-57cee0cab960" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- customviewの範囲のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->