### PR TITLE
ユーザーインポート時の「役割」項目は、$default_languageの翻訳後名称を使って翻訳後の文字列と当てるように修正

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1691,6 +1691,7 @@ class Users extends CRMEntity {
 	}
 
 	function createRecords($obj) {
+		global $log, $default_language;
 		$adb = PearDatabase::getInstance();
 		$moduleName = $obj->module;
 		$createdRecords = array();
@@ -1756,7 +1757,10 @@ class Users extends CRMEntity {
 						}
 					} else if($fieldName == 'roleid') {
 						foreach($allRoles as $role) {
-							if(strtolower($fieldValue) == strtolower($role->getName())) {
+							$roleLabelKey = $role->getName();
+							// 「役割」は翻訳後の値での比較、default_languageを見て比較する
+							$translatedRoleName = Vtiger_Language_Handler::getTranslatedString($roleLabelKey, 'Settings:Roles', $default_language);
+							if(strtolower($fieldValue) == strtolower($translatedRoleName)) {
 								$roleId = $role->getId();
 								break;
 							}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
なし

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ユーザーインポートが正常にできない
2. 仕様が分かり辛い

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ユーザーインポートで、役割を設定する時、ロールの内部名称（LBL_GENERAL 等）を入れなくてはいけないが、この内部名称を知る手段がない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 「役割」をインポート時に指定する時、FRの $default_language に依存した変換後の文字列で当てるように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
ユーザーインポート部分のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->