### PR TITLE
リスト追加時、リストの共有にチェック＞共有ユーザーの選択欄が、一部モバイルでフッターにかぶって選択不能となる問題の対応

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -1803,5 +1803,10 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
   .select2-drop {
     min-width: 200px;
   }
+
+  /* 共有ユーザー選択欄がフッターに隠れないようにスクロールコンテナに下部パディングを追加 */
+  #filterContainer .customview-content .mCSB_container {
+    padding-bottom: 70px;
+  }
 }
 


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 一部モバイル（iPhone SEで確認）において、リストの追加＞リストの共有にチェックを行った際、共有ユーザーの選択欄がフッターにかぶって操作できない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. フッター（.modal-overlay-footer）がposition: fixedで画面下部に固定されている
1. スクロールコンテナ（.mCSB_container）内のコンテンツが下部まで描画される際、フッターと重なる位置まで表示されていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 共有ユーザー選択欄がフッターに隠れないようにスクロールコンテナに下部パディングを追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="503" height="719" alt="image" src="https://github.com/user-attachments/assets/0d7d1e4f-c99b-4ea9-9e7b-b06530487b89" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->