### PR TITLE
メール送信制御追加

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
@@ -852,6 +852,28 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                 </div>
               </div>
             </div>
+            {/* メール送信チェックボックス*/}
+            <div className="md:col-span-2">
+              <div className="flex items-start gap-2">
+                <label
+                  className={cn(
+                    'text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]',
+                    isDisabled && 'text-gray-400'
+                  )}
+                >
+                  {t('LBL_SEND_MAIL')}
+                </label>
+                <span className="w-3 leading-[30px] flex-shrink-0" aria-hidden="true" />
+                <div className="flex-1 min-w-0 flex items-center h-[30px]">
+                  <Checkbox
+                    id="send_mail"
+                    checked={formData.send_mail === '1'}
+                    onCheckedChange={(checked) => onFieldChange('send_mail', checked ? '1' : '0')}
+                    disabled={isDisabled}
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
@@ -856,6 +856,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
             <div className="md:col-span-2">
               <div className="flex items-start gap-2">
                 <label
+                  htmlFor="send_mail"
                   className={cn(
                     'text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]',
                     isDisabled && 'text-gray-400'

--- a/assets/react-web-components/src/components/QuickCreate/hooks/useCalendarFields.ts
+++ b/assets/react-web-components/src/components/QuickCreate/hooks/useCalendarFields.ts
@@ -185,9 +185,8 @@ export function useCalendarFields(
       const picklistValues = assignedUserField.fieldinfo
         .picklistvalues as Record<string, Record<string, string> | undefined>;
 
-      // Get users from the "Users" or "ユーザー" group (supports both English and Japanese)
-      // Groups are excluded from invitees
-      const userGroup = picklistValues['Users'] || picklistValues['ユーザー'];
+      // Get users and groups (invitees can be both; supports English and Japanese)
+      const userGroup = Object.assign({}, picklistValues['Users'] || picklistValues['ユーザー'], picklistValues['Groups'] || picklistValues['グループ']);
       if (userGroup && typeof userGroup === 'object') {
         Object.entries(userGroup).forEach(([id, name]) => {
           users.push({ id, name });

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -664,6 +664,7 @@ $languageStrings = array(
 	'Country' => 'Country',
 	'Description' => 'Description',
 	'Common Memo' => 'Common Memo',
+	'LBL_SEND_MAIL' => 'Send Mail',
 
 	'Created'=>'Created',
 	'Approved'=>'Approved',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -669,6 +669,7 @@ $languageStrings = array(
 	'Country' => '国',
 	'Description' => '詳細内容',
 	'Common Memo' => '共有メモ',
+	'LBL_SEND_MAIL' => 'メール送信する',
 
 	'Created'=>'登録済み',
 	'Approved'=>'承認済み',

--- a/layouts/v7/modules/Events/DetailViewBlockView.tpl
+++ b/layouts/v7/modules/Events/DetailViewBlockView.tpl
@@ -39,6 +39,16 @@
                             {/if}
                         {/foreach}
                     </td>
+                    <td class="fieldLabel {$WIDTHTYPE}">
+                        <span class="muted">{vtranslate('LBL_SEND_MAIL', $MODULE_NAME)}</span>
+                    </td>
+                    <td class="fieldValue {$WIDTHTYPE}">
+                        {if isset($RECORD) && $RECORD && $RECORD->get('send_mail') eq '1'}
+                            {vtranslate('LBL_YES', $MODULE_NAME)}
+                        {else}
+                            {vtranslate('LBL_NO', $MODULE_NAME)}
+                        {/if}
+                    </td>
                 </tr>
             </tbody>
         </table>

--- a/layouts/v7/modules/Events/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/Events/partials/EditViewContents.tpl
@@ -30,6 +30,14 @@
 							{/foreach}
 						</select>
 					</td>
+					<td>
+					<td class="fieldLabel alignMiddle">{vtranslate('LBL_SEND_MAIL', $MODULE)}</td>
+					<td class="fieldValue">
+						{if isset($SEND_MAIL_FIELD)}
+							{assign var="FIELD_MODEL" value=$SEND_MAIL_FIELD}
+							{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
+						{/if}
+					</td>
 					<td></td><td></td>
 				</tr>
 			</table>

--- a/layouts/v7/modules/Events/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/Events/partials/EditViewContents.tpl
@@ -28,6 +28,11 @@
 									{$USER_NAME}
 								</option>
 							{/foreach}
+							{foreach key=GROUP_ID item=GROUP_NAME from=$ACCESSIBLE_GROUPS}
+								<option value="{$GROUP_ID}" {if in_array($GROUP_ID,$INVITIES_SELECTED)}selected{/if}>
+									{$GROUP_NAME}
+								</option>
+							{/foreach}
 						</select>
 					</td>
 					<td class="fieldLabel alignMiddle">{vtranslate('LBL_SEND_MAIL', $MODULE)}</td>

--- a/layouts/v7/modules/Events/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/Events/partials/EditViewContents.tpl
@@ -30,7 +30,6 @@
 							{/foreach}
 						</select>
 					</td>
-					<td>
 					<td class="fieldLabel alignMiddle">{vtranslate('LBL_SEND_MAIL', $MODULE)}</td>
 					<td class="fieldValue">
 						{if isset($SEND_MAIL_FIELD)}
@@ -38,7 +37,6 @@
 							{include file=vtemplate_path($FIELD_MODEL->getUITypeModel()->getTemplateName(),$MODULE)}
 						{/if}
 					</td>
-					<td></td><td></td>
 				</tr>
 			</table>
 			<input type="hidden" name="recurringEditMode" value="" />

--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -152,7 +152,14 @@ class Activity extends CRMEntity {
 				$this->invitee_array[] = $smownerid;
 			}
 			if(!in_array($request_assigned_user_id, $this->invitee_array)){
-				$this->invitee_array[] = $request_assigned_user_id;
+				require_once 'include/utils/GetGroupUsers.php';
+				$userGroups = new GetGroupUsers();
+				$userGroups->getAllUsersInGroup($request_assigned_user_id);
+				if(!empty($userGroups->group_users)){ // 担当がグループである場合
+					$this->invitee_array = array_unique(array_merge($this->invitee_array, $userGroups->group_users));
+				}else{
+					$this->invitee_array[] = $request_assigned_user_id;
+				}
 			}
 		} else if(empty($this->invitee_array) && php7_count($_REQUEST['selectedusers']) > 0){// 概要欄や関連からの遷移の場合
 			$this->invitee_array = $_REQUEST['selectedusers'];
@@ -162,7 +169,14 @@ class Activity extends CRMEntity {
 				$this->invitee_array[] = $smownerid;
 			}
 			if(!in_array($request_assigned_user_id, $this->invitee_array)){
-				$this->invitee_array[] = $request_assigned_user_id;
+				require_once 'include/utils/GetGroupUsers.php';
+				$userGroups = new GetGroupUsers();
+				$userGroups->getAllUsersInGroup($request_assigned_user_id);
+				if(!empty($userGroups->group_users)){ // 担当がグループである場合
+					$this->invitee_array = array_unique(array_merge($this->invitee_array, $userGroups->group_users));
+				}else{
+					$this->invitee_array[] = $request_assigned_user_id;
+				}
 			}
 		} else {// リクエストに入っていない場合はDBから取得を試みる
 			$this->loadInvitees();

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -1150,6 +1150,36 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 		if ($sendMailValue !== null && method_exists($recordModel, 'syncRecurringSendMail')) {
 			$recordModel->syncRecurringSendMail($sendMailValue);
 		}
+		if ($sendMailValue == '1') {
+			if(empty($selectUsers)){
+				$selectUsers = array();
+			}
+
+			// 担当にも招待・更新メールが送信されるようにする
+			require_once 'include/utils/GetGroupUsers.php';
+			$assigneduserId = $recordModel->get('assigned_user_id');
+			$userGroups = new GetGroupUsers();
+			$userGroups->getAllUsersInGroup($assigneduserId);
+			if(!empty($userGroups->group_users)){ // 担当がグループである場合
+				$assigneduserId = $userGroups->group_users;
+			}else{
+				$assigneduserId = array($assigneduserId);
+			}
+			$selectUsers = array_unique(array_merge($selectUsers, $assigneduserId));
+
+			// 参加者にグループが設定されている場合も展開する
+			$expandedUsers = array();
+			foreach ($selectUsers as $id) {
+				$userGroups = new GetGroupUsers();
+				$userGroups->getAllUsersInGroup($id);
+				if (!empty($userGroups->group_users)) {
+					$expandedUsers = array_merge($expandedUsers, $userGroups->group_users);
+				} else {
+					$expandedUsers[] = $id;
+				}
+			}
+			$selectUsers = array_values(array_unique($expandedUsers));
+		}
 		if (!empty($selectUsers) && $sendMailValue == '1') {
 			$invities = implode(';', $selectUsers);
 			$mail_contents = $recordModel->getInviteUserMailData();

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -1146,12 +1146,11 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 		$focus->save($moduleName);
 		//活動保存後に参加者(担当者抜き)がいるかつメール送信フラグがONの場合、参加者にメール送信する
 		$selectUsers = $recordModel->get('selectedusers');
-		$send_mail = $recordModel->get('send_mail');
 		$sendMailValue = $recordModel->get('send_mail');
 		if ($sendMailValue !== null && method_exists($recordModel, 'syncRecurringSendMail')) {
 			$recordModel->syncRecurringSendMail($sendMailValue);
 		}
-		if (!empty($selectUsers) && $send_mail == '1') {
+		if (!empty($selectUsers) && $sendMailValue == '1') {
 			$invities = implode(';', $selectUsers);
 			$mail_contents = $recordModel->getInviteUserMailData();
 			$activityMode = ($recordModel->getModuleName() == 'Calendar') ? 'Task' : 'Events';

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -1132,25 +1132,31 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 			if(is_array($fieldValue)){
 				$focus->column_fields[$fieldName] = $fieldValue;
 			}else if($fieldValue !== null) {
-				/*
-				 * for ajax edit, in Vtiger_SaveAjax_Action we are setting relatedContact to 
-				 * the record model which is an object
-				 * Note : decode_html expects only strings
-				 */
 				$value = is_string($fieldValue) ? decode_html($fieldValue) : $fieldValue;
 				$focus->column_fields[$fieldName] = $value;
 			}
 		}
 		$focus->mode = $recordModel->get('mode');
 		$focus->id = $recordModel->getId();
-
 		$focus->is_allday = $recordModel->get('is_allday');
 		$focus->is_not_invitees_update = $recordModel->get('is_not_invitees_update');
 		$focus->invitee_parentid = $recordModel->get('invitee_parentid');
 		$focus->invitee_array = $recordModel->get('invitee_array');
 
 		$focus->save($moduleName);
+		//活動保存後に参加者(担当者抜き)がいるかつメール送信フラグがONの場合、参加者にメール送信する
+		$selectUsers = $recordModel->get('selectedusers');
+		$send_mail = $recordModel->get('send_mail');
+		$sendMailValue = $recordModel->get('send_mail');
+		if ($sendMailValue !== null && method_exists($recordModel, 'syncRecurringSendMail')) {
+			$recordModel->syncRecurringSendMail($sendMailValue);
+		}
+		if (!empty($selectUsers) && $send_mail == '1') {
+			$invities = implode(';', $selectUsers);
+			$mail_contents = $recordModel->getInviteUserMailData();
+			$activityMode = ($recordModel->getModuleName() == 'Calendar') ? 'Task' : 'Events';
+			sendInvitation($invities, $activityMode, $recordModel, $mail_contents);
+		}
 		return $recordModel->setId($focus->id);
 	}
-
 }

--- a/modules/Calendar/models/Module.php
+++ b/modules/Calendar/models/Module.php
@@ -1150,7 +1150,8 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 		if ($sendMailValue !== null && method_exists($recordModel, 'syncRecurringSendMail')) {
 			$recordModel->syncRecurringSendMail($sendMailValue);
 		}
-		if ($sendMailValue == '1') {
+		// 招待メールはEvents(活動)のみ送信
+		if ($sendMailValue == '1' && method_exists($recordModel, 'getInviteUserMailData')) {
 			if(empty($selectUsers)){
 				$selectUsers = array();
 			}
@@ -1180,7 +1181,7 @@ class Calendar_Module_Model extends Vtiger_Module_Model {
 			}
 			$selectUsers = array_values(array_unique($expandedUsers));
 		}
-		if (!empty($selectUsers) && $sendMailValue == '1') {
+		if (!empty($selectUsers) && $sendMailValue == '1' && method_exists($recordModel, 'getInviteUserMailData')) {
 			$invities = implode(';', $selectUsers);
 			$mail_contents = $recordModel->getInviteUserMailData();
 			$activityMode = ($recordModel->getModuleName() == 'Calendar') ? 'Task' : 'Events';

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -215,7 +215,57 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 		$recurringRecordsList[$parentRecurringId] = $childRecords;
 		return $recurringRecordsList;
 	}
-	
+	/**
+	 * 繰り返し予定の send_mail を系列全体に同期する
+	 */
+	public function syncRecurringSendMail($sendMailValue) {
+		global $adb;
+		$recordId = $this->getId();
+		if (empty($recordId)) {
+			return;
+		}
+		// 現在レコードを、その日の親予定IDに正規化する
+		$currentResult = $adb->pquery("SELECT activityid, invitee_parentid FROM vtiger_activity WHERE activityid = ?", array($recordId));
+		if ($adb->num_rows($currentResult) <= 0) {
+			return;
+		}
+		$currentActivityId = $adb->query_result($currentResult, 0, 'activityid');
+		$currentInviteeParentId = $adb->query_result($currentResult, 0, 'invitee_parentid');
+		$currentParentId = !empty($currentInviteeParentId) ? $currentInviteeParentId : $currentActivityId;
+		// 繰り返し系列の全レコードIDを取得
+		$recurringRecordsList = $this->getRecurringRecordsList();
+		$seriesRecordIds = array();
+		if (!empty($recurringRecordsList) && is_array($recurringRecordsList)) {
+			foreach ($recurringRecordsList as $parent => $childs) {
+				$seriesRecordIds[] = $parent;
+				if (!empty($childs) && is_array($childs)) {
+					foreach ($childs as $childId) {
+						$seriesRecordIds[] = $childId;
+					}
+				}
+			}
+		}
+		if (empty($seriesRecordIds)) {
+			$seriesRecordIds[] = $currentParentId;
+		}
+		$seriesRecordIds = array_values(array_unique(array_filter($seriesRecordIds)));
+		// 各レコードIDを、その日の親予定IDに正規化する
+		$parentIds = array();
+		foreach ($seriesRecordIds as $seriesRecordId) {
+			$result = $adb->pquery("SELECT activityid, invitee_parentid FROM vtiger_activity WHERE activityid = ?", array($seriesRecordId));
+			if ($adb->num_rows($result) > 0) {
+				$activityId = $adb->query_result($result, 0, 'activityid');
+				$inviteeParentId = $adb->query_result($result, 0, 'invitee_parentid');
+				$parentIds[] = !empty($inviteeParentId) ? $inviteeParentId : $activityId;
+			}
+		}
+		$parentIds[] = $currentParentId;
+		$parentIds = array_values(array_unique(array_filter($parentIds)));
+		// 各日の親予定と、その親に紐づく現存子予定をまとめて更新する
+		foreach ($parentIds as $parentId) {
+			$adb->pquery("UPDATE vtiger_activity SET send_mail = ? WHERE deleted = 0 AND (activityid = ? OR invitee_parentid = ?)", array($sendMailValue, $parentId, $parentId));
+		}
+	}
 	/**
 	 * Function to get recurring enabled for record
 	 */

--- a/modules/Calendar/models/Record.php
+++ b/modules/Calendar/models/Record.php
@@ -251,11 +251,12 @@ class Calendar_Record_Model extends Vtiger_Record_Model {
 		$seriesRecordIds = array_values(array_unique(array_filter($seriesRecordIds)));
 		// 各レコードIDを、その日の親予定IDに正規化する
 		$parentIds = array();
-		foreach ($seriesRecordIds as $seriesRecordId) {
-			$result = $adb->pquery("SELECT activityid, invitee_parentid FROM vtiger_activity WHERE activityid = ?", array($seriesRecordId));
-			if ($adb->num_rows($result) > 0) {
-				$activityId = $adb->query_result($result, 0, 'activityid');
-				$inviteeParentId = $adb->query_result($result, 0, 'invitee_parentid');
+		if (!empty($seriesRecordIds)) {
+			$result = $adb->pquery("SELECT activityid, invitee_parentid FROM vtiger_activity WHERE activityid IN (".generateQuestionMarks($seriesRecordIds).")", $seriesRecordIds);
+			$numRows = $adb->num_rows($result);
+			for ($i = 0; $i < $numRows; $i++) {
+				$activityId = $adb->query_result($result, $i, 'activityid');
+				$inviteeParentId = $adb->query_result($result, $i, 'invitee_parentid');
 				$parentIds[] = !empty($inviteeParentId) ? $inviteeParentId : $activityId;
 			}
 		}

--- a/modules/Calendar/views/Edit.php
+++ b/modules/Calendar/views/Edit.php
@@ -197,9 +197,11 @@ Class Calendar_Edit_View extends Vtiger_Edit_View {
 		}
 		$picklistDependencyDatasource = Vtiger_DependencyPicklist::getPicklistDependencyDatasource($moduleName);
 		$accessibleUsers = $currentUser->getAccessibleUsers();
+		$accessibleGroups = $currentUser->getAccessibleGroups();
 
 		$viewer->assign('PICKIST_DEPENDENCY_DATASOURCE',Vtiger_Functions::jsonEncode($picklistDependencyDatasource));
 		$viewer->assign('ACCESSIBLE_USERS', $accessibleUsers);
+		$viewer->assign('ACCESSIBLE_GROUPS', $accessibleGroups);
 		if($request->get('selectedusers')) {
 			$invetees = $request->get('selectedusers');
 			if(!is_array($invetees)) {

--- a/modules/Calendar/views/Edit.php
+++ b/modules/Calendar/views/Edit.php
@@ -209,6 +209,16 @@ Class Calendar_Edit_View extends Vtiger_Edit_View {
 		} else {
 			$viewer->assign('INVITIES_SELECTED', $recordModel->getInvities());
 		}
+		if ($request->has('send_mail')) {
+			$sendMailValue = ($request->get('send_mail') == '1') ? '1' : '0';
+		} else {
+			$sendMailValue = ($recordModel->get('send_mail') == '1') ? '1' : '0';
+		}
+		$sendMailField = Vtiger_Field_Model::getInstance('send_mail', $moduleModel);
+		if ($sendMailField) {
+			$sendMailField->set('fieldvalue', $sendMailValue);
+			$viewer->assign('SEND_MAIL_FIELD', $sendMailField);
+		}
 		$viewer->assign('CURRENT_USER', $currentUser);
 
 		// added to set the return values

--- a/modules/Calendar/views/QuickCreateAjax.php
+++ b/modules/Calendar/views/QuickCreateAjax.php
@@ -104,6 +104,15 @@ class Calendar_QuickCreateAjax_View extends Vtiger_QuickCreateAjax_View {
 			$viewer->assign('ACCESSIBLE_USERS', $accessibleUsers);
 			$viewer->assign('INVITIES_SELECTED', $recordModel->getInvities());
 			$viewer->assign('INVITEES_DETAILS', $recordModel->getInviteesDetails());
+			$sendMailField = Vtiger_Field_Model::getInstance('send_mail', $moduleModel);
+			if ($sendMailField) {
+				$sendMailValue = '0';
+				if ($mode === 'edit' && !empty($recordId)) {
+					$sendMailValue = $recordModel->get('send_mail');
+				}
+				$sendMailField->set('fieldvalue', $sendMailValue);
+				$viewer->assign('SEND_MAIL_FIELD', $sendMailField);
+			}
 		}
 
 		$viewer->assign('CURRENTDATE', date('Y-n-j'));

--- a/modules/Calendar/views/QuickCreateAjax.php
+++ b/modules/Calendar/views/QuickCreateAjax.php
@@ -104,15 +104,6 @@ class Calendar_QuickCreateAjax_View extends Vtiger_QuickCreateAjax_View {
 			$viewer->assign('ACCESSIBLE_USERS', $accessibleUsers);
 			$viewer->assign('INVITIES_SELECTED', $recordModel->getInvities());
 			$viewer->assign('INVITEES_DETAILS', $recordModel->getInviteesDetails());
-			$sendMailField = Vtiger_Field_Model::getInstance('send_mail', $moduleModel);
-			if ($sendMailField) {
-				$sendMailValue = '0';
-				if ($mode === 'edit' && !empty($recordId)) {
-					$sendMailValue = $recordModel->get('send_mail');
-				}
-				$sendMailField->set('fieldvalue', $sendMailValue);
-				$viewer->assign('SEND_MAIL_FIELD', $sendMailField);
-			}
 		}
 
 		$viewer->assign('CURRENTDATE', date('Y-n-j'));

--- a/modules/Events/actions/Save.php
+++ b/modules/Events/actions/Save.php
@@ -204,6 +204,13 @@ class Events_Save_Action extends Calendar_Save_Action {
 		if($request->has('selectedusers')) {
 			$recordModel->set('selectedusers', $request->get('selectedusers'));
 		}
+		if($request->has('send_mail')) {
+			if($request->get('send_mail')=='on'  || $request->get('send_mail') == '1') {
+				$recordModel->set('send_mail', '1');
+			} else {
+				$recordModel->set('send_mail', '0');
+			}
+		}
 		return $recordModel;
 	}
 	

--- a/modules/Events/models/EditRecordStructure.php
+++ b/modules/Events/models/EditRecordStructure.php
@@ -12,5 +12,13 @@
  * Events Edit View Record Structure Model
  */
 class Events_EditRecordStructure_Model extends Calendar_EditRecordStructure_Model {
+    public function getStructure() {
+        
+        $values = parent::getStructure();
+        if (isset($values['LBL_EVENT_INFORMATION']['send_mail'])) {
+            unset($values['LBL_EVENT_INFORMATION']['send_mail']);
+        }
 
+        return $values;
+    }
 }

--- a/modules/Events/models/Module.php
+++ b/modules/Events/models/Module.php
@@ -28,9 +28,10 @@ class Events_Module_Model extends Calendar_Module_Model {
 	public function saveRecord(Vtiger_Record_Model $recordModel) {
         $recordModel = parent::saveRecord($recordModel);
         
-        //code added to send mail to the vtiger_invitees
+        //活動保存後に参加者(担当者抜き)がいるかつメール送信フラグがONの場合、参加者にメール送信する
         $selectUsers = $recordModel->get('selectedusers');
-        if(!empty($selectUsers))
+		$send_mail = $recordModel->get('send_mail');
+        if(!empty($selectUsers) && $send_mail == '1')
         {
             $invities = implode(';',$selectUsers);
             $mail_contents = $recordModel->getInviteUserMailData();

--- a/modules/Events/models/Module.php
+++ b/modules/Events/models/Module.php
@@ -27,17 +27,6 @@ class Events_Module_Model extends Calendar_Module_Model {
 	 */
 	public function saveRecord(Vtiger_Record_Model $recordModel) {
         $recordModel = parent::saveRecord($recordModel);
-        
-        //活動保存後に参加者(担当者抜き)がいるかつメール送信フラグがONの場合、参加者にメール送信する
-        $selectUsers = $recordModel->get('selectedusers');
-		$send_mail = $recordModel->get('send_mail');
-        if(!empty($selectUsers) && $send_mail == '1')
-        {
-            $invities = implode(';',$selectUsers);
-            $mail_contents = $recordModel->getInviteUserMailData();
-            $activityMode = ($recordModel->getModuleName()=='Calendar') ? 'Task' : 'Events';
-            sendInvitation($invities,$activityMode,$recordModel,$mail_contents);
-        }
     }
 
 	/**

--- a/setup/migration/scripts/20260119191046_add_send_mail.php
+++ b/setup/migration/scripts/20260119191046_add_send_mail.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * マイグレーション: add_send_mail_field_to_event
+ * 生成日時: 20260119191046
+ */
+require_once('include/logging.php');
+require_once('includes/main/WebUI.php');
+require_once('include/utils/utils.php');
+require_once('includes/runtime/BaseModel.php');
+require_once('modules/Settings/MenuEditor/models/Module.php');
+require_once('modules/Settings/Vtiger/models/Module.php');
+require_once('modules/Vtiger/models/MenuStructure.php');
+require_once('modules/Vtiger/models/Module.php');
+require_once('modules/Vtiger/models/Record.php');
+require_once('modules/Users/models/Record.php');
+require_once('setup/utils/FRFieldSetting.php');
+require_once('setup/utils/FRFilterSetting.php');
+include_once('vtlib/Vtiger/Menu.php');
+include_once('vtlib/Vtiger/Module.php');
+include_once('modules/ModTracker/ModTracker.php');
+include_once('include/utils/CommonUtils.php');
+include_once('includes/Loader.php');
+include_once('includes/runtime/LanguageHandler.php');
+include_once('includes/runtime/Globals.php');
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260119191046_AddSendMail extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     * ここにマイグレーション処理を記述してください
+     */
+     public function process() {
+        global $current_user;
+        $current_user = Users::getActiveAdminUser();
+        $this->addSendMailBlock();
+        $this->log("マイグレーション add_send_mail が正常に完了しました");
+    }
+    private function addSendMailBlock() {
+        $moduleModel = Vtiger_Module_Model::getInstance('Events');
+
+        // 基本情報 ブロック取得
+        $descriptionBlock = Vtiger_Block_Model::getInstance('LBL_EVENT_INFORMATION', $moduleModel);
+        $descriptionBlockId = $descriptionBlock->id;
+
+        // Block / Module インスタンス取得
+        $module = Vtiger_Module::getInstance('Events');
+        $blockInstance = Vtiger_Block::getInstance($descriptionBlockId, $module);
+
+        /**************************************************************
+         * send_mail(送信メール制御) 
+         **************************************************************/
+        $field = new Vtiger_Field();
+        $field->name        = 'send_mail';
+        $field->label       = 'Send Mail';
+        $field->table       = 'vtiger_activity';
+        $field->column      = 'send_mail';
+        $field->columntype  = 'VARCHAR(3)';
+        $field->uitype      = 56;
+        $field->typeofdata  = 'C~O';
+        $field->presence    = 0;
+        $field->readonly    = 1;
+        $field->masseditable= 1;
+        $field->quickcreate = 2;
+        $blockInstance->addField($field);
+    }
+
+}

--- a/setup/migration/scripts/20260119191046_add_send_mail.php
+++ b/setup/migration/scripts/20260119191046_add_send_mail.php
@@ -23,7 +23,6 @@ include_once('includes/Loader.php');
 include_once('includes/runtime/LanguageHandler.php');
 include_once('includes/runtime/Globals.php');
 require_once dirname(__FILE__) . '/../FRMigrationClass.php';
-require_once dirname(__FILE__) . '/../FRMigrationClass.php';
 
 class Migration20260119191046_AddSendMail extends FRMigrationClass {
     
@@ -53,7 +52,7 @@ class Migration20260119191046_AddSendMail extends FRMigrationClass {
          **************************************************************/
         $field = new Vtiger_Field();
         $field->name        = 'send_mail';
-        $field->label       = 'Send Mail';
+        $field->label       = 'LBL_SEND_MAIL';
         $field->table       = 'vtiger_activity';
         $field->column      = 'send_mail';
         $field->columntype  = 'VARCHAR(3)';


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1194 
- fix #957

##  要望
 1. スケジュール登録時、メール通知可否は画面上の選択内容に応じて制御したい。
 2. 招待者（参加者）にグループを選択できるよう追加する。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. メール送信チェックボックスの判定処理を見直した。 チェックON時のみ send_mail を有効値として保持し、チェックOFF時は無効値となるよう更新処理を修正した。
2.  レコード詳細画面におけるメール送信項目の表示追加した。
3. 担当に「グループ」を指定した場合、所属ユーザーへ展開してメール送信するよう対応した。
4. 招待者（参加者）にグループを選択できるよう追加した（活動クイック作成 活動・編集画面の両方）。
5. 繰り返し予定保存時の send_mail 同期およびチェック状態の維持。

## スクリーンショット / Screenshot
<img width="811" height="761" alt="image" src="https://github.com/user-attachments/assets/8b19ecb6-6a5a-42d0-a6f3-899fc490e6c0" />
<img width="2508" height="1273" alt="image" src="https://github.com/user-attachments/assets/029ac591-24fa-4e18-89bf-f546a6fce28a" />
<img width="2484" height="1100" alt="image" src="https://github.com/user-attachments/assets/4f2ff4ad-4e1e-4aae-b086-7cf2e5d3220f" />
<img width="895" height="893" alt="image" src="https://github.com/user-attachments/assets/5ecc2a08-8c9f-4b95-82b2-ab388f1ab2fc" />
<img width="1233" height="1223" alt="image" src="https://github.com/user-attachments/assets/3b8f06ec-41f6-476f-82b4-a7b8283bc187" />


## 影響範囲  / Affected Area
1. カレンダーのスケジュール登録画面におけるメール送信チェックボックスの挙動。
2.  Events 保存時の通知メール送信可否判定。
3. レコード詳細画面におけるメール送信項目の表示および値の保持。
4. 招待者（参加者）の選択へグループ追加。
5. 繰り返し予定保存時のメール送信同期およびチェックボックス状態の維持。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った