### PR TITLE
fix #190 スマホサイズ画面でユーザー詳細画面でアイコンが隠れる不具合の修正

### DIFF
--- a/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ModuleHeader.tpl
@@ -12,7 +12,7 @@
 {strip}
 	<div class="col-sm-12 col-xs-12 module-action-bar coloredBorderTop">
 		<div class="module-action-content clearfix">
-			<div class="col-lg-7 col-md-7">
+			<div class="col-lg-7 col-md-7 textOverflowTest">
 				{if $USER_MODEL->isAdminUser()}
 					<a title="{vtranslate('Home', $MODULE)}" href='index.php?module=Vtiger&parent=Settings&view=Index'>
 						<h4 class="module-title pull-left text-uppercase">{vtranslate('LBL_HOME', $MODULE)} </h4>

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -334,6 +334,10 @@ div.detailview-content.container-fluid span.value img {
 }
 .module-action-bar.coloredBorderTop {
   width: calc(100% - 42px);
+  height: 90px;
+}
+.textOverflowTest{
+	width: 600px;
 }
 @media all and (min-width:992px) and (max-width: 1290px) {
     .global-nav .app-list {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #190
##  関連プルリクエスト
- fix #447 

## 備考
　コンフリクトが多く小さい修正だったため、別で出し直し