### PR TITLE
WebComponents版QuickCreateで他者活動編集時の確認ダイアログを追加

### DIFF
--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -225,6 +225,83 @@ Vtiger.Class("Calendar_Calendar_Js", {
 
 		return aDeferred.promise();
 	},
+	registerWebComponentsBeforeSaveEvent: function() {
+		var thisInstance = this;
+
+		// 重複登録防止: 既に登録済みの場合はスキップ
+		if (this._webComponentsBeforeSaveRegistered) {
+			return;
+		}
+		this._webComponentsBeforeSaveRegistered = true;
+
+		document.addEventListener('before-save', function(e) {
+			// calendar-quick-create からのイベントのみ処理
+			if (!e.target.matches('calendar-quick-create')) {
+				return;
+			}
+
+			// 既に別のリスナーがpreventDefault()を呼んでいる場合はスキップ
+			// （繰り返し活動の確認モーダルが処理中の場合など）
+			if (e.defaultPrevented) {
+				return;
+			}
+
+			var detail = e.detail;
+
+			// 編集モードでない場合はスキップ（新規作成は確認不要）
+			if (!detail.isEditMode || !detail.recordId) {
+				return;
+			}
+
+			// 保存をキャンセルして確認処理を挟む
+			e.preventDefault();
+
+			// z-index問題対策: bootbox確認ダイアログをWebComponents dialogの前面に表示するため、
+			// bootboxのz-indexを一時的に上げ、WebComponentsダイアログのポインターイベントを無効化
+			var styleElement = document.createElement('style');
+			styleElement.id = 'webcomponents-modal-zindex-fix-others';
+			styleElement.textContent = '.bootbox, .bootbox * { z-index: 100010 !important; pointer-events: auto !important; } .bootbox + .modal-backdrop, .modal-backdrop.in { z-index: 100009 !important; } [data-slot="dialog-overlay"], [data-slot="dialog-content"], .web-components-wrapper { pointer-events: none !important; } [data-slot="dialog-content"] * { pointer-events: none !important; }';
+			document.head.appendChild(styleElement);
+
+			// フォーカスループ対策: Radix UIのFocusScopeとBootstrapモーダルのフォーカス管理が競合するため、
+			// bootbox表示中はRadix UIのフォーカストラップを一時的に無効化
+			var dialogContent = document.querySelector('[data-slot="dialog-content"]');
+			var originalTabIndex = null;
+			var originalInert = null;
+			if (dialogContent) {
+				originalTabIndex = dialogContent.getAttribute('tabindex');
+				originalInert = dialogContent.hasAttribute('inert');
+				dialogContent.setAttribute('inert', '');
+				dialogContent.removeAttribute('tabindex');
+			}
+
+			// クリーンアップ関数
+			var cleanup = function() {
+				// z-index修正用のスタイルを削除
+				var styleEl = document.getElementById('webcomponents-modal-zindex-fix-others');
+				if (styleEl) styleEl.remove();
+				// フォーカストラップを復元
+				if (dialogContent) {
+					dialogContent.removeAttribute('inert');
+					if (originalTabIndex !== null) {
+						dialogContent.setAttribute('tabindex', originalTabIndex);
+					}
+				}
+			};
+
+			// 既存の confirmEditOthersEvent を使用（jQuery Deferred）
+			thisInstance.confirmEditOthersEvent(detail.recordId)
+				.done(function() {
+					cleanup();
+					// 確認OK → 保存を続行（引数なし）
+					detail.continueSave();
+				})
+				.fail(function() {
+					cleanup();
+					// キャンセルまたはエラー → 何もしない（モーダルは開いたまま）
+				});
+		});
+	},
 	registerCalendarSharingTypeChangeEvent: function (modalContainer) {
 		var selectedUsersContainer = app.helper.getSelect2FromSelect(
 				jQuery('#selectedUsers', modalContainer)
@@ -2969,5 +3046,6 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		this.registerWidgetPostLoadEvent();
 		this.initializeWidgets();
 		this.registerPostQuickCreateSaveEvent();
+		this.registerWebComponentsBeforeSaveEvent();
 	}
 });


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- #1084 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. WebComponents版QuickCreate（カレンダー）で他者の活動を編集する際、従来のjQuery版にあった確認ダイアログが表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. WebComponents版QuickCreateはReactベースで実装されているため、jQuery版の`confirmEditOthersEvent`が呼び出されず、他者活動編集時の確認処理がスキップされていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `Calendar.js`に`registerWebComponentsBeforeSaveEvent`メソッドを追加
2. WebComponents版QuickCreateの`before-save`カスタムイベントをリッスンし、編集モード時に既存の`confirmEditOthersEvent`を呼び出す処理を実装
3. bootboxダイアログとRadix UIのモーダルのz-index競合を解決するためのスタイル調整を追加
4. Radix UIのFocusScopeとBootstrapモーダルのフォーカス管理の競合を防ぐため、確認ダイアログ表示中は一時的にinert属性を付与

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- カレンダーモジュールのWebComponents版QuickCreate（活動編集時）
- 他者の活動を編集する際の確認ダイアログ表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 既存の`confirmEditOthersEvent`メソッドを再利用しているため、確認ダイアログの内容・動作は従来通り
- 重複登録防止フラグ（`_webComponentsBeforeSaveRegistered`）により、複数回の初期化でもイベントリスナーは1度のみ登録される