### PR TITLE
クイック作成メニュー内をクリックしてもメニューが閉じないように修正

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/Vtiger.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Vtiger.js
@@ -494,6 +494,14 @@ Vtiger.Class('Vtiger_Index_Js', {
 			e.stopImmediatePropagation();
 			jQuery(e.currentTarget).closest('.dropdown').toggleClass('open');
 		});
+
+		// メニュー内をクリックしてもメニューが閉じないようにする（モジュール項目は除く）
+		jQuery(".quickCreateDropdown").on("click", function(e) {
+			// モジュール項目（.quickCreateModule）以外のクリックは伝播を止める
+			if (!jQuery(e.target).closest('.quickCreateModule').length) {
+				e.stopPropagation();
+			}
+		});
 	},
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- #1440 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. クイック作成メニュー（右上の+アイコンから開くドロップダウン）で、「クイック作成」タイトル部分・区切り線・余白部分をクリックするとメニューが閉じてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. Bootstrapのドロップダウンはドキュメント全体へのクリックイベントでメニューを閉じる仕組みになっており、メニュー内のクリックイベントが伝播してしまうことで意図しないタイミングでメニューが閉じていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `registerQuickCreateSubMenus`関数に、メニュー内クリック時のイベント伝播制御を追加
2. モジュール項目（`.quickCreateModule`）以外の箇所をクリックした場合、`stopPropagation()`でイベント伝播を停止するように変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- クイック作成メニューのクリック動作

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
