### PR TITLE
#1253 ユーザー名の変更時にユーザー登録時にない文字制限がある問題の修正

### DIFF
--- a/layouts/v7/modules/Users/ChangeUsername.tpl
+++ b/layouts/v7/modules/Users/ChangeUsername.tpl
@@ -24,7 +24,7 @@
                                 <span class="redColor">*</span>
                             </label>
                             <div class="controls col-sm-6">
-                                <input type="text" name="new_username" class="form-control inputElement" data-rule-required="true" data-rule-illegal="true"/>
+                                <input type="text" name="new_username" class="form-control inputElement" data-rule-required="true"/>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1253 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザー登録では問題なかった文字が、ユーザー名の変更の際は利用できない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ユーザー登録時にはかけられていなかったバリデーションが、ユーザー名変更時にかけられていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. ユーザー名変更時のバリデーションを削除した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="575" height="189" alt="image" src="https://github.com/user-attachments/assets/8823b6c7-35fc-42b6-938e-c8dfa5bc6e92" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザー名変更時のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->