### PR TITLE
#1269　メール送信モーダルのモジュール検索ボタンが機能修正

### DIFF
--- a/layouts/v7/modules/Vtiger/ComposeEmailForm.tpl
+++ b/layouts/v7/modules/Vtiger/ComposeEmailForm.tpl
@@ -52,7 +52,7 @@
                                 <input id="emailField" style="width:100%" name="toEmail" type="text" class="autoComplete sourceField select2" data-rule-required="true" data-rule-multiEmails="true" value="{$TO_EMAILS}" placeholder="{vtranslate('LBL_TYPE_AND_SEARCH',$MODULE)}">
                             </div>
                             <div class="col-lg-4 input-group">
-                                <select style="width: 140px;" class="select2 emailModulesList pull-right" multiple>
+                                <select style="width: 140px;" class="select2 emailModulesList pull-right">
                                     {foreach item=MODULE_NAME from=$RELATED_MODULES}
                                         <option value="{$MODULE_NAME}" {if $MODULE_NAME eq $FIELD_MODULE} selected {/if}>{vtranslate($MODULE_NAME,$MODULE_NAME)}</option>
 							 {/foreach}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1269

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. メール送信モーダルのモジュール検索ボタンを押すとシステムエラーメッセージが表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. emailModulesList を multiple にしたことで配列データが送信されましたが、サーバー側の initializeListViewContents が単一値のみを想定していたため、型の不一致でエラーが発生しました。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `emailModulesList` を multiple から単一選択に変更し、サーバー側が正しい単一値を受け取れるように修正しました。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="901" height="693" alt="image" src="https://github.com/user-attachments/assets/d617697d-56e8-4dcd-b7b1-34ccf9cc5798" />
<img width="907" height="706" alt="image" src="https://github.com/user-attachments/assets/81307f66-0732-4d37-8149-645f80bd881a" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ComposeEmailForm.tpl – emailModulesList の選択方式を multiple から単一選択に変更したことによる影響。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->