### PR TITLE
#1464 検索窓の選択肢が重複しないように修正

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/Utils.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Utils.js
@@ -77,6 +77,11 @@ var vtUtils = {
 						 var element = jQuery(e.currentTarget);
 						 var instance = element.data('select2');
 						 instance.dropdown.css('z-index',1000002);
+					 }).on("select2-selecting", function(e) {
+						 var currentVal = jQuery(this).val() || [];
+						 if (Array.isArray(currentVal) && currentVal.indexOf(e.val) >= 0) {
+							 e.preventDefault();
+						 }
 					 });
         //validator should not validate select2 text inputs
         selectElement.select2("container").find('input.select2-input').addClass('ignore-validation');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1464 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リストビューの検索窓で、選択肢項目を連打すると複数選択肢が入る。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 制御していない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 選択項目を初期化するとき、selectingのイベントとして、すでに選択中の項目が選択されたら中断する処理を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

<img width="428" height="248" alt="image" src="https://github.com/user-attachments/assets/9d2574f1-cba7-4ab0-84cd-da2b03eab758" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
select2を使用している要素(重複が必要な運用はないため問題なし)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
