### PR TITLE
Fix #1369 共有カレンダーにおいて他者の活動を削除した際、権限チェックで弾かれた場合に「成功」と表示される問題の修正

### DIFF
--- a/modules/Calendar/actions/DeleteAjax.php
+++ b/modules/Calendar/actions/DeleteAjax.php
@@ -45,7 +45,7 @@ class Calendar_DeleteAjax_Action extends Vtiger_DeleteAjax_Action {
 		
 		$recordModel = Vtiger_Record_Model::getInstanceById($recordId, $moduleName);
 		$recordModel->set('recurringEditMode', $recurringEditMode);
-		if($request->get('view') == 'SharedCalendar'){ // 共有カレンダーの場合, 共同参加者の予定もJavaScript側にて削除する
+		if($request->get('calendarType') == 'SharedCalendar'){ // 共有カレンダーの場合, 共同参加者の予定もJavaScript側にて削除する
 			$deletedRecords = $recordModel->getInviteeRecordById($recordId);
 			$recordModel->delete();
 		}else{

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1646,7 +1646,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		}
 		var params = {
 			"module": "Calendar",
-			"view": app.view(),
+			"calendarType": app.view(),
 			"action": "DeleteAjax",
 			"record": eventId,
 			"sourceModule": sourceModule


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1369 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. #1369 

##  原因 / Cause
<!-- バグの原因を記述 -->
1. #865 において、カレンダーから活動を削除する際、"view"パラメータとして個人カレンダーなのか、共有カレンダーなのかをDeleteAjaxへ送信するよう修正が行われていた
2. 権限チェックで弾かれた場合、リクエストパラメータにviewが含まれていればviewのレスポンス、そうでなければactionのJSONレスポンス、といった挙動をするため、viewパラメータが含まれることで、viewのレスポンスが返るようになってしまっていた。
3. そのため、JS側でエラーレスポンスのparseが正常に行われず、常に「成功」と表示されてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. Calendar/DeleteAjaxに送信するパラメータをviewからcalendarTypeへ変更
2. 合わせて、DeleteAjax側で受け取って検証するパラメータを変更

## スクリーンショット / Screenshot
<img width="538" height="352" alt="image" src="https://github.com/user-attachments/assets/0e90f9af-d1e3-46d0-8774-26d029da5c96" />

## 影響範囲  / Affected Area
カレンダーの削除

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->