### PR TITLE
#1285 初期設定されている一部のワークフローが編集時にエラーとなっている問題の対応

### DIFF
--- a/setup/migration/scripts/20260205065656_fix_workflow_task_serialization.php
+++ b/setup/migration/scripts/20260205065656_fix_workflow_task_serialization.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * マイグレーション: fix_workflow_task_serialization
+ * 生成日時: 20260205065656
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260205065656_FixWorkflowTaskSerialization extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     *
+     * Issue #1285: ワークフロータスクのシリアライズ形式を修正
+     * PHP 8.3でunserialize()が失敗する不正な形式 s:0:"1" を s:1:"1" に修正
+     */
+    public function process() {
+        // 不正なシリアライズ形式を修正
+        // s:0:"1" は「長さ0の文字列」と宣言しながら "1" を持つ不正な形式
+        // 正しくは s:1:"1"（長さ1の文字列 "1"）
+        // 対象は初期インストール時のデフォルトタスク（task_id: 1-16）のみ
+        $sql = "UPDATE com_vtiger_workflowtasks
+                SET task = REPLACE(task, 's:0:\"1\"', 's:1:\"1\"')
+                WHERE task LIKE '%s:0:\"1\"%'
+                AND task_id <= 16";
+        $this->db->pquery($sql, array());
+
+        $this->log("Fixed workflow task serialization format (Issue #1285)");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1285

##  不具合の内容 / Bug
1. デフォルトでインストールされているワークフローの編集画面を開くと、タスク部分でエラーが表示される
2. `Fatal error: get_class(): Argument #1 ($object) must be of type object, false given` が発生

##  原因 / Cause
1. `com_vtiger_workflowtasks`テーブルの`task`カラムに格納されているシリアライズデータに不正な形式が含まれていた
2. 具体的には `s:6:"active";s:0:"1"` という形式で、「長さ0の文字列」と宣言しながら `"1"` という長さ1の値を持つ矛盾した状態
3. PHP 8.3で`unserialize()`の検証が厳密化されたことにより、この不正な形式でエラーが発生するようになった

##  変更内容 / Details of Change
1. マイグレーションスクリプト `20260205065656_fix_workflow_task_serialization.php` を追加
2. 不正なシリアライズ形式 `s:0:"1"` を正しい形式 `s:1:"1"` に修正するUPDATEクエリを実行
3. 対象は初期インストール時のデフォルトタスク（task_id: 1-16）のみに限定

## スクリーンショット / Screenshot
**修正前：**
関連Issue参照

**修正後：**
<img width="885" height="669" alt="image" src="https://github.com/user-attachments/assets/d83170da-c769-4e5e-8185-c85656c274b9" />

## 影響範囲  / Affected Area
- `com_vtiger_workflowtasks`テーブルの既存データ（初期インストール時のデフォルトワークフロータスク task_id 1-16）
- インストール後のマイグレーション実行時に自動修正される

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（該当なし：マイグレーションスクリプトのみ）

## 備考 / Remarks
- このマイグレーションは冪等性があり、複数回実行しても問題ない