### PR TITLE
#1333 vtiger_tabのnameを文字数増加

### DIFF
--- a/setup/migration/scripts/20251111191427_update_vtiger_tab_name_length.php
+++ b/setup/migration/scripts/20251111191427_update_vtiger_tab_name_length.php
@@ -27,6 +27,14 @@ class Migration20251111191427_UpdateModuleNameFieldLength extends FRMigrationCla
         $sql = "ALTER TABLE vtiger_ws_entity MODIFY COLUMN name VARCHAR(50) NOT NULL";
         $db->pquery($sql, array());
 
+        // vtiger_ws_entity_referencetype.type
+        $sql = "ALTER TABLE vtiger_ws_entity_referencetype MODIFY COLUMN type VARCHAR(50) NOT NULL";
+        $db->pquery($sql, array());
+
+        // vtiger_customview.entitytype
+        $sql = "ALTER TABLE vtiger_customview MODIFY COLUMN entitytype VARCHAR(50) NOT NULL";
+        $db->pquery($sql, array());
+
         $this->log("マイグレーション update_field_length_to_50 が正常に完了しました");
     }
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1333 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 要望:
現状varchar(25)になっており、少し長い文字を登録しようとすると制限にひっかかり挙動がおかしくなる。
文字数増加し、25から50に変更します。
##  原因 / Cause
<!-- バグの原因を記述 -->
1. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. - vtiger_tab テーブルの name カラムの文字数上限を拡張するためのマイグレーションスクリプトを追加
- 追加ファイル: setup/migration/scripts/20251111191427_update_vtiger_tab_name_length.php

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="865" height="966" alt="image" src="https://github.com/user-attachments/assets/4b093a23-96af-4a0a-9455-2a721ba9df02" />
<img width="846" height="970" alt="image" src="https://github.com/user-attachments/assets/c8c5c24c-d46a-45d1-adb9-b0884e191f72" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- データベーススキーマ（`vtiger_tab` テーブルの `name` カラム）
- モジュール登録処理（モジュール名が 25 文字を超える場合の登録・表示）
- マイグレーション実行環境（`setup/migration/scripts/20251111191427_update_vtiger_tab_name_length.php`）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->