### PR TITLE
# 1388 ユーザー永久削除時に関連する MFA 情報も全て削除するよう対応

### DIFF
--- a/modules/Users/models/Record.php
+++ b/modules/Users/models/Record.php
@@ -786,6 +786,14 @@ class Users_Record_Model extends Vtiger_Record_Model {
 	public static function deleteUserPermanently($userId, $newOwnerId) {
 		$db = PearDatabase::getInstance();
 
+		$userRecord = Users_Record_Model::getInstanceById($userId, 'Users');
+        $credentials = $userRecord->getUserCredential();
+
+        foreach ($credentials as $credential) {
+            $credentialId = $credential['id'];
+            $userRecord->deleteMultiFactorAuthentication($credentialId);
+        }
+
 		$sql = "UPDATE vtiger_crmentity SET smcreatorid=?,smownerid=?,modifiedtime=? WHERE smcreatorid=? AND setype=?";
 		$db->pquery($sql, array($newOwnerId, $newOwnerId, date('Y-m-d H:i:s'), $userId,'ModComments'));
 


### PR DESCRIPTION
(cherry picked from commit cbdb4c3071ece364e6a811b948f9213f489546f2)

##  関連Issue / Related Issue
- fix #1388  

##  不具合の内容 / Bug
1. ユーザーを「削除」または「永久削除」しても、
該当ユーザーに紐づく 多要素認証（MFA）レコード が残り続ける

##  原因 / Cause
1. 単一MFA削除のみ対応しており、ユーザー本体の削除処理が実行されており、該当ユーザーに紐づくMFA レコード削除ロジックが存在しない。

##  変更内容 / Details of Change
1. deleteUserPermanently永久削除内で該当ユーザーの全 MFA レコード削除処理を追加。

## スクリーンショット / Screenshot
<img width="1283" height="223" alt="image" src="https://github.com/user-attachments/assets/33b9a20e-76c9-45e8-ad2b-1da077c45003" />
<img width="1849" height="218" alt="image" src="https://github.com/user-attachments/assets/27c5baf6-4529-403c-8192-c4e8785b5efc" />
<img width="1103" height="185" alt="image" src="https://github.com/user-attachments/assets/ddde3624-32d5-4fbe-bd95-57b7e11b49a6" />
<img width="892" height="184" alt="image" src="https://github.com/user-attachments/assets/66e595e1-52b9-4218-a398-d9c59934673b" />
<img width="1333" height="322" alt="image" src="https://github.com/user-attachments/assets/6e3a6c97-45cb-44c3-87e1-d26a2377e050" />
<img width="647" height="90" alt="image" src="https://github.com/user-attachments/assets/539b0073-0ede-4b10-a35a-6572102ccea7" />
<img width="1275" height="267" alt="image" src="https://github.com/user-attachments/assets/c95401ba-284d-42b8-895d-c3277616282f" />
<img width="783" height="162" alt="image" src="https://github.com/user-attachments/assets/950e4db3-064d-4566-8a31-bdf32586c9ce" />
<img width="899" height="177" alt="image" src="https://github.com/user-attachments/assets/87e5534e-fb03-4fb8-858a-a47385cefe44" />


## 影響範囲  / Affected Area
1.ユーザー削除処理（永久削除）
2.vtiger_user_credentials テーブル（関連レコード削除)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->