### PR TITLE
#1482 メールの不具合修正

### DIFF
--- a/include/utils/ListViewUtils.php
+++ b/include/utils/ListViewUtils.php
@@ -694,7 +694,7 @@ function getEntityIdByColumns($module, $referenceValueList, $cache) {
 
 function decode_emptyspace_html($str){
 	$str = str_replace("&nbsp;", "*#chr*#",$str); // (*#chr*#) used as jargan to replace it back with &nbsp;
-	$str = str_replace("\xc2", "*#chr*#",$str); // Ã (for special chrtr)
+	$str = str_replace("\xc2\xa0", "*#chr*#",$str); // Ã (for special chrtr)
 	$str = decode_html($str);
 	return str_replace("*#chr*#", "&nbsp;", $str);
 	

--- a/vtlib/Vtiger/Mailer.php
+++ b/vtlib/Vtiger/Mailer.php
@@ -251,8 +251,8 @@ class Vtiger_Mailer extends PHPMailer {
 				$queueid = $queue_record['id'];
 				$relcrmid= $queue_record['relcrmid'];
 
-				$mailer->From = $queue_record['fromemail'];
-				$mailer->From = $queue_record['fromname'];
+				$mailer->From = decode_html($queue_record['fromemail']);
+				$mailer->FromName = $queue_record['fromname'];
 				$mailer->Subject=$queue_record['subject'];
 				$mailer->Body = decode_emptyspace_html($queue_record['body']);
 				$mailer->Mailer=$queue_record['mailer'];
@@ -261,10 +261,11 @@ class Vtiger_Mailer extends PHPMailer {
 				$emails = $adb->pquery('SELECT * FROM vtiger_mailer_queueinfo WHERE id=?', Array($queueid));
 				for($eidx = 0; $eidx < $adb->num_rows($emails); ++$eidx) {
 					$email_record = $adb->fetch_array($emails, $eidx);
-					if($email_record['type'] == 'TO')     $mailer->AddAddress($email_record['email'], $email_record['name']);
-					else if($email_record['type'] == 'CC')$mailer->AddCC($email_record['email'], $email_record['name']);
-					else if($email_record['type'] == 'BCC')$mailer->AddBCC($email_record['email'], $email_record['name']);
-					else if($email_record['type'] == 'RPLYTO')$mailer->AddReplyTo($email_record['email'], $email_record['name']);
+					$decoded_email = decode_html($email_record['email']);
+					if($email_record['type'] == 'TO')     $mailer->AddAddress($decoded_email, $email_record['name']);
+					else if($email_record['type'] == 'CC')$mailer->AddCC($decoded_email, $email_record['name']);
+					else if($email_record['type'] == 'BCC')$mailer->AddBCC($decoded_email, $email_record['name']);
+					else if($email_record['type'] == 'RPLYTO')$mailer->AddReplyTo($decoded_email, $email_record['name']);
 				}
 
 				$attachments = $adb->pquery('SELECT * FROM vtiger_mailer_queueattachments WHERE id=?', Array($queueid));

--- a/vtlib/Vtiger/Mailer.php
+++ b/vtlib/Vtiger/Mailer.php
@@ -81,6 +81,7 @@ class Vtiger_Mailer extends PHPMailer {
 	 * @access private
 	 */
 	function reinitialize() {
+		$this->smtpClose();
 		$this->ClearAllRecipients();
 		$this->ClearReplyTos();
 		$this->ClearCustomHeaders();
@@ -241,11 +242,10 @@ class Vtiger_Mailer extends PHPMailer {
 		global $adb;
 		if(!Vtiger_Utils::CheckTable('vtiger_mailer_queue')) return;
 
-		$mailer = new self();
 		$queue = $adb->pquery('SELECT * FROM vtiger_mailer_queue', array());
 		if($adb->num_rows($queue)) {
 			for($index = 0; $index < $adb->num_rows($queue); ++$index) {
-				$mailer->reinitialize();
+				$mailer = new self();
 
 				$queue_record = $adb->fetch_array($queue, $index);
 				$queueid = $queue_record['id'];


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1482 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
①送信の際、メアドがエスケープされる
②c2a0の文字コードを受信すると本文が切れる。
③1件目の送信メールがSMTPエラーになると、2件目もエラーになる。

##  原因 / Cause
<!-- バグの原因を記述 -->
①fetch_array()内でHTMLエンコードしているため
②2バイトの文字コードの1バイトしか置換していないため
③メーラーインスタンスを再作成していないため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
①デコードした
②2バイト置換した
③初期化処理で、接続を切る処理を追加した

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
メール送信処理、メール受信本文

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
