### PR TITLE
#1512 vtiger_crmentityへの参照をbasetableに置換

### DIFF
--- a/modules/Calendar/models/ListView.php
+++ b/modules/Calendar/models/ListView.php
@@ -242,7 +242,7 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 
 		
 		if(empty($orderBy)) {
-            $listQuery .= " ORDER BY vtiger_crmentity.modifiedtime $sortOrder ";
+            $listQuery .= " ORDER BY vtiger_activity.modifiedtime $sortOrder ";
 		} else if($orderBy == 'date_start') {
             $listQuery .= " ORDER BY str_to_date(concat(date_start,time_start),'%Y-%m-%d %H:%i:%s') $sortOrder ";
         } else if($orderBy == 'due_date') {

--- a/modules/Documents/models/ListView.php
+++ b/modules/Documents/models/ListView.php
@@ -218,7 +218,7 @@ class Documents_ListView_Model extends Vtiger_ListView_Model {
 			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 		} else if(empty($orderBy) && empty($sortOrder)){
 			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_crmentity.modifiedtime DESC';
+			$listQuery .= ' ORDER BY vtiger_notes.modifiedtime DESC';
 		}
 
 		$viewid = ListViewSession::getCurrentView($moduleName);

--- a/modules/PriceBooks/models/ListView.php
+++ b/modules/PriceBooks/models/ListView.php
@@ -105,7 +105,7 @@ class PriceBooks_ListView_Model extends Vtiger_ListView_Model {
 			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 		} else if(empty($orderBy) && empty($sortOrder)){
 			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_crmentity.modifiedtime DESC';
+			$listQuery .= ' ORDER BY vtiger_pricebook.modifiedtime DESC';
 		}
 
 		$viewid = ListViewSession::getCurrentView($moduleName);

--- a/modules/Products/models/ListView.php
+++ b/modules/Products/models/ListView.php
@@ -79,7 +79,7 @@ class Products_ListView_Model extends Vtiger_ListView_Model {
 			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 		} else if(empty($orderBy) && empty($sortOrder)){
 			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_crmentity.modifiedtime DESC';
+			$listQuery .= ' ORDER BY vtiger_products.modifiedtime DESC';
 		}
 
 		$viewid = ListViewSession::getCurrentView($moduleName);

--- a/setup/migration/scripts/20260327101100_update_field_tablename.php
+++ b/setup/migration/scripts/20260327101100_update_field_tablename.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * マイグレーション: update_field_tablename
+ * 生成日時: 20260327101100
+ *
+ * 75_Update_CRMEntity.php で CRMEntity->id（レコードID）を tabid として
+ * 使用していたため、vtiger_field.tablename の更新が実行されなかった問題を修正する。
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260327101100_UpdateFieldTablename extends FRMigrationClass {
+
+    public function process() {
+        $db = PearDatabase::getInstance();
+
+        // エンティティモジュール一覧を取得（name, tabid）
+        $ignoreModules = array('SMSNotifier', 'PBXManager', 'Webmails');
+        $result = $db->pquery(
+            'SELECT name, tabid FROM vtiger_tab WHERE isentitytype = ? AND name NOT IN (' . generateQuestionMarks($ignoreModules) . ')',
+            array(1, $ignoreModules)
+        );
+        if ($result === false) {
+            throw new Exception('vtiger_tab の取得に失敗しました');
+        }
+
+        $modules = array();
+        while ($row = $db->fetchByAssoc($result)) {
+            $modules[] = $row;
+        }
+
+        $executedTables = array();
+        $totalUpdated = 0;
+
+        foreach ($modules as $moduleInfo) {
+            $moduleName = $moduleInfo['name'];
+            $tabid = $moduleInfo['tabid'];
+
+            // CRMEntityからモジュールのベーステーブル名を取得
+            $entity = CRMEntity::getInstance($moduleName);
+            $baseTable = $entity->table_name;
+            if (empty($baseTable)) continue;
+
+            // 同じbaseTableを共有するモジュールはフィールドも共有しているためスキップ
+            if (in_array($baseTable, $executedTables)) continue;
+
+            // vtiger_crmentityからbaseTableへtablenameを付け替える
+            $updateResult = $db->pquery(
+                'UPDATE vtiger_field SET tablename = ? WHERE tabid = ? AND tablename = ?',
+                array($baseTable, $tabid, 'vtiger_crmentity')
+            );
+            if ($updateResult === false) {
+                throw new Exception("vtiger_field の更新に失敗しました: モジュール=$moduleName, tabid=$tabid");
+            }
+
+            $affectedRows = $db->getAffectedRowCount($updateResult);
+            $this->log("モジュール: $moduleName (tabid=$tabid), テーブル: $baseTable, 更新件数: $affectedRows");
+
+            $totalUpdated += $affectedRows;
+            $executedTables[] = $baseTable;
+        }
+
+        $this->log("合計 $totalUpdated 件の vtiger_field レコードを更新しました");
+    }
+}

--- a/setup/migration/scripts/20260327101100_update_field_tablename.php
+++ b/setup/migration/scripts/20260327101100_update_field_tablename.php
@@ -29,7 +29,6 @@ class Migration20260327101100_UpdateFieldTablename extends FRMigrationClass {
             $modules[] = $row;
         }
 
-        $executedTables = array();
         $totalUpdated = 0;
 
         foreach ($modules as $moduleInfo) {
@@ -41,10 +40,8 @@ class Migration20260327101100_UpdateFieldTablename extends FRMigrationClass {
             $baseTable = $entity->table_name;
             if (empty($baseTable)) continue;
 
-            // 同じbaseTableを共有するモジュールはフィールドも共有しているためスキップ
-            if (in_array($baseTable, $executedTables)) continue;
-
             // vtiger_crmentityからbaseTableへtablenameを付け替える
+            // baseTableを共有するモジュール（Calendar/Events/Emails等）でもtabidが異なるため個別に更新が必要
             $updateResult = $db->pquery(
                 'UPDATE vtiger_field SET tablename = ? WHERE tabid = ? AND tablename = ?',
                 array($baseTable, $tabid, 'vtiger_crmentity')
@@ -57,7 +54,6 @@ class Migration20260327101100_UpdateFieldTablename extends FRMigrationClass {
             $this->log("モジュール: $moduleName (tabid=$tabid), テーブル: $baseTable, 更新件数: $affectedRows");
 
             $totalUpdated += $affectedRows;
-            $executedTables[] = $baseTable;
         }
 
         $this->log("合計 $totalUpdated 件の vtiger_field レコードを更新しました");


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1512 

##  不具合の内容 / Bug
1. basetableに同一のfieldがあるにもかかわらず、vtiger_crmentityを参照する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. setup/scripts/75_Update_CRMEntity.phpで、該当fieldのtablenameをbasetableへreplaceをしているが
　crmentityクラスのidをtabidに指定して抽出している。crmentityクラスはレコードのidをもつため、このスクリプトではnullとなる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. tabidをDBから取得

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
vtiger_fieldのtablename

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
