### PR TITLE
#1504 検索時もJSONエンコードする仕様に変更

### DIFF
--- a/modules/Settings/Picklist/handlers/PickListHandler.php
+++ b/modules/Settings/Picklist/handlers/PickListHandler.php
@@ -94,8 +94,11 @@ class PickListHandler extends VTEventHandler {
 		}
 		
 		//update Workflows values
-		$query= 'SELECT workflow_id,test FROM com_vtiger_workflows where module_name=? AND test != "" AND test IS NOT NULL AND test !="null" AND test LIKE ?';
-		$result = $db->pquery($query, array($moduleName,"%$oldValue%"));
+		// json_encodeはデフォルトで非ASCII文字をUnicodeエスケープするため、エスケープ版でも検索する
+		$escapedOldValue = trim(json_encode($oldValue), '"');
+		$escapedLikeOld = str_replace('\\', '\\\\', $escapedOldValue);
+		$query= 'SELECT workflow_id,test FROM com_vtiger_workflows where module_name=? AND test != "" AND test IS NOT NULL AND test !="null" AND (test LIKE ? OR test LIKE ?)';
+		$result = $db->pquery($query, array($moduleName, "%$oldValue%", "%$escapedLikeOld%"));
 		$num_rows = $db->num_rows($result);
 		for($i = 0;$i < $num_rows; $i++) {
 			$row = $db->query_result_rowdata($result, $i);
@@ -122,8 +125,8 @@ class PickListHandler extends VTEventHandler {
 		}
 		
 		//update workflow task
-		$query = 'SELECT task,task_id,workflow_id FROM com_vtiger_workflowtasks where task LIKE ?';
-		$result = $db->pquery($query, array("%$oldValue%"));
+		$query = 'SELECT task,task_id,workflow_id FROM com_vtiger_workflowtasks where (task LIKE ? OR task LIKE ?)';
+		$result = $db->pquery($query, array("%$oldValue%", "%$escapedLikeOld%"));
 		$num_rows = $db->num_rows($result);
 		
 		for ($i = 0; $i < $num_rows; $i++) {
@@ -245,8 +248,10 @@ class PickListHandler extends VTEventHandler {
 		
 		foreach ($valueToDelete as $value) {
 			//update Workflows values
-			$query = 'SELECT workflow_id,test FROM com_vtiger_workflows where module_name=? AND test != "" AND test IS NOT NULL AND test !="null" AND test LIKE ?';
-			$result = $db->pquery($query, array($moduleName,"%$value%"));
+			$escapedValue = trim(json_encode($value), '"');
+			$escapedLikeValue = str_replace('\\', '\\\\', $escapedValue);
+			$query = 'SELECT workflow_id,test FROM com_vtiger_workflows where module_name=? AND test != "" AND test IS NOT NULL AND test !="null" AND (test LIKE ? OR test LIKE ?)';
+			$result = $db->pquery($query, array($moduleName, "%$value%", "%$escapedLikeValue%"));
 			$num_rows = $db->num_rows($result);
 			for ($i = 0; $i < $num_rows; $i++) {
 				$row = $db->query_result_rowdata($result, $i);
@@ -278,8 +283,10 @@ class PickListHandler extends VTEventHandler {
 		
 		foreach ($valueToDelete as $value) {
 			//update workflow task
-			$query = 'SELECT task,task_id,workflow_id FROM com_vtiger_workflowtasks where task LIKE ?';
-			$result = $db->pquery($query, array("%$value%"));
+			$escapedValueForTask = trim(json_encode($value), '"');
+			$escapedLikeValueForTask = str_replace('\\', '\\\\', $escapedValueForTask);
+			$query = 'SELECT task,task_id,workflow_id FROM com_vtiger_workflowtasks where (task LIKE ? OR task LIKE ?)';
+			$result = $db->pquery($query, array("%$value%", "%$escapedLikeValueForTask%"));
 			$num_rows = $db->num_rows($result);
 
 			for ($i = 0; $i < $num_rows; $i++) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1504 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. ワークフローの条件やタスクに選択肢の値をいれた時。
　その選択肢が置換、編集されても、置き換わらない。

##  原因 / Cause
<!-- バグの原因を記述 -->
 条件式や、タスクのINSERT時、JSONエンコードされているにもかかわらず
置換元の値を使用したタスクが存在するか確認する際に、エンコードしていないから。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 検索前にエンコードする。

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
選択肢変更後イベント

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
