### PR TITLE
create_dbのチェック状態と入力欄表示の同期不整合、およびボタン表示制御の修正

### DIFF
--- a/layouts/v7/modules/Install/Step5.tpl
+++ b/layouts/v7/modules/Install/Step5.tpl
@@ -99,7 +99,9 @@
 				<div class="col-sm-2"></div>
 				<div class="col-sm-8">
 					<div class="button-container">
-						<input type="button" class="btn btn-default" value="{vtranslate('LBL_BACK','Install')}" {if $DB_CONNECTION_INFO['flag'] eq true} disabled= "disabled" {/if} name="back"/>
+						{if $DB_CONNECTION_INFO['flag'] neq true}
+							<input type="button" class="btn btn-default" value="{vtranslate('LBL_BACK','Install')}" name="back"/>
+						{/if}
 						{if $DB_CONNECTION_INFO['flag'] eq true}
 							<input type="button" class="btn btn-large btn-primary" value="{vtranslate('LBL_NEXT','Install')}" name="step6"/>
 						{/if}

--- a/public/layouts/v7/modules/Install/resources/Index.js
+++ b/public/layouts/v7/modules/Install/resources/Index.js
@@ -32,29 +32,22 @@ jQuery.Class('Install_Index_Js', {}, {
 	registerEventForStep4: function () {
 		jQuery('input[type="text"]').not('.short').css('width', '210px');
 		jQuery('input[type="password"]').css('width', '210px');
-
-		jQuery('input[name="create_db"]').on('click', function () {
-			var userName = jQuery('#root_user');
-			var password = jQuery('#root_password');
-			var classU = userName.attr('class');
-			if (classU == 'hide')
-				userName.removeClass('hide');
-			else
-				userName.addClass('hide');
-
-			var classP = password.attr('class');
-			if (classP == 'hide')
-				password.removeClass('hide');
-			else
-				password.addClass('hide');
-		});
-
-		if (jQuery('input[name="create_db"]').prop('checked'))
-		{
-			jQuery('#root_user').removeClass("hide");
-			jQuery('#root_password').removeClass("hide");
+		// create_db のチェック状態に応じて、Rootユーザー／Rootパスワード入力欄の表示を切り替える
+		function updateCreateDbFieldsVisibility() {
+			var isChecked = jQuery('input[name="create_db"]').prop('checked');
+			jQuery('#root_user').toggleClass('hide', !isChecked);
+			jQuery('#root_password').toggleClass('hide', !isChecked);
 		}
-
+		// チェック状態が変更されたタイミングで表示状態を同期する
+		jQuery('input[name="create_db"]').on('change', function () {
+			updateCreateDbFieldsVisibility();
+		});
+		// 初期表示時にも、ブラウザ保持中のチェック状態をもとに表示状態を同期する
+		updateCreateDbFieldsVisibility();
+		// 戻る操作などで画面が再表示された場合にも、チェック状態と表示状態を再同期する
+		jQuery(window).on('pageshow', function () {
+			updateCreateDbFieldsVisibility();
+		});
 		function clearPasswordError() {
 			jQuery('#passwordError').html('');
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1339 

##  不具合の内容 / Bug
1. Step4 画面にて、create_db のチェック状態と Rootユーザー／Rootパスワード入力欄の表示状態が一致しない場合があり、チェック済みでも入力欄が非表示になることがあった。
2. Step5 から Back で Step4 に戻った際、ブラウザに保持された create_db のチェック状態と、入力欄の初期表示状態がずれ、表示不整合が発生していた。
3. DB接続確認結果に応じたボタン制御で、不要な disabled 表示が残っていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. create_db の表示制御が checked 状態ではなく、hide クラスの単純な切り替えで実装されていたため、初期表示や画面再表示時に状態不整合が発生していた。
2. ブラウザが保持した checkbox の状態と、テンプレート初期値の表示状態が別管理になっており、Back や再読み込み時に同期されていなかった。
3. ボタン制御が disabled 付与方式だったため、入力データ正しい時に「戻る」ボタンを押せない状態になるだけです。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. create_db の checked 状態に応じて、Rootユーザー／Rootパスワード入力欄の表示を同期する処理に修正した。
2. Step4 初期表示時にも create_db の状態を参照して、関連入力欄の表示状態を再同期するよう修正した。
3. DB接続確認結果に応じて、Back / Next ボタンを disabled 制御ではなく表示切替で出し分けるよう修正した。

## スクリーンショット / Screenshot
<img width="1803" height="669" alt="image" src="https://github.com/user-attachments/assets/64be8caa-9d80-426f-b287-9460b64e8de4" />
<img width="1810" height="752" alt="image" src="https://github.com/user-attachments/assets/13ef7786-0973-4e0b-a8d6-a82092c7bcd2" />
<img width="1881" height="721" alt="image" src="https://github.com/user-attachments/assets/f8c40d8c-5e74-40a4-b574-9a27d3a9fa8b" />

## 影響範囲  / Affected Area
- Install Step4 の create_db 関連表示制御
- Install Step4〜Step5 間の戻る操作時の表示整合性
- Install 画面下部の Back / Next ボタン表示制御
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
