### PR TITLE
bootstrap更新により、Inventory関連の割引額、タグ編集のpopoverが動作しなくなっている問題の修正

### DIFF
--- a/public/layouts/v7/modules/Inventory/resources/Edit.js
+++ b/public/layouts/v7/modules/Inventory/resources/Edit.js
@@ -191,6 +191,12 @@ Vtiger_Edit_Js("Inventory_Edit_Js", {
     
     init : function() {
        this._super();
+       // Bootstrap 3.4.1のサニタイズ機能のwhitelistにbuttonとcenterを追加
+       // ポップオーバーの「保存」「キャンセル」ボタンが削除されないようにする
+       if (jQuery.fn.popover.Constructor.DEFAULTS && jQuery.fn.popover.Constructor.DEFAULTS.whiteList) {
+           jQuery.fn.popover.Constructor.DEFAULTS.whiteList.button = ['type', 'class'];
+           jQuery.fn.popover.Constructor.DEFAULTS.whiteList.center = [];
+       }
        this.initializeVariables();
     },
     

--- a/public/layouts/v7/modules/Vtiger/resources/Tag.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Tag.js
@@ -17,6 +17,15 @@ Vtiger.Class("Vtiger_Tag_Js",{},{
     editTagContainerCached : false,
     
     init : function() {
+        // Bootstrap 3.4.1のサニタイズ機能のwhitelistにbutton, center, form, input, labelを追加
+        // タグ編集ポップオーバーの保存・キャンセルボタン等が削除されないようにする
+        if (jQuery.fn.popover.Constructor.DEFAULTS && jQuery.fn.popover.Constructor.DEFAULTS.whiteList) {
+            jQuery.fn.popover.Constructor.DEFAULTS.whiteList.button = ['type', 'class', 'style'];
+            jQuery.fn.popover.Constructor.DEFAULTS.whiteList.center = [];
+            jQuery.fn.popover.Constructor.DEFAULTS.whiteList.form = ['onsubmit', 'class'];
+            jQuery.fn.popover.Constructor.DEFAULTS.whiteList.input = ['type', 'name', 'value', 'class', 'style', 'maxlength'];
+            jQuery.fn.popover.Constructor.DEFAULTS.whiteList.label = ['class', 'for'];
+        }
         this.editTagContainerCached = jQuery('.editTagContainer');
     },
     


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- #1421

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Bootstrap 3.4.1へのアップデート後、Inventory（見積書/受注/請求書等）の割引額編集ポップオーバーで「保存」「キャンセル」ボタンが表示されない
2. タグ編集ポップオーバーで保存・キャンセルボタンやフォーム要素が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Bootstrap 3.4.1でXSS対策としてpopoverにHTMLサニタイズ機能が追加され、whiteListに含まれないHTML要素（button, center, form, input, label等）が自動的に削除されるようになった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `Inventory_Edit_Js`のinit関数でBootstrapのwhiteListに`button`と`center`要素を追加
2. `Vtiger_Tag_Js`のinit関数でBootstrapのwhiteListに`button`, `center`, `form`, `input`, `label`要素を追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- Inventory系モジュール（見積書、受注、請求書、発注書、仕入）の編集画面における割引額ポップオーバー
- 全モジュールのタグ編集機能

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 今回はJS修正のみで言語ファイル変更なし
- Bootstrap 3.4.1のサニタイズ機能はDEFAULTS.whiteListが存在する場合のみ処理を行うため、存在確認を行ってから設定している