### PR TITLE
fix: #1479 4KディスプレイでトグルスイッチがUI崩れを起こす対応

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -1811,3 +1811,8 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
   }
 }
 
+/* #1479 4Kモニターでトグルスイッチを表示した際のUI崩れを修正 */
+.bootstrap-switch .bootstrap-switch-container {
+    white-space: nowrap;
+}
+


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1479 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 4Kモニター環境でbootstrap-switchの表示が崩れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 親要素幅不足そのものではなく、bootstrap-switch の固定幅前提レイアウト内でbootstrap-switch-container 配下が折り返し可能になっていたこと

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. public/resources/styles.css に以下の override を追加
    .bootstrap-switch .bootstrap-switch-container {
    white-space: nowrap;
　}

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
<img width="898" height="841" alt="トグルスイッチUI崩れ(修正前)" src="https://github.com/user-attachments/assets/51b2bb65-3822-4059-864e-386ef5a5cca4" />

修正後
<img width="902" height="842" alt="トグルスイッチUI崩れ(修正後)" src="https://github.com/user-attachments/assets/03f02403-85ad-4dd9-a0ed-3d69280f56a8" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
bootstrap-switchを利用している画面全般
※横並びのスイッチUIとして利用する都合上問題ない認識

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->