### PR TITLE
終日予定を時間予定へドラッグ変換した際の重複予定検知不具合及び時間帯予定から終日予定に変更できない問題を修正

### DIFF
--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1741,6 +1741,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		Friday: 5,
 		Saturday: 6
 	},
+	// 重複チェック時に、終了日時が null の場合に補完するデフォルト時間（単位: 時間）
+	// サーバ側 DragDropAjax.php の `$endSecondsDelta = $secondsDelta + 7200`（2時間=7200秒）と揃えること
+	overlapEndDefaultDurationHours: 2,
 	refreshFeed: function (feedCheckbox) {
 		var thisInstance = this;
 		if (feedCheckbox.is(':checked')) {
@@ -1789,7 +1792,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	getOverlapEndDateTime: function (event) {
 		var overlapEnd = event.end ? moment(event.end) : null;
 		if (!overlapEnd && !event.allDay && event.start) {
-			overlapEnd = moment(event.start).add(2, 'hours');
+			overlapEnd = moment(event.start).add(this.overlapEndDefaultDurationHours, 'hours');
 		}
 		return overlapEnd;
 	},


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1320 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 終日予定をカレンダー上で時間予定エリアへドラッグした際、重複予定確認で実際には重複していない場合でも重複ダイアログが表示されることがある。

##  原因 / Cause
1. ドラッグ保存処理と重複予定確認処理で、参照する日時データが分かれていた。
2. 終日予定を時間予定へドラッグした場合、重複予定確認側で終了日時を正しく取得できていなかった。
3. その結果、重複判定の時間範囲が不正となり、誤って重複と判定されることがあった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `Calendar.js` のドラッグ・リサイズ時の重複予定確認用データ生成処理を修正した。
2. `event.end` が取得できない場合でも、終日予定から時間予定へ変換するケースでは終了時刻を補完して `due_date` / `time_end` を設定するようにした。
3. 重複予定確認時の時間範囲と、実際のドラッグ保存時の時間計算の整合性を取るようにした。

## 影響範囲  / Affected Area
- カレンダー画面での時間予定から終日予定へのドラッグ操作
- 終日予定から時間予定への変更時の重複予定確認
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
