### PR TITLE
複数選択肢項目を削除しようとすると削除途中でエラーとなり、削除できない問題の修正

### DIFF
--- a/modules/Settings/LayoutEditor/actions/Field.php
+++ b/modules/Settings/LayoutEditor/actions/Field.php
@@ -183,7 +183,8 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         $sourceModule = $fieldInstance->get('block')->module->name;
         $fieldLabel = $fieldInstance->get('label');
         if($fieldInstance->uitype == 16 || $fieldInstance->uitype == 33){
-            $pickListValues = Settings_Picklist_Field_Model::getEditablePicklistValues ($fieldInstance->name);
+            $picklistFieldModel = new Settings_Picklist_Field_Model();
+            $pickListValues = $picklistFieldModel->getEditablePicklistValues($fieldInstance->name);
             $fieldLabel = array_merge(array($fieldLabel),$pickListValues);
         }
         $fieldInstance->delete();


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 項目設定から複数選択肢項目が削除できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. modules/Settings/LayoutEditor/actions/Field.php:186 で、インスタンスメソッドを静的メソッドとして呼び出していたためPHP Fatal Errorが発生していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インスタンスを生成

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->