### PR TITLE
クイック作成における担当項目が英語表示の際に選択肢が表示されない不具合の修正

### DIFF
--- a/assets/react-web-components/src/components/OwnerField.tsx
+++ b/assets/react-web-components/src/components/OwnerField.tsx
@@ -114,8 +114,14 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     };
   }, [isOpen, dropdownPosition]);
 
+  // 翻訳済みのラベルをキーとして使用（APIは翻訳済み文字列をキーとして返す）
+  const userLabel = t('LBL_USERS', 'ユーザー');
+  const groupLabel = t('LBL_GROUPS', 'グループ');
+
   /**
    * picklistvaluesからユーザーとグループのオプションを抽出
+   * picklistvaluesのキーは、APIから翻訳済みラベルとして返される
+   * t()で翻訳したラベルをキーとして使用することで、どの言語でも対応可能
    */
   const allOptions = useMemo(() => {
     const options: OwnerOption[] = [];
@@ -123,17 +129,17 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     if (fieldinfo?.picklistvalues) {
       const picklistValues = fieldinfo.picklistvalues as Record<string, Record<string, string>>;
 
-      // ユーザーを取得
-      if (picklistValues['ユーザー'] && typeof picklistValues['ユーザー'] === 'object') {
-        const userObj = picklistValues['ユーザー'] as { [id: string]: string };
+      // ユーザーを取得（t('LBL_USERS')の翻訳結果をキーとして使用）
+      if (picklistValues[userLabel] && typeof picklistValues[userLabel] === 'object') {
+        const userObj = picklistValues[userLabel] as { [id: string]: string };
         Object.entries(userObj).forEach(([id, name]) => {
           options.push({ id, name, type: 'user' });
         });
       }
 
-      // グループを取得
-      if (picklistValues['グループ'] && typeof picklistValues['グループ'] === 'object') {
-        const groupObj = picklistValues['グループ'];
+      // グループを取得（t('LBL_GROUPS')の翻訳結果をキーとして使用）
+      if (picklistValues[groupLabel] && typeof picklistValues[groupLabel] === 'object') {
+        const groupObj = picklistValues[groupLabel];
         if (!Array.isArray(groupObj)) {
           Object.entries(groupObj).forEach(([id, name]) => {
             options.push({ id, name: name as string, type: 'group' });
@@ -143,7 +149,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     }
 
     return options;
-  }, [fieldinfo]);
+  }, [fieldinfo, userLabel, groupLabel]);
 
   /**
    * 検索でフィルタリングされたオプション
@@ -307,7 +313,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
             {filteredUsers.length > 0 && (
               <>
                 <div className="px-3 py-1 text-xs font-semibold text-gray-500 bg-gray-50">
-                  ユーザー
+                  {userLabel}
                 </div>
                 {filteredUsers.map(user => (
                   <div
@@ -328,7 +334,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
             {filteredGroups.length > 0 && (
               <>
                 <div className="px-3 py-1 text-xs font-semibold text-gray-500 bg-gray-50">
-                  グループ
+                  {groupLabel}
                 </div>
                 {filteredGroups.map(group => (
                   <div
@@ -347,7 +353,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
           </div>
         ) : (
           <div className="px-3 py-1.5 text-md text-gray-500 text-center">
-            該当する担当者がいません
+            {t('LBL_NO_MATCHING_OWNER', '該当する担当者がいません')}
           </div>
         )}
       </div>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1491

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 言語設定を英語表示にした場合、「Assigned To（担当）」項目の選択肢が表示されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `OwnerField.tsx`において、picklistvaluesのキーとして日本語の「ユーザー」「グループ」がハードコードされていた
2. APIは言語設定に応じて翻訳済みのラベル（英語: "Users"/"Groups"、日本語: "ユーザー"/"グループ"）をキーとして返すため、英語表示時にキーが一致せず選択肢を取得できなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. フロントエンド側で`t('LBL_USERS')`、`t('LBL_GROUPS')`を使用して翻訳済みキーを動的に取得するよう変更
2. ドロップダウンのoptgroupラベル（「ユーザー」「グループ」）も翻訳キーを使用するよう変更し、言語設定に応じた表示に対応
3. 「該当する担当者がいません」のメッセージも翻訳キー`LBL_NO_MATCHING_OWNER`を使用するよう変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- React版クイック作成モーダルの担当者（Assigned To / UIType 53）フィールド
- Calendar、Products、その他WebComponents版QuickCreateを使用するモジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
