### PR TITLE
fix #1463 カレンダーの複製を行うと、複製元の活動を編集してしまう問題の修正

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -34,6 +34,8 @@ export interface ExtendedQuickCreateProps extends QuickCreateProps {
   variant?: 'default' | 'calendar';
   /** Record ID for edit mode */
   recordId?: string;
+  /** Duplicate mode flag (when true, treat as new record even with recordId) */
+  isDuplicate?: boolean;
 }
 
 /**
@@ -95,6 +97,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   isOpen: externalIsOpen,
   initialData = {},
   recordId,
+  isDuplicate = false,
   onSave,
   onCancel,
   onGoToFullForm,
@@ -106,7 +109,9 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   const isCalendarModule = module === 'Calendar' || module === 'Events';
   const variant = explicitVariant ?? (isCalendarModule ? 'calendar' : 'default');
   const isCalendarVariant = variant === 'calendar';
-  const isEditMode = !!recordId;
+  // 複製モード時はrecordIdが存在しても編集モードではなく新規作成として扱う
+  const isDuplicateMode = isDuplicate === true;
+  const isEditMode = !!recordId && !isDuplicateMode;
 
   // Modal state
   const [internalIsOpen, setInternalIsOpen] = useState(false);
@@ -137,7 +142,9 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   const successTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ========================================
-  // Hooks for record data (edit mode)
+  // Hooks for record data (edit mode and duplicate mode)
+  // 編集モードと複製モードの両方でrecordDataを取得する
+  // 複製モードではデータのコピー元として使用
   // ========================================
   const {
     data: recordData,
@@ -146,7 +153,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   } = useRecordData({
     module: isCalendarVariant ? (module === 'Calendar' ? 'Calendar' : 'Events') : module,
     recordId: recordId,
-    skip: !isEditMode || !isOpen
+    skip: (!isEditMode && !isDuplicateMode) || !isOpen
   });
 
   // ========================================
@@ -205,9 +212,9 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   // Computed values based on variant
   // ========================================
   const fields = isCalendarVariant ? calendarCurrentFields : defaultFields;
-  // Include recordDataLoading in overall loading state for edit mode
+  // Include recordDataLoading in overall loading state for edit mode and duplicate mode
   const fieldsLoading = (isCalendarVariant ? calendarFieldsLoading : defaultFieldsLoading) ||
-    (isEditMode && recordDataLoading);
+    ((isEditMode || isDuplicateMode) && recordDataLoading);
   const fieldsError = isCalendarVariant ? calendarFieldsError : defaultFieldsError || recordDataError;
   const moduleLabel = isCalendarVariant
     ? (activeTab === 'Calendar' ? t('LBL_TASK') : t('LBL_EVENT'))
@@ -265,20 +272,28 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   useEffect(() => {
     // For edit mode, wait for recordData to be loaded
     if (!isCalendarVariant && isOpen && defaultFields.length > 0 && !isInitializedRef.current) {
-      // For edit mode, wait for recordData (skip if still loading)
-      if (isEditMode && recordDataLoading) {
+      // For edit mode or duplicate mode, wait for recordData (skip if still loading)
+      if ((isEditMode || isDuplicateMode) && recordDataLoading) {
         return;
       }
 
-      // Merge initialData and recordData (recordData takes priority for edit mode)
+      // Merge initialData and recordData
+      // 編集モードと複製モードの両方でrecordDataを使用する
+      // 複製モードではデータのコピー元として使用
       const initial: Record<string, any> = {
         ...initialData,
-        ...(isEditMode && recordData ? recordData : {})
+        ...((isEditMode || isDuplicateMode) && recordData ? recordData : {})
       };
 
-      // Add record parameter for edit mode
+      // Add record parameter for edit mode only (NOT for duplicate mode)
+      // 複製モードではrecordパラメータを追加しない（新規作成として保存するため）
       if (isEditMode && recordId) {
         initial.record = recordId;
+      }
+
+      // 複製モードの場合、recordパラメータを明示的に除外
+      if (isDuplicateMode && initial.record) {
+        delete initial.record;
       }
 
       defaultFields.forEach(field => {
@@ -300,14 +315,16 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       clearSaveError();
       isInitializedRef.current = true;
     }
-  }, [isCalendarVariant, isOpen, defaultFields, initialData, isEditMode, recordId, recordData, recordDataLoading, clearSaveError]);
+  }, [isCalendarVariant, isOpen, defaultFields, initialData, isEditMode, isDuplicateMode, recordId, recordData, recordDataLoading, clearSaveError]);
 
   /**
-   * Initialize form data (calendar variant - edit mode)
+   * Initialize form data (calendar variant - edit mode or duplicate mode)
    * Uses recordData from useRecordData hook (fetched via GetRecord API)
+   * 複製モードでも編集モードと同様にrecordDataを使用してデータをコピーする
    */
   useEffect(() => {
-    if (!isCalendarVariant || !isOpen || !isEditMode || isInitializedRef.current) {
+    // 編集モードまたは複製モードで実行（複製モードでもrecordDataからデータをコピーする）
+    if (!isCalendarVariant || !isOpen || (!isEditMode && !isDuplicateMode) || isInitializedRef.current) {
       return;
     }
 
@@ -331,9 +348,21 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
 
     // transformInitialDataForEdit already handles datetime conversion
     // but recordData from useRecordData is already transformed, so we need to handle both cases
-    const transformedData = recordData
-      ? { ...recordData, record: recordId } // recordData is already transformed
-      : transformInitialDataForEdit(initialData, activeTab);
+    let transformedData;
+    if (recordData) {
+      // recordData is already transformed
+      // 編集モードの場合のみrecordパラメータを追加、複製モードでは追加しない
+      if (isDuplicateMode) {
+        // 複製モード: recordパラメータを除外して新規作成として保存
+        const { record, ...dataWithoutRecord } = recordData;
+        transformedData = dataWithoutRecord;
+      } else {
+        // 編集モード: recordパラメータを追加
+        transformedData = { ...recordData, record: recordId };
+      }
+    } else {
+      transformedData = transformInitialDataForEdit(initialData, activeTab);
+    }
 
     // Determine tab based on activitytype
     const activityType = dataSource.activitytype;
@@ -351,13 +380,15 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
     }
 
     isInitializedRef.current = true;
-  }, [isCalendarVariant, isOpen, isEditMode, initialData, recordData, recordDataLoading, recordId, activeTab, transformInitialDataForEdit]);
+  }, [isCalendarVariant, isOpen, isEditMode, isDuplicateMode, initialData, recordData, recordDataLoading, recordId, activeTab, transformInitialDataForEdit]);
 
   /**
    * Initialize form data (calendar variant - new mode)
+   * 複製モードでは編集/複製モードの初期化処理を使用するため、ここではスキップ
    */
   useEffect(() => {
-    if (!isCalendarVariant || isEditMode || !isOpen || isInitializedRef.current) {
+    // 複製モードは編集/複製モードの初期化処理で処理されるためスキップ
+    if (!isCalendarVariant || isEditMode || isDuplicateMode || !isOpen || isInitializedRef.current) {
       return;
     }
 

--- a/assets/react-web-components/src/main.ts
+++ b/assets/react-web-components/src/main.ts
@@ -29,10 +29,11 @@ createWebComponent(
 // module="Calendar" または module="Events" で自動的にカレンダーモードになります
 // variant="calendar" で明示的にカレンダーモードを指定することも可能
 // record-id: 編集モード時のレコードID
+// is-duplicate: 複製モード時にtrue（recordIdが存在しても新規作成として扱う）
 createWebComponent(
   CalendarQuickCreate,
   "calendar-quick-create",
-  ["module", "is-open", "initial-data", "record-id"],
+  ["module", "is-open", "initial-data", "record-id", "is-duplicate"],
   ["onSave", "onCancel", "onGoToFullForm", "onOpenChange"]
 );
 

--- a/assets/react-web-components/src/types/quickcreate.ts
+++ b/assets/react-web-components/src/types/quickcreate.ts
@@ -14,6 +14,8 @@ export interface QuickCreateProps {
   isOpen?: boolean;
   /** 初期値（関連レコードからの値等） */
   initialData?: Record<string, any>;
+  /** 複製モードフラグ（trueの場合、recordIdが存在しても新規作成として扱う） */
+  isDuplicate?: boolean;
   /** 保存成功時コールバック */
   onSave?: (result: QuickCreateSaveResult) => void;
   /** キャンセル時コールバック */

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -2008,6 +2008,11 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			// 編集モード: record IDを設定（WebComponents版で使用）
 			triggerParams.record = record;
 
+			// 複製モードフラグを設定（WebComponents版で使用）
+			if (isDuplicate === true) {
+				triggerParams.isDuplicate = true;
+			}
+
 			try {
 				var calendarContainer = thisInstance.getCalendarViewContainer();
 				if (calendarContainer && calendarContainer.length) {

--- a/public/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -550,13 +550,19 @@ Vtiger.Class('Vtiger_Index_Js', {
 			quickCreate.setAttribute('record-id', params.record);
 		}
 
+		// 複製モードの場合はis-duplicateを設定
+		// 複製モードではrecordIdでデータを取得するが、保存時は新規作成として扱う
+		if (params.isDuplicate) {
+			quickCreate.setAttribute('is-duplicate', 'true');
+		}
+
 		// 初期データがあれば設定
 		if (params.data) {
 			quickCreate.setAttribute('initial-data', JSON.stringify(params.data));
 		}
 
-		// 編集モードかどうか
-		var isEditMode = !!params.record;
+		// 編集モードかどうか（複製モードは編集モードではない）
+		var isEditMode = !!params.record && !params.isDuplicate;
 
 		// 保存前のコールバック（繰り返し活動の確認モーダル表示用）
 		// Calendar/Eventsモジュールで繰り返し活動を編集する場合に使用
@@ -659,16 +665,22 @@ Vtiger.Class('Vtiger_Index_Js', {
 
 			// WebComponents版QuickCreateが有効な場合はそちらを使用
 			if (thisInstance.isWebComponentsQuickCreateEnabled(quickCreateModuleName)) {
-				// URLからrecordパラメータを抽出（編集モード対応）
+				// URLからrecord, isDuplicateパラメータを抽出（編集・複製モード対応）
+				// ただし、paramsに既に設定されている値を優先
 				if (quickCreateUrl && quickCreateUrl.indexOf('record=') !== -1) {
 					var urlParams = new URLSearchParams(quickCreateUrl.split('?')[1] || quickCreateUrl);
 					var recordId = urlParams.get('record');
 					var mode = urlParams.get('mode');
-					if (recordId) {
+					var isDuplicateFromUrl = urlParams.get('isDuplicate');
+					if (recordId && !params.record) {
 						params.record = recordId;
 					}
-					if (mode) {
+					if (mode && !params.mode) {
 						params.mode = mode;
+					}
+					// 複製モードフラグを設定（paramsに既に設定されている場合は優先）
+					if (isDuplicateFromUrl === 'true' && !params.isDuplicate) {
+						params.isDuplicate = true;
 					}
 				}
 				app.helper.showProgress();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1463 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー上から活動の複製を行う際、WebComponents版クイック作成で活動編集として開いてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 活動の複製時、既存活動のIDを内部的に持っており、IDが存在する場合は活動編集としてクイック作成が開いてしまっていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動複製の場合はIDを送信しないように修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->