### PR TITLE
#1448 インストール画面Step3にてボタン操作が効かない不具合の修正

### DIFF
--- a/public/layouts/v7/resources/MultiFactorAuthentication.js
+++ b/public/layouts/v7/resources/MultiFactorAuthentication.js
@@ -526,6 +526,10 @@ window.FR_MultiFactorAuthentication_Js = {
      */
     init: function () {
         this.cacheDom();
+        // MFA画面でない場合は処理をスキップ
+        if (!this.elements.passkeyForm && !this.elements.totpForm) {
+            return;
+        }
         this.bindEvents();
         this.handleInitialState();
     }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1448 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インストール画面（Step3等）でJavaScriptエラーが発生し、ボタン操作が効かない
2. コンソールに `Uncaught TypeError: Cannot set properties of null (setting 'checked')` エラーが表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `MultiFactorAuthentication.js`が全ページで読み込まれるが、インストール画面にはMFA関連のDOM要素（`#remember_mfa_checkbox`等）が存在しない
2. `init()`関数から呼ばれる`applyPreferredMfa()`内で、存在しないDOM要素のプロパティを設定しようとしてエラーが発生

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `init()`関数内で`passkeyForm`と`totpForm`の両方が存在しない場合は早期リターンするように変更
2. MFA関連のDOM要素がないページでは初期化処理をスキップ

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- インストール画面（Step1〜Step7）
- MFA機能がない画面全般
- MFA機能がある画面（ログイン画面、ユーザー設定画面）への影響なし

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
