### PR TITLE
ごみ箱のモジュール一覧で権限制御不具合修正

### DIFF
--- a/modules/RecycleBin/models/Module.php
+++ b/modules/RecycleBin/models/Module.php
@@ -108,8 +108,9 @@ class RecycleBin_Module_Model extends Vtiger_Module_Model {
 	public function getAllModuleList(){
 		$moduleModels = parent::getEntityModules();
 		$restrictedModules = array('Emails', 'ProjectMilestone', 'ModComments', 'Rss', 'Portal', 'Integration', 'PBXManager', 'Dashboard', 'Home', 'Events');
+		$currentUserPrivilegesModel = Users_Privileges_Model::getCurrentUserPrivilegesModel();
 		foreach($moduleModels as $key => $moduleModel){
-			if(in_array($moduleModel->getName(),$restrictedModules) || $moduleModel->get('isentitytype') != 1){
+			if(in_array($moduleModel->getName(),$restrictedModules) || $moduleModel->get('isentitytype') != 1 || !$currentUserPrivilegesModel->hasModulePermission($moduleModel->getId())){
 				unset($moduleModels[$key]);
 			}
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1205 

##  不具合の内容 / Bug
ごみ箱の画面左モジュール一覧において、役割・プロファイルによるモジュールのアクセス権限制御が効いておらず、アクセスが制限されているユーザーでも全モジュールが表示されてしまう。
##  原因 / Cause
RecycleBin_Module_Model::getAllModuleList() にて、モジュール一覧を取得する際に、制限モジュール名リスト（$restrictedModules）と isentitytype のチェックのみ行っており、ログインユーザーのモジュールアクセス権限（プロファイル設定）をチェックしていなかった。

##  変更内容 / Details of Change
modules/RecycleBin/models/Module.php の getAllModuleList() メソッドにて、Users_Privileges_Model::getCurrentUserPrivilegesModel() を取得し、hasModulePermission() によるモジュール権限チェックを追加。権限のないモジュールは一覧から除外するようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1777" height="804" alt="image" src="https://github.com/user-attachments/assets/091d1827-606c-4147-8ff2-dbe3ec00035b" />
<img width="973" height="338" alt="image" src="https://github.com/user-attachments/assets/6d210f75-b986-4a6a-92a6-9ad75f5f47c3" />
<img width="865" height="574" alt="image" src="https://github.com/user-attachments/assets/0513f10a-5031-49c0-bd96-808db21f55e8" />
<img width="869" height="571" alt="image" src="https://github.com/user-attachments/assets/78c479f8-11a5-43d0-9685-4195ca61424b" />

## 影響範囲  / Affected Area
ごみ箱（RecycleBin）画面の左サイドバーに表示されるモジュール一覧
管理者以外のユーザーで、プロファイルにてモジュールアクセスが制限されている場合に影響あり

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
