### PR TITLE
fix #1207 カレンダー一括削除で参加者予定の親子レコード同時削除時にエラーが発生する問題を修正

### DIFF
--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -123,7 +123,8 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 			foreach($childRecords as $record) {
 				$recordModel = $this->getInstanceById($record, $this->getModuleName());
 				$adb->pquery("DELETE FROM vtiger_activity_recurring_info WHERE activityid=? AND recurrenceid=?", array($parentRecurringId, $record));
-				$recordModel->deleteInviteeRecord();
+				$inviteeDeletedRecords = $recordModel->deleteInviteeRecord();
+				$deletedRecords = array_merge($deletedRecords, $inviteeDeletedRecords);
 				$recordModel->getModule()->deleteRecord($recordModel);
 				$deletedRecords[] = $record;
 			}
@@ -132,7 +133,8 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 				$parentRecurringId = $this->getParentRecurringRecord();
 				$adb->pquery("DELETE FROM vtiger_activity_recurring_info WHERE activityid=? AND recurrenceid=?", array($parentRecurringId, $this->getId()));
 			}
-			$this->deleteInviteeRecord();
+			$inviteeDeletedRecords = $this->deleteInviteeRecord();
+			$deletedRecords = array_merge($deletedRecords, $inviteeDeletedRecords);
 			$this->getModule()->deleteRecord($this);
 			$deletedRecords[] = $this->getId();
 		}
@@ -225,6 +227,7 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 	
 	public function deleteInviteeRecord() {
 		global $adb;
+		$deletedRecords = array();
 
 		$result = $adb->pquery("SELECT
 									a.activityid
@@ -247,7 +250,9 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 
 			$adb->pquery("DELETE FROM vtiger_activity_recurring_info WHERE recurrenceid=?", array($recordModel->getId()));
 			$recordModel->getModule()->deleteRecord($recordModel);
+			$deletedRecords[] = $activityid;
 		}
+		return $deletedRecords;
 	}
 
 	// 共同参加者のカレンダーidを取得する関数


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1207 
- #1210 
- #1077 

##  不具合の内容 / Bug
1. カレンダーモジュールで参加者を含む予定を一括削除する際、親レコードと子レコード（参加者のレコード）を同時に選択して削除すると「指定したレコードは削除されています。」エラーが発生する

##  原因 / Cause
1. 参加者を含む予定（親）を削除すると、`deleteInviteeRecord()`により参加者の予定（子）も自動的に削除される
2. 一括削除のループで親と子の両方を選択していた場合、親の削除時に子も削除されるが、その後ループで子レコードを削除しようとしてエラーが発生する

##  変更内容 / Details of Change
1. `deleteInviteeRecord()`: 削除したレコードIDの配列を返すように変更
2. `Calendar_Record_Model::delete()`: `deleteInviteeRecord()`の戻り値を削除済みリストにマージ
3. `Calendar_MassDelete_Action::process()`: 削除済みレコードを追跡し、既に削除されたレコードはスキップするよう変更

## 影響範囲  / Affected Area
- カレンダーモジュールの一括削除機能
- 参加者を含む予定の削除処理

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- PR #1210 のレビュー指摘（`delete()`の戻り値を利用する方針）を反映した実装
- テスト結果:
- 参加者予定の親子同時削除: 修正前 ❌ → 修正後 ✅
- 繰り返し予定の一括削除: 修正前後ともに ✅
- 通常の予定削除: 修正前後ともに ✅