### PR TITLE
#1383 モジュール権限無効をアクション権限有効より優先する

### DIFF
--- a/include/utils/UserInfoUtil.php
+++ b/include/utils/UserInfoUtil.php
@@ -1580,6 +1580,8 @@ function getCombinedUserActionPermissions($userId)
 	$actionPerrArr=Array();
 
 	$actionPerrArr=getProfileAllActionPermission($profArr[0]);
+	$tabPerArr = getProfileTabsPermission($profArr[0]);
+
 	if($no_of_profiles != 1)
 	{
 		for($i=1;$i<$no_of_profiles;$i++)
@@ -1591,7 +1593,13 @@ function getCombinedUserActionPermissions($userId)
 			{
 				foreach($perArr as $actionid=>$per)
 				{
-					if($per == 1)
+					//元のモジュール権限が無効の場合、アクション権限も無効にする
+					if($tabPerArr[$tabId] != 0)
+					{
+						$actionPerrArr[$tabId][$actionid]=$tabPerArr[$tabId];
+					}
+					//複数プロファイルの場合、有効のアクション権限を優先する
+					if($actionPerrArr[$tabId][$actionid] == 1)
 					{
 						$now_permission = $tempActionPerrArr[$tabId][$actionid];
 						if($now_permission == 0 && $now_permission != "" && $tempTabPerArr[$tabId] == 0)


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1383 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  前提：TabのPermissionがon、かつ、ActionのPermissionがoffのケースは存在する
1. ProfileIdの数字が小さいほうが、Tabがoff、Actionがすべてon
1. ProfileIdの数字が大きいほうが読み取り権限のみ
1. 結果、Tab権限はProfildが大きいほうのPermissionを採用してonになり、Ationの権限はProfileIdが小さいほうonを採用するため、本来使用できない機能も使用可能となる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. TabPermissionがoffのとき、ActionPermissionがすべてoffだと、offに上書きしないため

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. createUserPrivilegesfile内でActionのPermissionを作成するとき、Tab権限がoffのとき、Action権限もoffにする。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
行った試験
<img width="1508" height="303" alt="image" src="https://github.com/user-attachments/assets/c773b183-8091-495a-805d-2b6c66ed0472" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
複数プロファイル時のアクションの権限

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
