### PR TITLE
活動の編集画面において、繰り返しか否かの判定がYes/Noで判定されているが、翻訳がかかった値と比較が行われてしまっている問題の修正

### DIFF
--- a/layouts/v7/modules/Vtiger/uitypes/RecurrenceDetailView.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/RecurrenceDetailView.tpl
@@ -9,7 +9,7 @@
   *
  ********************************************************************************/
 -->*}
-<div id="addEventRepeatUI" data-recurring-enabled="{if $RECURRING_INFORMATION['recurringcheck'] eq 'Yes'}true{else}false{/if}">
+<div id="addEventRepeatUI" data-recurring-enabled="{if $RECURRING_INFORMATION['recurringcheck_raw'] eq 'Yes'}true{else}false{/if}">
 	<div><span>{$RECURRING_INFORMATION['recurringcheck']}</span></div>
 	{if $RECURRING_INFORMATION['recurringcheck'] eq 'Yes'}
 	<div>

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -149,13 +149,15 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 		$recurringObject = $this->getRecurringObject();
 		if ($recurringObject) {
 			$recurringInfoDisplayData = $recurringObject->getDisplayRecurringInfo();
-			$recurringEndDate = $recurringObject->getRecurringEndDate(); 
+			$recurringInfoDisplayData['recurringcheck_raw'] = 'Yes';
+			$recurringEndDate = $recurringObject->getRecurringEndDate();
 		} else {
 			$recurringInfoDisplayData['recurringcheck'] = vtranslate('LBL_NO', $currentModule);
+			$recurringInfoDisplayData['recurringcheck_raw'] = 'No';
 			$recurringInfoDisplayData['repeat_str'] = '';
 		}
-		if(!empty($recurringEndDate)){ 
-			$recurringInfoDisplayData['recurringenddate'] = $recurringEndDate->get_formatted_date(); 
+		if(!empty($recurringEndDate)){
+			$recurringInfoDisplayData['recurringenddate'] = $recurringEndDate->get_formatted_date();
 		}
 
 		return $recurringInfoDisplayData;


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー詳細画面から繰り返し予定を削除する際、繰り返し選択ダイアログ（この予定のみ/以降すべて/すべて）が表示されず、通常の削除確認ダイアログのみが表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `RecurrenceDetailView.tpl`で`data-recurring-enabled`属性の判定に`$RECURRING_INFORMATION['recurringcheck']`を使用しているが、この値は翻訳済み（日本語では「はい」）のため、`'Yes'`との比較が常にfalseになる
2. `getRecurringDetails()`が返す`recurringcheck`は表示用の翻訳済み文字列であり、判定用の未翻訳値が存在しなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `modules/Calendar/models/Record.php`の`getRecurringDetails()`に`recurringcheck_raw`キーを追加し、未翻訳の`'Yes'`/`'No'`を返すように修正
2. `layouts/v7/modules/Vtiger/uitypes/RecurrenceDetailView.tpl`の`data-recurring-enabled`属性の判定条件を`recurringcheck_raw`に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- カレンダー詳細画面からの削除操作
- 繰り返し予定の削除時の挙動

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 言語対応は不要（コード内の文字列変更なし、判定用の内部値を追加しただけ）