### PR TITLE
#1282 　2つエラーメッセージが表示エラー修正

### DIFF
--- a/public/layouts/v7/modules/Settings/Tags/resources/List.js
+++ b/public/layouts/v7/modules/Settings/Tags/resources/List.js
@@ -99,7 +99,7 @@ Settings_Vtiger_List_Js('Settings_Tags_List_Js',{
         var editTagContainer = this.getEditTagContainer();
         var self = this;
 
-        this.getEditTagContainer().find('.saveTag').off('click').on('click', function(e){
+        this.getEditTagContainer().find('.saveTag').on('click', function(e){
 
             var tagName = editTagContainer.find('[name="tagName"]').val();
             if(tagName.trim() == ""){
@@ -197,7 +197,7 @@ Settings_Vtiger_List_Js('Settings_Tags_List_Js',{
         app.event.on('post.listViewFilter.click', function(e){
             //clearing cached dom element. Since it will be replaced with ajax request
             self.editTagContainer = null;
-            self.registerEditTagSaveEvent();
+            // self.registerEditTagSaveEvent();
         })
     }
 });


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1282 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 個人設定 > 個人タグでタグ編集モーダル内で値を空のまま保存を押下すると
同じエラーメッセージが2つ表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 「registerEditTagSaveEvent」内で .saveTag のクリックイベントが毎回再登録され、重複実行されたため、エラーポップアップが二重に表示された。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. registerEditTagSaveEvent 内で、クリックイベントの重複登録を防ぐために .off('click') を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="609" height="377" alt="image" src="https://github.com/user-attachments/assets/83f330a4-39fe-4024-923c-aa9b859e0988" />
<img width="2249" height="210" alt="image" src="https://github.com/user-attachments/assets/d503366e-06d0-4f06-adde-fa60d1919d6d" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
1. タグ編集時の「保存」ボタンのクリックイベント処理が変更されたため、
タグ保存処理・エラーメッセージ表示の挙動に影響が及ぶ可能性があります。
2. 新規タグ作成機能およびタグ削除機能には影響なし。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [X] 自らテストを行った
- [X] 不必要な変更が無い
- [X] 影響範囲の検討を行った
- [X] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->