### PR TITLE
レポート出力画面でHeaderを固定するように修正（982修正PR）

### DIFF
--- a/layouts/v7/modules/Reports/ReportContents.tpl
+++ b/layouts/v7/modules/Reports/ReportContents.tpl
@@ -46,7 +46,7 @@
             {/if}
         </div>
     </div>
-    <div id="reportDetails" class="contents-bottomscroll">
+    <div id="reportDetails" class="contents-bottomscroll table-container">
         <div class="bottomscroll-div">
             <input type="hidden" id="updatedCount" value="{$NEW_COUNT}" />
             {if $DATA neq ''}

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -936,6 +936,31 @@ ul#productsImageContainer > li a{
   font-size: 12px;
 }
 
+/* レポートのヘッダーを固定する */
+#reportDetails.contents-bottomscroll {
+	max-height: 70vh;
+}
+#reportDetails table tr.blockHeader th{
+  position: sticky;
+  z-index: 1;
+  top: 0;
+
+  border-color: inherit;
+  background-color: inherit;
+  background-image: inherit;
+  background-repeat: inherit;
+}
+#reportDetails table tr.blockHeader th::before {
+  /* stickyにより枠線が消えてしまうため疑似要素に枠線を追加 */
+  content: "";
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: -1px;
+  left: 0;
+  border-top: 2px solid white;
+}
+
 /* レコード編集画面のpadding-leftを可変ではなく固定にする */
 @media (min-width: 992px) {
   .editViewPageDiv.viewContent > .content-area {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #970 
https://github.com/thinkingreed-inc/F-RevoCRM/pull/982 の修正版PR

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポートのヘッダーをスクロール時に固定したい。
レポートの横スクロールが必要な時一番したまで行かなければならない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. テーブルにmax-heightを設定し、ページ最下までいかなくても横スクロールができるように変更
2. position:stickyでレポート項目の行が固定されるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
* レポート項目の行が固定されている様子（右スクロールバーを移動してもレポート項目が表示されている）
![image](https://github.com/thinkingreed-inc/F-RevoCRM/assets/75693720/bc6f40f6-7d6e-4914-b44a-a87b0c106a06)


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
レポート一覧のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
指定が厳密ではないため、本来はFlexで正しくスタリングしたい。
むずかしいため、現状は70vhによる指定とする