### PR TITLE
#1474 更新履歴表示バグ不具合調査

### DIFF
--- a/modules/ModTracker/models/Record.php
+++ b/modules/ModTracker/models/Record.php
@@ -36,7 +36,7 @@ class ModTracker_Record_Model extends Vtiger_Record_Model {
 		$pageLimit = $pagingModel->getPageLimit();
 
 		$listQuery = "SELECT * FROM vtiger_modtracker_basic WHERE crmid = ? AND module = ? ".
-						" ORDER BY changedon DESC LIMIT $startIndex, $pageLimit";
+						" ORDER BY changedon DESC, id DESC LIMIT $startIndex, $pageLimit";
 
 		$result = $db->pquery($listQuery, array($parentRecordId, $moduleName));
 		$rows = $db->num_rows($result);

--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -2796,7 +2796,11 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			app.helper.showProgress();
 			var currentPage = jQuery("#updatesCurrentPage").val();
 			var recordId = jQuery("#recordId").val();
-			var nextPage = parseInt(currentPage) + 1;
+			if (parseInt(currentPage) === 1) {
+				var nextPage = 5; // 初回は20件表示されている。また、limit=5のため、4ページ分表示済み。
+			} else {
+				var nextPage = parseInt(currentPage) + 1;
+			}
 			var url = "index.php?module=" + app.getModuleName() + "&view=Detail&record=" + recordId + "&mode=showRecentActivities&page=" 
 					  + nextPage + "&limit=5&tab_label=LBL_UPDATES";
 			var postParams  = app.convertUrlToDataParams(url);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1474 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
①その他ボタンを押して、格納されている更新履歴を表示すると、すでに表示されたレコードがもう一度表示される。
②作成の履歴が一番初めにきていない。

##  原因 / Cause
<!-- バグの原因を記述 -->
①初回の更新履歴は20件表示されるにもかかわらず、その他ボタン押下時は1ページ（5件）先のレコードを表示する仕様であった。
②更新日時でしか並べ替えていないため、更新日時が一致する場合に不正確な並びになる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
①初回のその他ボタン押下時は、5ページ目（21件）から表示する。
②更新日時＋IDで並び変える。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
①
<img width="1130" height="909" alt="image" src="https://github.com/user-attachments/assets/2e782716-db87-43b4-8b94-fa20c2337f36" />


②
<img width="1263" height="1103" alt="image" src="https://github.com/user-attachments/assets/71bad69e-f290-44ea-a553-278b445f5ec8" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
更新日時の表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->