### PR TITLE
 開始日時の「等しくない」条件での絞り込み不備を修正

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -388,11 +388,6 @@ class QueryGenerator {
 		//TODO optimization to eliminate one more lookup of name, incase the field refers to only
 		//one module or is of type owner.
 		$column = $field->getColumnName();
-		// Calendar の date_start は一覧表示上も実質的に date_start + time_start の開始日時として扱われるため、
-		// DT 条件での比較時にも date_start 単体ではなく日時として比較できるようにする
-		if ($this->meta->getEntityName() == 'Calendar' && $name === 'date_start') {
-			return "TIMESTAMP({$field->getTableName()}.{$column}, {$field->getTableName()}.time_start)";
-		}
 		return $field->getTableName().'.'.$column;
 	}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1236 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 活動の一覧画面で「開始日時」項目に対して「等しくない」を条件に設定した場合、同一日内の時刻付きレコードが期待どおりに除外されず、絞り込み結果が不正になる。
##  原因 / Cause
<!-- バグの原因を記述 -->
1.modules/CustomView/models/Record.php の transformStandardFilter() にて、vtiger_activity.date_start が createdtime / modifiedtime と同様に DT として変換される実装になっていた。
2.具体的には、以下の条件により date_start が :DT 付きの項目として扱われ、標準フィルタ上は開始日時として比較される形になっていた。if ($fields[1] == 'createdtime' || $fields[1] == 'modifiedtime' || ($fields[0] == 'vtiger_activity' && $fields[1] == 'date_start'))
3.その結果、$tranformedStandardFilter['columnname'] = $standardFilter['columnname'].':DT'; により date_start が DT として扱われる一方、実際の比較処理側では date_start 単体を基準にしている箇所があり、表示ロジックと比較ロジックに不整合が発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.date_start が標準フィルタ変換時に DT として扱われる前提を踏まえ、Calendar の date_start 比較時には time_start を含めた開始日時として比較するよう修正。
2.「開始日時」項目の比較値が日付のみに丸められないよう調整し、「等しくない」条件でも時刻付きレコードを正しく絞り込めるよう修正。
3.影響範囲を抑えるため、Calendar の date_start 比較時のみ特別処理を追加。

## スクリーンショット / Screenshot
<img width="2521" height="444" alt="image" src="https://github.com/user-attachments/assets/f1e483bd-e2fa-4001-b223-75f8882ff960" />
<img width="978" height="521" alt="image" src="https://github.com/user-attachments/assets/29b8cb50-5f05-4899-a9ea-340eeb740dca" />
<img width="1079" height="759" alt="image" src="https://github.com/user-attachments/assets/8c6052dc-aca6-40d3-9b9c-41c224a41add" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
Calendar モジュールの活動一覧における「開始日時」条件の絞り込み処理
特に「等しい / 等しくない」など、開始日時を日時として比較する条件

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->