### PR TITLE
#1384 チケットの関連リストに資産・レンタル管理が重複表示を修正

### DIFF
--- a/setup/migration/scripts/20251127120006_fix_duplicate_helpdesk_assets_relation.php
+++ b/setup/migration/scripts/20251127120006_fix_duplicate_helpdesk_assets_relation.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * マイグレーション: fix_duplicate_helpdesk_assets_relation
+ * 生成日時: 20251127120006
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+require_once dirname(__FILE__) . '/../../../include/utils/CommonUtils.php';
+
+class Migration20251127120006_FixDuplicateHelpdeskAssetsRelation extends FRMigrationClass {
+    public function process() {
+        global $adb;
+
+        // ---- HelpDesk と Assets の tabid を取得 ----
+        $helpdeskTabId = $this->getTabId('HelpDesk');
+        $assetsTabId   = $this->getTabId('Assets');
+
+        // モジュールが存在しない場合は処理を中止
+        if (!$helpdeskTabId || !$assetsTabId) {
+            return;
+        }
+
+        // ---- HelpDesk → Assets の N:N 関係のみ取得（重複検出用）----
+        $sql = "SELECT relation_id FROM vtiger_relatedlists WHERE tabid = ? AND related_tabid = ? AND name = 'get_related_list'AND relationfieldid IS NULL AND relationtype = 'N:N' ORDER BY relation_id ASC";
+        $result = $adb->pquery($sql, [$helpdeskTabId, $assetsTabId]);
+        $count = $adb->num_rows($result);
+
+        // 重複が1件以下存在する場合スキップ
+        if ($count <= 1) {
+            return; 
+        }
+
+        // 最初の1件（最も古い関係）は削除せず保持するためのフラグ
+        $firstRow = true;   
+
+        // 取得した relation_id を1件ずつ処理
+        while ($row = $adb->fetch_array($result)) {
+
+            // ---- 最初の1件は削除せずスキップ ----
+            if ($firstRow) {    // first row → keep
+                $firstRow = false;
+                continue;
+            }
+
+            // ---- 2件目以降の重複データを削除 ----
+            $adb->pquery(
+                "DELETE FROM vtiger_relatedlists WHERE relation_id = ?",
+                [$row['relation_id']]
+            );
+        }
+    }
+
+    /** モジュール名から tabid を取得する関数 */
+    private function getTabId($moduleName) {
+        global $adb;
+
+        $result = $adb->pquery("SELECT tabid FROM vtiger_tab WHERE name = ?", [$moduleName]);
+
+        if ($adb->num_rows($result) > 0) {
+            $row = $adb->fetch_array($result);
+            return $row['tabid'];
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1384 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. HelpDesk → Assets の N:N 関連がMigration により 2 件（180, 181）重複登録され、関連タブが二重表示されていた。

##  原因 / Cause
同じ setRelatedList() を複数の Migration で実行しており、同一の N:N 関係が重複作成されたため。

##  変更内容 / Details of Change
HelpDesk → Assets の N:N 関連（relationfieldid IS NULL / get_related_list）を取得し、最初から生成されの 1 件だけ残し、それ以外を削除する Migration を追加。

## スクリーンショット / Screenshot
<img width="1205" height="589" alt="image" src="https://github.com/user-attachments/assets/f90047eb-8d62-41b5-b629-5cb578796cee" />
<img width="1397" height="150" alt="image" src="https://github.com/user-attachments/assets/e3f939b1-8629-4fe1-9220-00b2c2979a9a" />

## 影響範囲  / Affected Area
HelpDesk（チケット） の関連タブ表示
（※ 1:N の関連には影響なし）

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->