### PR TITLE
活動のクイック作成における複数の問題の対応

### DIFF
--- a/assets/react-web-components/src/components/ui/time-combobox.tsx
+++ b/assets/react-web-components/src/components/ui/time-combobox.tsx
@@ -71,6 +71,8 @@ export function TimeComboBox({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  // Track if an option was just selected to skip blur normalization
+  const optionSelectedRef = useRef(false);
   const [dropdownPosition, setDropdownPosition] = useState<{
     top: number;
     left: number;
@@ -108,6 +110,13 @@ export function TimeComboBox({
     setTimeout(() => {
       setIsOpen(false);
 
+      // Skip normalization if an option was just selected
+      // (handleOptionClick already handled the value correctly)
+      if (optionSelectedRef.current) {
+        optionSelectedRef.current = false;
+        return;
+      }
+
       // Normalize the input value
       const normalized = normalizeTimeInput(inputValue);
       if (normalized) {
@@ -129,6 +138,8 @@ export function TimeComboBox({
 
   // Handle option click
   const handleOptionClick = useCallback((option: TimeOption) => {
+    // Mark that an option was selected to skip blur normalization
+    optionSelectedRef.current = true;
     setInputValue(option.value);
     setLastValidValue(option.value);
     onChange(option.value);

--- a/assets/react-web-components/src/utils/datetime.ts
+++ b/assets/react-web-components/src/utils/datetime.ts
@@ -116,3 +116,37 @@ export function calcRoundMinDate(date: Date, roundNum: number): Date {
 
   return newDate;
 }
+
+/**
+ * Calendar/Events用の日時フィールド変換
+ * datetime-local形式 (YYYY-MM-DDTHH:MM) を date + time に分割
+ *
+ * @example
+ * // date_start: "2024-01-15T10:00" → date_start: "2024-01-15", time_start: "10:00"
+ * // due_date: "2024-01-15T11:00" → due_date: "2024-01-15", time_end: "11:00"
+ */
+export function transformCalendarDateTime(data: Record<string, unknown>): Record<string, unknown> {
+  const transformed = { ...data };
+
+  // date_start → date_start + time_start
+  if (transformed.date_start && typeof transformed.date_start === 'string') {
+    const dateStartValue = transformed.date_start;
+    if (dateStartValue.includes('T')) {
+      const [datePart, timePart] = dateStartValue.split('T');
+      transformed.date_start = datePart;
+      transformed.time_start = timePart;
+    }
+  }
+
+  // due_date → due_date + time_end
+  if (transformed.due_date && typeof transformed.due_date === 'string') {
+    const dueDateValue = transformed.due_date;
+    if (dueDateValue.includes('T')) {
+      const [datePart, timePart] = dueDateValue.split('T');
+      transformed.due_date = datePart;
+      transformed.time_end = timePart;
+    }
+  }
+
+  return transformed;
+}

--- a/modules/Vtiger/apis/GetRecord.php
+++ b/modules/Vtiger/apis/GetRecord.php
@@ -77,6 +77,13 @@ class Vtiger_GetRecord_Api extends Vtiger_Api_Controller {
             $sensitiveFields = array('user_password', 'confirm_password', 'accesskey', 'crypt_type', 'user_hash');
             $data = array_diff_key($data, array_flip($sensitiveFields));
 
+            // Calendar/Events モジュールの場合、繰り返し活動情報を追加
+            if (($sourceModule === 'Calendar' || $sourceModule === 'Events') && method_exists($recordModel, 'getRecurrenceInformation')) {
+                $recurringInfo = $recordModel->getRecurrenceInformation();
+                // recurringcheck: 'Yes' or 'No'
+                $data['recurringcheck'] = isset($recurringInfo['recurringcheck']) ? $recurringInfo['recurringcheck'] : 'No';
+            }
+
             // HTMLをデコード
             $decodedData = array_map('decode_html', $data);
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1456 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 繰り返し活動の編集時、単体の活動編集/繰り返し活動のどれを編集するかの確認モーダルが表示されない
1. 詳細入力画面遷移時、開始日時・終了日時が引き継がれない
1. 開始時刻・終了時刻をドロップダウンから選択時、元の入力されていた時刻にリセットされてしまう場合がある

##  原因 / Cause
<!-- バグの原因を記述 -->
1. WebComponents版クイック作成実装時の考慮漏れ

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 繰り返し活動をカレンダーから編集した際、既存同様の繰り返し予定の変更/削除モーダルを表示するよう変更
2. 活動をカレンダーからクイック作成中、詳細入力画面遷移時に開始・終了日時が正常に引き継がれるよう修正
3. 開始時刻・終了時刻をドロップダウンから選択時、正常に選択できるよう改修

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー上からの活動クイック作成

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->