### PR TITLE
モバイルiOS使用時、クイック作成メニューを開くとアプリアイコンもz-indexの問題で被ってしまう問題の修正

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -692,8 +692,9 @@ button#advanceIntiateSave + input {
 
 /* モバイル: 2列 + 全幅モーダル */
 @media (max-width: 767px) {
-  /* クイック作成メニューが開いている時、カレンダーのアクションバーを非表示にする（iPhoneでのz-index問題対策） */
-  body:has(.dropdown.open > .quickCreateDropdown) .app-nav .module-action-bar {
+  /* クイック作成メニューが開いている時、カレンダーのアクションバーとアプリアイコンを非表示にする（iPhoneでのz-index問題対策） */
+  body:has(.dropdown.open > .quickCreateDropdown) .app-nav .module-action-bar,
+  body:has(.dropdown.open > .quickCreateDropdown) .app-indicator-icon-container {
     visibility: hidden;
   }
   /* 開いている時だけモーダル表示（visibility: visible !importantでドロップダウン自体は常に表示） */


### PR DESCRIPTION
##  関連Issue / Related Issue
- #1483

##  不具合の内容 / Bug
1. モバイルiOS(Safari)でクイック作成メニューを開いた際、アプリアイコン（`.app-indicator-icon-container`）がz-indexの解釈の違いによりメニューの上に被って表示される
2. #1483 で `.module-action-bar` のz-index問題を修正したが、同様の問題が `.app-indicator-icon-container`（サイドバー左側のカレンダーアイコン等）でも発生していた

##  原因 / Cause
1. `.app-indicator-icon-container` に `z-index: 2` が設定されており、iOSでのスタッキングコンテキストの解釈により、クイック作成メニュー（z-index: 1050）の上に被ってしまう

##  変更内容 / Details of Change
1. クイック作成メニューが開いている時に `.app-indicator-icon-container` も `visibility: hidden` で非表示にするよう修正

## スクリーンショット / Screenshot
N/A

## 影響範囲  / Affected Area
- モバイル表示（767px以下）でのクイック作成メニュー表示時のみ

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った

## 備考 / Remarks