### PR TITLE
#1376 ログイン画面エラーメッセージの修正

### DIFF
--- a/languages/en_us/Users.php
+++ b/languages/en_us/Users.php
@@ -285,6 +285,7 @@ $languageStrings = array(
 	'LBL_ENTER_USERNAME_AND_PASSWORD' => 'Please enter your username and password',
 	'LBL_ENTER_USERNAME' => 'Please enter your username.',
 	'LBL_ENTER_PASSWORD' => 'Please enter your password.',
+	'LBL_ENTER_MAILADDRESS' => 'Please enter your email address.',
 	'LBL_ENTER_USERNAME_AND_MAILADDRESS' => 'Please enter your username and email address',
 	'LBL_INVALID_MAILADDRESS' => 'Invalid email address.',
 	

--- a/languages/ja_jp/Users.php
+++ b/languages/ja_jp/Users.php
@@ -285,8 +285,9 @@ $languageStrings = array(
 	'LBL_ENTER_USERNAME_AND_PASSWORD' => 'ユーザー名とパスワードを入力してください',
 	'LBL_ENTER_USERNAME' => 'ユーザー名を入力してください。',
 	'LBL_ENTER_PASSWORD' => 'パスワードを入力してください。',
+	'LBL_ENTER_MAILADDRESS' => 'メールアドレスを入力してください。',
 	'LBL_ENTER_USERNAME_AND_MAILADDRESS' => 'ユーザー名とメールアドレスを入力してください',
-	'LBL_INVALID_MAILADDRESS' => 'パスワードを入力してください。',
+	'LBL_INVALID_MAILADDRESS' => '無効なメールアドレスです。',
 
 	'LBL_INVALID_USERNAME_OR_PASSWORD' => '無効なユーザー名またはパスワード',
 	'LBL_INVALID_USERNAME_OR_MAILADDRESS' => '無効なユーザー名またはE-mailアドレス',

--- a/layouts/v7/modules/Users/Login.tpl
+++ b/layouts/v7/modules/Users/Login.tpl
@@ -194,7 +194,7 @@
 						errorMessage = "{vtranslate('LBL_ENTER_USERNAME_AND_PASSWORD','Users')}";
 						result = false;
 					} else if (username === '') {
-						errorMessage = "{vtranslate('LBL_USER_NAME','Users')}";
+						errorMessage = "{vtranslate('LBL_ENTER_USERNAME','Users')}";
 						result = false;
 					} else if (password === '') {
 						errorMessage = "{vtranslate('LBL_ENTER_PASSWORD','Users')}";
@@ -216,17 +216,17 @@
 
 					var result = true;
 					var errorMessage = '';
-					if (username === '' & (!emailFilter.test(email1) || email == '')) {
-						errorMessage = '{vtranslate('LBL_ENTER_USERNAME_AND_MAILADDRESS','Users')}";';
+					if (username === '' & email == '') {
+						errorMessage = "{vtranslate('LBL_ENTER_USERNAME_AND_MAILADDRESS','Users')}";
 						result = false;
 					} else if (username === '') {
-						errorMessage = '{vtranslate('LBL_ENTER_USERNAME','Users')}";';
+						errorMessage = "{vtranslate('LBL_ENTER_USERNAME','Users')}";
 						result = false;
-					} else if (!emailFilter.test(email1) || email == '') {
-						errorMessage = '{vtranslate('LBL_ENTER_MAILADDRESS','Users')}";';
+					} else if (email == '') {
+						errorMessage = "{vtranslate('LBL_ENTER_MAILADDRESS','Users')}";
 						result = false;
-					} else if (email.match(illegalChars)) {
-						errorMessage = '{vtranslate('LBL_INVALID_MAILADDRESS','Users')}";';
+					} else if (email.match(illegalChars) || !emailFilter.test(email1)) {
+						errorMessage = "{vtranslate('LBL_INVALID_MAILADDRESS','Users')}";
 						result = false;
 					}
 					if (errorMessage) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1376 

##  不具合の内容 / Bug
1. エラーメッセージがラベルのまま出力される
2. エラーメッセージに";が含まれている
3. 出力されるエラーメッセージが誤っている。

##  原因 / Cause
1. ログイン画面開発時の試験不十分

##  変更内容 / Details of Change
1. ログイン画面、ユーザー名のみ空欄のエラーメッセージを修正
2 パスワード送信画面、エラーメッセージに";が含まれる不具合の修正
2 パスワード送信画面、メールアドレスが無効の場合、無効のメッセージを出すよう修正

## スクリーンショット / Screenshot
<img width="395" height="423" alt="image" src="https://github.com/user-attachments/assets/1c82fa11-c777-4d59-8a65-cdc56246b8fb" />

<img width="396" height="420" alt="image" src="https://github.com/user-attachments/assets/e9d16196-a498-42d7-b548-2e430afa8b43" />

<img width="399" height="427" alt="image" src="https://github.com/user-attachments/assets/f2f60a9d-b032-49a6-a5b7-aa9a6f1487b4" />

<img width="402" height="431" alt="image" src="https://github.com/user-attachments/assets/73328a2c-c53b-4ceb-8015-60083d754639" />

<img width="394" height="420" alt="image" src="https://github.com/user-attachments/assets/15e2d52b-3355-49e4-aa3f-b13ae905ec43" />

<img width="390" height="421" alt="image" src="https://github.com/user-attachments/assets/c1cf1d21-f9cc-4277-b152-aa785a7b12aa" />

<img width="396" height="427" alt="image" src="https://github.com/user-attachments/assets/ac845a87-e33b-4454-a80e-2faed6093a88" />

<img width="399" height="430" alt="image" src="https://github.com/user-attachments/assets/6223d881-1d1f-4a2c-9d7c-3be8bb2565f2" />

<img width="389" height="427" alt="image" src="https://github.com/user-attachments/assets/daf769d3-6f2c-4d66-bb99-ca76a3a905e3" />

<img width="393" height="428" alt="image" src="https://github.com/user-attachments/assets/543fb9c9-2091-49db-bbce-345b27a74359" />

## 影響範囲  / Affected Area
ログイン画面のユーザー名が空の場合のメッセージ
パスワード送信画面のエラーチェック

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
