### PR TITLE
 #1371リストで関連項目検索ボタン機能を修正

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/List.js
+++ b/public/layouts/v7/modules/Vtiger/resources/List.js
@@ -1361,7 +1361,7 @@ Vtiger.Class("Vtiger_List_Js", {
 					var params = listSearchParams[i];
 					var fieldName = params[0];  
 					var searchContributorElement = listViewPageDiv.find('.listSearchContributor[name="' + fieldName + '"]');
-			     	var	fieldType = searchContributorElement.data('field-type')
+			     	var	fieldType = searchContributorElement.data('field-type');
 					if (fieldType == 'date' || fieldType == 'datetime') {
 						params[2].split(',').forEach(function(param){
 							var value = (param || '').trim();


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1371

##  不具合の内容 / Bug
1. モジュールのリストで関連項目を検索しようとすると、検索ボタンが押せなくなる。
2. 日付・日時誤った値を正しく検知できない場合があった。
##  原因 / Cause

1. リストビュー検索時のバリデーションチェックで uimeta.field.get(fieldName) を前提に fieldInfo.type を参照していたが、
account_id ; (Accounts) createdtime などの 関連項目のフィールド は uimeta に存在せず、
fieldInfo .type が undefined となり JS エラーが発生、検索ボタンが動かなくなっていた。

  2.日付・日時のチェックが new Date(param) だけだったため、
  20211-10-15 のような誤った値を正しく検知できない場合があった。

##  変更内容 / Details of Change
uimeta は使用せず、画面上の input 要素から data-field-type を取得して判定するように変更。

日付フォーマットのチェックを厳密化、日付値は不正としたらエラーメッセージ を表示し、検索を中断。

## スクリーンショット / Screenshot
不具合＜一＞対応完了
<img width="1438" height="415" alt="image" src="https://github.com/user-attachments/assets/56c05274-b9cd-4164-b707-e5e1c8eb398a" />

<img width="1469" height="205" alt="image" src="https://github.com/user-attachments/assets/633c0d5c-babc-4e3b-ac98-f94e3bd28cbf" />


不具合＜二＞現象
<img width="1985" height="213" alt="image" src="https://github.com/user-attachments/assets/a0358eba-cd01-4851-83a2-b07162c2411e" />
<img width="1710" height="392" alt="image" src="https://github.com/user-attachments/assets/6f76083c-68d4-4706-84b2-8b564845a1f5" />
<img width="1871" height="562" alt="image" src="https://github.com/user-attachments/assets/d8c2af09-8e35-4215-af3b-293c105c12d6" />

不具合＜ニ＞対応完了
<img width="2504" height="379" alt="image" src="https://github.com/user-attachments/assets/7a57d240-3f7e-46d1-9c3c-7957b29679eb" />
<img width="2489" height="407" alt="image" src="https://github.com/user-attachments/assets/6d01fa4d-0293-404f-9143-50e2899388f9" />


## 影響範囲  / Affected Area
全モジュールのリストビュー検索（ヘッダの「検索」ボタン）

特に、関連項目を含むカスタムビュー、日付 / 日時 / 時刻フィールドでの検索
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->