### PR TITLE
#1387 管理者(ID =1)を削除不可対応

### DIFF
--- a/layouts/v7/modules/Users/ListViewRecordActions.tpl
+++ b/layouts/v7/modules/Users/ListViewRecordActions.tpl
@@ -23,7 +23,7 @@
 						<li><a href="{$LISTVIEW_ENTRY->getEditViewUrl()}&parentblock=LBL_USER_MANAGEMENT" name="editlink">{vtranslate('LBL_EDIT', $MODULE)}</a></li>
 					{/if}
 				{/if}
-				{if $IS_MODULE_DELETABLE && $LISTVIEW_ENTRY->getId() != $USER_MODEL->getId()}
+				{if $IS_MODULE_DELETABLE && $LISTVIEW_ENTRY->getId() != $USER_MODEL->getId()&& $LISTVIEW_ENTRY->getId() != 1}
 					{if $LISTVIEW_ENTRY->get('status') eq 'Active'}
 						<li>
 							<a onclick='Settings_Users_List_Js.triggerDeleteUser("{$LISTVIEW_ENTRY->getDeleteUrl()}")'>{vtranslate("LBL_REMOVE_USER",$MODULE)}</a>

--- a/modules/Users/actions/DeleteAjax.php
+++ b/modules/Users/actions/DeleteAjax.php
@@ -22,9 +22,11 @@ class Users_DeleteAjax_Action extends Vtiger_Delete_Action {
 
 		if(!$currentUser->isAdminUser() && $mode !== 'credential') {
 			throw new AppException(vtranslate('LBL_PERMISSION_DENIED', 'Vtiger'));
-		} else if($currentUser->isAdminUser() && ($currentUser->getId() == $ownerId)) {
+		} else if($currentUser->isAdminUser() && ($currentUser->getId() == $ownerId) ){
 			throw new AppException(vtranslate('LBL_PERMISSION_DENIED', 'Vtiger'));
-		} 
+		} else if ($ownerId == 1) {
+            throw new AppException(vtranslate('LBL_PERMISSION_DENIED', 'Vtiger'));
+        }
 	}
 
     public function deleteUserCredential($userid, $credentialId) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1387 

##  不具合の内容 / Bug
システム管理者（ID = 1）が通常ユーザーと同様に削除操作の対象となってる

##  原因 / Cause
1.ユーザー削除時のチェックロジックにおいて、「ID = 1 のスーパー管理者」を特別扱いする条件分岐が実装されていなかった。

##  変更内容 / Details of Change
1.ユーザー削除処理 (RecordActions,checkPermission,) にID = 1 の場合は削除ボタンを表示しない / 削除処理を拒否する 制御を追加。

## スクリーンショット / Screenshot
<img width="1916" height="231" alt="image" src="https://github.com/user-attachments/assets/e81e2c08-d26f-4800-96dc-a6c86595066e" />
<img width="1106" height="184" alt="image" src="https://github.com/user-attachments/assets/4aeab9ea-cf5b-4125-b358-4528c9471d2b" />
<img width="2309" height="304" alt="image" src="https://github.com/user-attachments/assets/49de3bb6-dfcf-47ea-94a8-583f67ef32b7" />
(システム管理者権限を持つとしても、adminユーザー(レコードID=1)を削除ボタン表示されない)
<img width="1277" height="242" alt="image" src="https://github.com/user-attachments/assets/63137043-2e2d-419a-8ba4-d41444c962ab" />


## 影響範囲  / Affected Area
1.Users モジュールの削除操作全般
2.(一覧画面 / Ajax 削除 API）
3.管理者（ID = 1）の削除防止に関する UI および処理ロジック

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->