### PR TITLE
fix:1375 ログイン履歴にpassword, totp, passkeyのどれで認証したかを記録するように修正

### DIFF
--- a/languages/en_us/Settings/Vtiger.php
+++ b/languages/en_us/Settings/Vtiger.php
@@ -319,6 +319,7 @@ $languageStrings = array(
 	'LBL_LOGIN_TIME' => 'Sign-in Time',
 	'LBL_LOGGED_OUT_TIME' => 'Sign-out Time', 
 	'LBL_STATUS' => 'Status',
+	'LBL_LOGIN_TYPE' => 'Login Type',
     
     // Leads and Potentials Mapping 
     'LBL_SAVED_SUCCESSFULLY' => 'Saved Successfully',

--- a/languages/ja_jp/Settings/Vtiger.php
+++ b/languages/ja_jp/Settings/Vtiger.php
@@ -319,6 +319,7 @@ $languageStrings = array(
 	'LBL_LOGIN_TIME' => 'ログイン時刻',
 	'LBL_LOGGED_OUT_TIME' => 'ログアウト時刻',
 	'LBL_STATUS' => 'ステータス',
+	'LBL_LOGIN_TYPE' => 'ログイン種類',
 
 	// Leads and Potentials Mapping 
 	'LBL_SAVED_SUCCESSFULLY' => '保存しました。',

--- a/modules/Settings/LoginHistory/models/ListView.php
+++ b/modules/Settings/LoginHistory/models/ListView.php
@@ -35,7 +35,7 @@ class Settings_LoginHistory_ListView_Model extends Settings_Vtiger_ListView_Mode
 			$userNameSql = $module->baseTable.'.user_name';
 		}
 		
-		$query = "SELECT login_id, case when $userNameSql <> '' then $userNameSql else $module->baseTable.user_name end AS user_name, user_ip, login_time, logout_time, vtiger_loginhistory.status, is_portal FROM $module->baseTable 
+		$query = "SELECT login_id, case when $userNameSql <> '' then $userNameSql else $module->baseTable.user_name end AS user_name, user_ip, login_time, logout_time, vtiger_loginhistory.status, is_portal, login_type FROM $module->baseTable 
 				LEFT JOIN vtiger_users ON vtiger_users.user_name = $module->baseTable.user_name";
 		
         $params = array();

--- a/modules/Settings/LoginHistory/models/Module.php
+++ b/modules/Settings/LoginHistory/models/Module.php
@@ -19,8 +19,9 @@ class Settings_LoginHistory_Module_Model extends Settings_Vtiger_Module_Model {
 			'user_name'=> 'LBL_USER_NAME',
 			'user_ip'=> 'LBL_USER_IP_ADDRESS', 
 			'login_time' => 'LBL_LOGIN_TIME',
-		    'logout_time' => 'LBL_LOGGED_OUT_TIME', 
-			'status' => 'LBL_STATUS'
+			'logout_time' => 'LBL_LOGGED_OUT_TIME', 
+			'status' => 'LBL_STATUS',
+			'login_type' => 'LBL_LOGIN_TYPE'
 		);
 
 	var $name = 'LoginHistory';

--- a/modules/Users/helpers/MultiFactorAuthentication.php
+++ b/modules/Users/helpers/MultiFactorAuthentication.php
@@ -333,7 +333,8 @@ class Users_MultiFactorAuthentication_Helper {
         }
     }
 
-    public static function LoginProcess($userid, $username){
+    // $type: totp or passkey
+    public static function LoginProcess($userid, $username, $type){
         unset($_SESSION['force_2fa_registration']);
         unset($_SESSION['registration_userid']);
 
@@ -357,8 +358,9 @@ class Users_MultiFactorAuthentication_Helper {
         // End
 
         //Track the login History
+        $loginType = $type == 'totp' ? 'mfa_totp' : 'mfa_passkey';
         $moduleModel = Users_Module_Model::getInstance('Users');
-        $moduleModel->saveLoginHistory($username);
+        $moduleModel->saveLoginHistory($username, false, $loginType);
         //End
                     
         header ('Location: index.php?module=Users&parent=Settings&view=SystemSetup');

--- a/modules/Users/models/Module.php
+++ b/modules/Users/models/Module.php
@@ -180,7 +180,7 @@ class Users_Module_Model extends Vtiger_Module_Model {
 	 * Function to store the login history
 	 * @param type $username
 	 */
-	public function saveLoginHistory($username, $isCustomerPortal = false){
+	public function saveLoginHistory($username, $isCustomerPortal = false, $loginType = 'password'){
 		$adb = PearDatabase::getInstance();
 
 		if(empty($username)) {
@@ -194,8 +194,8 @@ class Users_Module_Model extends Vtiger_Module_Model {
 			$userIPAddress = $_SERVER['REMOTE_ADDR'];
 		}
 		$loginTime = date("Y-m-d H:i:s");
-		$query = "INSERT INTO vtiger_loginhistory (user_name, user_ip, logout_time, login_time, status, is_portal) VALUES (?,?,?,?,?,?)";
-		$params = array($username, $userIPAddress, $loginTime,  $loginTime, 'Signed in', $isCustomerPortal);
+		$query = "INSERT INTO vtiger_loginhistory (user_name, user_ip, logout_time, login_time, status, is_portal, login_type) VALUES (?,?,?,?,?,?,?)";
+		$params = array($username, $userIPAddress, $loginTime,  $loginTime, 'Signed in', $isCustomerPortal, $loginType);
 		//Mysql 5.7 doesn't support invalid date in Timestamp field
 		//$params = array($username, $userIPAddress, '0000-00-00 00:00:00',  $loginTime, 'Signed in');
 		$adb->pquery($query, $params);

--- a/modules/Users/views/MultiFactorAuthLogin.php
+++ b/modules/Users/views/MultiFactorAuthLogin.php
@@ -67,7 +67,7 @@ class Users_MultiFactorAuthLogin_View extends Vtiger_View_Controller {
             $currentUser->resetSignatureCount();
             $currentUser->resetLockTime();
             // ログイン処理
-            Users_MultiFactorAuthentication_Helper::LoginProcess($userid, $username);
+            Users_MultiFactorAuthentication_Helper::LoginProcess($userid, $username, $type);
             exit;
         } else {
             // 試行回数のカウントアップ

--- a/setup/migration/scripts/20251106184202_add_login_type_to_loginhistory.php
+++ b/setup/migration/scripts/20251106184202_add_login_type_to_loginhistory.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * マイグレーション: add_login_type_to_loginhistory
+ * 生成日時: 20251106184202
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20251106184202_AddLoginTypeToLoginhistory extends FRMigrationClass {
+    
+    /**
+     * ログイン履歴にlogin_type columnを追加する
+     */
+    public function process() {
+        $db = PearDatabase::getInstance();
+        // add login_type column to vtiger_loginhistory table
+        $sql = "ALTER TABLE vtiger_loginhistory ADD COLUMN login_type VARCHAR(255) NULL";
+        $db->query($sql);
+        
+        $this->log("マイグレーション add_login_type_to_loginhistory が正常に完了しました");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1375

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ログイン履歴にどの認証で認証されたか表示したい（password, totp, passkey）

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. カラムを増やし、ログイン時になんの方式でログインしているかを表示できるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1404" height="348" alt="image" src="https://github.com/user-attachments/assets/388266ec-c15a-4b95-b9cc-6b001a7855e0" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ログイン、ポータルにも影響する可能性があるが引数にデフォルトがあるため問題ない認識ではある

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->