### PR TITLE
fix #1453 レポートの関連モジュールとして、複数選択かつカレンダーを含めると、レポートが正常に表示されない

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -1355,7 +1355,7 @@ function insertIntoRecurringTable(& $recurObj)
 	 */
 	public function getReportsNonAdminAccessControlQuery($tableName, $tabId, $user, $parent_roles,$groups){
 		$sharedUsers = $this->getListViewAccessibleUsers($user->id);
-		$this->setupTemporaryTable($tableName, $tabId, $user, $parent_roles,$groups);
+		$this->setupTemporaryTableForEvents($tableName, $tabId, $user, $parent_roles,$groups);
 		$query = "SELECT id FROM $tableName WHERE $tableName.shared=0 AND $tableName.id IN ($sharedUsers)";
 		return $query;
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1453

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートの関連モジュールとしてカレンダーを含む複数のモジュールを選択した場合、一般ユーザーでレポートを閲覧すると「NaN」や「データがありません」と表示され、正常にデータが表示されない
2. 単一の関連モジュール（カレンダーのみ）の場合は正常に表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `Activity::getReportsNonAdminAccessControlQuery()`で使用している`setupTemporaryTable()`は、部下ユーザーのみを一時テーブルに追加する
2. しかし、`getListViewAccessibleUsers()`で取得する`calendarsharedtype='public'`のユーザーは一時テーブルに含まれないため、SQLクエリの結果が0件となる
3. 結果として、アクセス可能なユーザーIDリストが空になり、レポートにデータが表示されない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `Activity::getReportsNonAdminAccessControlQuery()`内で呼び出す関数を`setupTemporaryTable()`から`setupTemporaryTableForEvents()`に変更
2. `setupTemporaryTableForEvents()`は部下ユーザーに加えて、`vtiger_sharedcalendar`で共有されたユーザーおよび`calendarsharedtype='public'`のユーザーも一時テーブルに追加するため、正しくアクセス制御が適用さ
れる

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1900" height="693" alt="image" src="https://github.com/user-attachments/assets/6cb3c271-df62-49ae-bd5b-7b35e704165d" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- レポート機能（複数の関連モジュールを使用し、かつカレンダーを含む場合）
- 一般ユーザー（管理者以外）のレポート閲覧

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 単一モジュールの場合は`getNonAdminAccessControlQuery()`が使用され、複数モジュールの場合は`getReportsNonAdminAccessControlQuery()`が使用される（ReportRun.php:2148-2152）
