### PR TITLE
fix #1416 [不具合]カレンダー　終日でない活動をドラックアンドドロップで終日の領域に移動させると「この活動を編集する権限がありま…

### DIFF
--- a/modules/Calendar/actions/DragDropAjax.php
+++ b/modules/Calendar/actions/DragDropAjax.php
@@ -312,7 +312,7 @@ class Calendar_DragDropAjax_Action extends Calendar_SaveAjax_Action {
 	 */
 	public function changeDateTime($datetime,$daysToAdd,$minutesToAdd,$secondsDelta=NULL){
 		$datetime = strtotime($datetime);
-		if(!$secondsDelta) {
+		if($secondsDelta == NULL) {
 			$secondsDelta = (60*$minutesToAdd)+(24*60*60*$daysToAdd);
 		}
 		$futureDate = $datetime+$secondsDelta;


### PR DESCRIPTION

##  関連Issue / Related Issue
- fix #1416

##  原因 / Cause
1.  空と0が同様に判定されその後の処理がエラーになっていた

##  変更内容 / Details of Change
1. 空の場合のみ処理が通るように

## 影響範囲  / Affected Area
カレンダー画面での既存レコードに対するドラッグドロップ処理

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

