### PR TITLE
カレンダーのご担当者様名検索時、関連項目が設定されていると使用されるSQLがエラーとなっていた問題の修正

### DIFF
--- a/modules/Contacts/models/Module.php
+++ b/modules/Contacts/models/Module.php
@@ -158,10 +158,14 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
 	 */
 	function getSearchRecordsQuery($searchValue, $searchFields, $parentId=false, $parentModule=false) {
         $db = PearDatabase::getInstance();
+        // labelをvtiger_contactdetails.labelに置き換え（ベーステーブルのlabelを参照）
+        $searchFields = array_map(function($field) {
+            return $field === 'label' ? 'vtiger_contactdetails.label' : $field;
+        }, $searchFields);
         if($parentId && $parentModule == 'Accounts') {
 			$query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
 						INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
-						WHERE deleted = 0 AND vtiger_contactdetails.accountid = ? AND label like ?";
+						WHERE vtiger_contactdetails.deleted = 0 AND vtiger_contactdetails.accountid = ? AND vtiger_contactdetails.label like ?";
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
 			return $returnQuery;
@@ -170,8 +174,8 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
 						INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
 						LEFT JOIN vtiger_contpotentialrel ON vtiger_contpotentialrel.contactid = vtiger_contactdetails.contactid
 						LEFT JOIN vtiger_potential ON vtiger_potential.contact_id = vtiger_contactdetails.contactid
-						WHERE deleted = 0 AND (vtiger_contpotentialrel.potentialid = ? OR vtiger_potential.potentialid = ?)
-						AND label like ?";
+						WHERE vtiger_contactdetails.deleted = 0 AND (vtiger_contpotentialrel.potentialid = ? OR vtiger_potential.potentialid = ?)
+						AND vtiger_contactdetails.label like ?";
 			$params = array($parentId, $parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
             return $returnQuery;
@@ -179,7 +183,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_troubletickets ON vtiger_troubletickets.contact_id = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_troubletickets.ticketid  = ?  AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_troubletickets.ticketid  = ?  AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -188,7 +192,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_campaigncontrel ON vtiger_campaigncontrel.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_campaigncontrel.campaignid = ? AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_campaigncontrel.campaignid = ? AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -197,7 +201,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_vendorcontactrel ON vtiger_vendorcontactrel.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_vendorcontactrel.vendorid = ? AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_vendorcontactrel.vendorid = ? AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -206,7 +210,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_quotes ON vtiger_quotes.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_quotes.quoteid  = ?  AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_quotes.quoteid  = ?  AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -215,7 +219,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_purchaseorder ON vtiger_purchaseorder.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_purchaseorder.purchaseorderid  = ?  AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_purchaseorder.purchaseorderid  = ?  AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -224,7 +228,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_salesorder ON vtiger_salesorder.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_salesorder.salesorderid  = ?  AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_salesorder.salesorderid  = ?  AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);
@@ -233,7 +237,7 @@ class Contacts_Module_Model extends Vtiger_Module_Model {
             $query = "SELECT ".implode(',',$searchFields)." FROM vtiger_crmentity
                         INNER JOIN vtiger_contactdetails ON vtiger_contactdetails.contactid = vtiger_crmentity.crmid
                         INNER JOIN vtiger_invoice ON vtiger_invoice.contactid = vtiger_contactdetails.contactid
-                        WHERE deleted=0 AND vtiger_invoice.invoiceid  = ?  AND label like ?";
+                        WHERE vtiger_contactdetails.deleted=0 AND vtiger_invoice.invoiceid  = ?  AND vtiger_contactdetails.label like ?";
 
             $params = array($parentId, "%$searchValue%");
             $returnQuery = $db->convert2Sql($query, $params);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- #899

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーから「クイック作成 活動」モーダルを開き、「関連」フィールドに顧客企業や案件を設定した状態で「ご担当者様名」のクイック検索を行うと、該当するデータが存在しても常に「該当なし」と表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `modules/Contacts/models/Module.php`の`getSearchRecordsQuery()`メソッドにおいて、`deleted`カラムと`label`カラムにテーブルプレフィックスが付与されていなかった
2. `vtiger_crmentity`の一部カラム（`label`、`deleted`等）が各モジュールのベーステーブル（`vtiger_contactdetails`等）に移植されているため、JOINクエリ実行時にカラム名の曖昧性エラーが発生していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. WHERE句の`deleted`を`vtiger_contactdetails.deleted`に変更
2. WHERE句の`label`を`vtiger_contactdetails.label`に変更
3. SELECT句で使用される`$searchFields`配列内の`label`を`vtiger_contactdetails.label`に変換する処理を追加
4. 上記修正をAccountsからInvoiceまでの全9つの親モジュールに対応するクエリ分岐に適用

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- カレンダー > クイック作成 活動 > ご担当者様名の検索
- 親レコード（顧客企業、案件、チケット、キャンペーン、仕入先、見積、発注、受注、請求）を指定した状態での顧客担当者検索全般

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->