### PR TITLE
fix:1510 HTMLタグを利用しない画面でHTMLタグをエスケープ・除去して表示する

### DIFF
--- a/layouts/v7/modules/Calendar/ModuleHeader.tpl
+++ b/layouts/v7/modules/Calendar/ModuleHeader.tpl
@@ -40,13 +40,13 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;</a></p>
 				{/if}
 
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{$RECORD->get('label')}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-lg-5 col-md-6 col-sm-7 col-xs-1 padding0 pull-right">

--- a/layouts/v7/modules/Calendar/ModuleHeader.tpl
+++ b/layouts/v7/modules/Calendar/ModuleHeader.tpl
@@ -40,13 +40,13 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags|escape:'html'}&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;</a></p>
 				{/if}
 
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-lg-5 col-md-6 col-sm-7 col-xs-1 padding0 pull-right">

--- a/layouts/v7/modules/Campaigns/RelatedList.tpl
+++ b/layouts/v7/modules/Campaigns/RelatedList.tpl
@@ -188,7 +188,7 @@
 											{else if $HEADER_FIELD->getFieldDataType() eq 'picklist'}
 												<span {if !empty($RELATED_LIST_VALUE)} class="picklist-color picklist-{$HEADER_FIELD->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RELATED_LIST_VALUE)}" {/if}> {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)} </span>
 											{else if $HEADER_FIELD->getFieldDataType() eq 'text'}
-												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}
 											{else}
 												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
 											{/if}

--- a/layouts/v7/modules/Campaigns/RelatedList.tpl
+++ b/layouts/v7/modules/Campaigns/RelatedList.tpl
@@ -187,6 +187,8 @@
 												{/if}
 											{else if $HEADER_FIELD->getFieldDataType() eq 'picklist'}
 												<span {if !empty($RELATED_LIST_VALUE)} class="picklist-color picklist-{$HEADER_FIELD->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RELATED_LIST_VALUE)}" {/if}> {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)} </span>
+											{else if $HEADER_FIELD->getFieldDataType() eq 'text'}
+												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
 											{else}
 												{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
 											{/if}

--- a/layouts/v7/modules/Documents/DocumentsRelatedList.tpl
+++ b/layouts/v7/modules/Documents/DocumentsRelatedList.tpl
@@ -214,6 +214,8 @@
                                         {/if}
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'picklist'}
                                         <span {if !empty($RELATED_LIST_VALUE)} class="picklist-color picklist-{$HEADER_FIELD->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RELATED_LIST_VALUE)}" {/if}> {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)} </span>
+                                    {else if $HEADER_FIELD->getFieldDataType() eq 'text'}
+                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
                                     {else}
                                         {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/Documents/DocumentsRelatedList.tpl
+++ b/layouts/v7/modules/Documents/DocumentsRelatedList.tpl
@@ -215,7 +215,7 @@
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'picklist'}
                                         <span {if !empty($RELATED_LIST_VALUE)} class="picklist-color picklist-{$HEADER_FIELD->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen($RELATED_LIST_VALUE)}" {/if}> {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)} </span>
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'text'}
-                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}
                                     {else}
                                         {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/Documents/ModuleHeader.tpl
+++ b/layouts/v7/modules/Documents/ModuleHeader.tpl
@@ -42,12 +42,12 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;</a></p>
 				{/if}
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;{$RECORD->get('label')}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-sm-6 col-xs-1 pull-right">

--- a/layouts/v7/modules/Documents/ModuleHeader.tpl
+++ b/layouts/v7/modules/Documents/ModuleHeader.tpl
@@ -42,12 +42,12 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags|escape:'html'}&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;</a></p>
 				{/if}
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags}&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-sm-6 col-xs-1 pull-right">

--- a/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
@@ -22,7 +22,7 @@
                             {foreach item=NAME_FIELD from=$MODULE_MODEL->getNameFields()}
                                 {assign var=FIELD_MODEL value=$MODULE_MODEL->getField($NAME_FIELD)}
                                 {if $FIELD_MODEL->getPermissions()}
-                                    <span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags}</span>&nbsp;
+                                    <span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags|escape:'html'}</span>&nbsp;
                                 {/if}
                             {/foreach}
                         </span>

--- a/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/HelpDesk/DetailViewHeaderTitle.tpl
@@ -18,11 +18,11 @@
             <div class="recordBasicInfo">
                 <div class="info-row">
                     <h4>
-                        <span class="recordLabel pushDown" title="{$RECORD->getName()}">
+                        <span class="recordLabel pushDown" title="{$RECORD->getName()|decode_html|strip_tags|escape:'html'}">
                             {foreach item=NAME_FIELD from=$MODULE_MODEL->getNameFields()}
                                 {assign var=FIELD_MODEL value=$MODULE_MODEL->getField($NAME_FIELD)}
                                 {if $FIELD_MODEL->getPermissions()}
-                                    <span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)}</span>&nbsp;
+                                    <span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags}</span>&nbsp;
                                 {/if}
                             {/foreach}
                         </span>

--- a/layouts/v7/modules/PriceBooks/RelatedList.tpl
+++ b/layouts/v7/modules/PriceBooks/RelatedList.tpl
@@ -97,6 +97,8 @@
 												{assign var=CURRENCY_VALUE value=CurrencyField::convertToUserFormat($RELATED_RECORD->get($RELATED_HEADERNAME), null, true)}
 											{/if}
 											{CurrencyField::appendCurrencySymbol($CURRENCY_VALUE, $CURRENCY_SYMBOL)}
+										{else if $HEADER_FIELD->getFieldDataType() eq 'text'}
+											{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
 										{else}
 											{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
 										{/if}

--- a/layouts/v7/modules/PriceBooks/RelatedList.tpl
+++ b/layouts/v7/modules/PriceBooks/RelatedList.tpl
@@ -98,7 +98,7 @@
 											{/if}
 											{CurrencyField::appendCurrencySymbol($CURRENCY_VALUE, $CURRENCY_SYMBOL)}
 										{else if $HEADER_FIELD->getFieldDataType() eq 'text'}
-											{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+											{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}
 										{else}
 											{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
 										{/if}

--- a/layouts/v7/modules/Products/ProductsPopupContents.tpl
+++ b/layouts/v7/modules/Products/ProductsPopupContents.tpl
@@ -108,7 +108,7 @@
                                             <input type="text" value="{if $EDITED_VALUE}{$EDITED_VALUE}{else}{$ENTRY_VALUE}{/if}" data-rule-positiveExcludingZero=true data-rule-positive=true name="{$QTY_ELEMENT_NAME}" class="form-control quantityTextBox" />
                                         </div>
                                     {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
-                                        {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)|decode_html|strip_tags}
+                                        {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)|decode_html|strip_tags|escape:'html'}
                                     {else}
                                         {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/Products/ProductsPopupContents.tpl
+++ b/layouts/v7/modules/Products/ProductsPopupContents.tpl
@@ -80,7 +80,7 @@
                                 {assign var="ROW_NUMBER" value={$smarty.foreach.listViewEntry.index}}
                                 {assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER->get('name')}
                                 {assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-                                <td class="listViewEntryValue textOverflowEllipsis" title="{$RECORD_DATA[$LISTVIEW_HEADERNAME]|strip_tags}">
+                                <td class="listViewEntryValue textOverflowEllipsis" title="{$RECORD_DATA[$LISTVIEW_HEADERNAME]|decode_html|strip_tags|escape:'html'}">
                                     {if $LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4'}
                                         <a>{$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}</a>
                                     {else if $LISTVIEW_HEADER->get('uitype') eq '72'}
@@ -107,6 +107,8 @@
                                             {assign var="QTY_ELEMENT_NAME" value="quantity"|cat:{$COL_NUMBER}|cat:{$ROW_NUMBER}}
                                             <input type="text" value="{if $EDITED_VALUE}{$EDITED_VALUE}{else}{$ENTRY_VALUE}{/if}" data-rule-positiveExcludingZero=true data-rule-positive=true name="{$QTY_ELEMENT_NAME}" class="form-control quantityTextBox" />
                                         </div>
+                                    {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
+                                        {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)|decode_html|strip_tags}
                                     {else}
                                         {$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/RecycleBin/ListViewContents.tpl
+++ b/layouts/v7/modules/RecycleBin/ListViewContents.tpl
@@ -118,7 +118,7 @@
                                                         <span {if !empty($LISTVIEW_ENTRY_VALUE)} class="picklist-color picklist-{$LISTVIEW_HEADER->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen(trim($MULTI_PICKLIST_VALUE))}" {/if}> {trim($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX])} </span>
                                                     {/foreach}
                                                 {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
-                                                    {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
+                                                    {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags|escape:'html'}
                                                 {else}
                                                     {$LISTVIEW_ENTRY_VALUE}
                                                 {/if}

--- a/layouts/v7/modules/RecycleBin/ListViewContents.tpl
+++ b/layouts/v7/modules/RecycleBin/ListViewContents.tpl
@@ -117,6 +117,8 @@
                                                     {foreach item=MULTI_PICKLIST_VALUE key=MULTI_PICKLIST_INDEX from=$MULTI_RAW_PICKLIST_VALUES}
                                                         <span {if !empty($LISTVIEW_ENTRY_VALUE)} class="picklist-color picklist-{$LISTVIEW_HEADER->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen(trim($MULTI_PICKLIST_VALUE))}" {/if}> {trim($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX])} </span>
                                                     {/foreach}
+                                                {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
+                                                    {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
                                                 {else}
                                                     {$LISTVIEW_ENTRY_VALUE}
                                                 {/if}

--- a/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
@@ -24,7 +24,7 @@
 							{foreach item=NAME_FIELD from=$MODULE_MODEL->getNameFields()}
 								{assign var=FIELD_MODEL value=$MODULE_MODEL->getField($NAME_FIELD)}
 								{if $FIELD_MODEL->getPermissions()}
-									<span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags}</span>&nbsp;
+									<span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags|escape:'html'}</span>&nbsp;
 								{/if}
 							{/foreach}
 						</span>

--- a/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/Vtiger/DetailViewHeaderTitle.tpl
@@ -20,11 +20,11 @@
 			<div class="recordBasicInfo">
 				<div class="info-row">
 					<h4>
-						<span class="recordLabel pushDown" title="{$RECORD->getName()}">
+						<span class="recordLabel pushDown" title="{$RECORD->getName()|decode_html|strip_tags|escape:'html'}">
 							{foreach item=NAME_FIELD from=$MODULE_MODEL->getNameFields()}
 								{assign var=FIELD_MODEL value=$MODULE_MODEL->getField($NAME_FIELD)}
 								{if $FIELD_MODEL->getPermissions()}
-									<span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)}</span>&nbsp;
+									<span class="{$NAME_FIELD}">{$RECORD->get($NAME_FIELD)|decode_html|strip_tags}</span>&nbsp;
 								{/if}
 							{/foreach}
 						</span>

--- a/layouts/v7/modules/Vtiger/EditView.tpl
+++ b/layouts/v7/modules/Vtiger/EditView.tpl
@@ -22,7 +22,7 @@
 							<div class="col-lg-12 col-md-12 col-lg-pull-0">
 								{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 								{if $RECORD_ID neq ''}
-									<h4 class="editHeader" style="margin-top:5px;" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags|escape:'html'}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags}</h4>
+									<h4 class="editHeader" style="margin-top:5px;" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags|escape:'html'}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags|escape:'html'}</h4>
 								{else}
 									<h4 class="editHeader" style="margin-top:5px;">{vtranslate('LBL_CREATING_NEW', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)}</h4>
 								{/if}

--- a/layouts/v7/modules/Vtiger/EditView.tpl
+++ b/layouts/v7/modules/Vtiger/EditView.tpl
@@ -22,7 +22,7 @@
 							<div class="col-lg-12 col-md-12 col-lg-pull-0">
 								{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 								{if $RECORD_ID neq ''}
-									<h4 class="editHeader" style="margin-top:5px;" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD_STRUCTURE_MODEL->getRecordName()}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD_STRUCTURE_MODEL->getRecordName()}</h4>
+									<h4 class="editHeader" style="margin-top:5px;" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags|escape:'html'}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD_STRUCTURE_MODEL->getRecordName()|decode_html|strip_tags}</h4>
 								{else}
 									<h4 class="editHeader" style="margin-top:5px;">{vtranslate('LBL_CREATING_NEW', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)}</h4>
 								{/if}

--- a/layouts/v7/modules/Vtiger/EmailRelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/EmailRelatedList.tpl
@@ -111,7 +111,7 @@
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'owner'}
                                         {getOwnerName($RELATED_RECORD->get($RELATED_HEADERNAME))}
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'text'}
-                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}
                                     {else}
                                         {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/Vtiger/EmailRelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/EmailRelatedList.tpl
@@ -110,6 +110,8 @@
                                         {/if}
                                     {else if $HEADER_FIELD->getFieldDataType() eq 'owner'}
                                         {getOwnerName($RELATED_RECORD->get($RELATED_HEADERNAME))}
+                                    {else if $HEADER_FIELD->getFieldDataType() eq 'text'}
+                                        {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
                                     {else}
                                         {$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
                                     {/if}

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -160,7 +160,7 @@
 							{assign var=LISTVIEW_ENTRY_RAWVALUE value=$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
 						{/if}
 						{assign var=LISTVIEW_ENTRY_VALUE value=$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}
-						<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)|strip_tags}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
+						<td class="listViewEntryValue" data-name="{$LISTVIEW_HEADER->get('name')}" title="{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)|decode_html|strip_tags|escape:'html'}" data-rawvalue="{$LISTVIEW_ENTRY_RAWVALUE}" data-field-type="{$LISTVIEW_HEADER->getFieldDataType()}">
 							<span class="fieldValue">
 								<span class="value">
 									{if ($LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4') and $MODULE_MODEL->isListViewNameFieldNavigationEnabled() eq true }
@@ -217,6 +217,8 @@
 											{/foreach}
 										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'reference'}
 											{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
+										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
+											{$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
 										{else if $LISTVIEW_HEADER->get('uitype') eq '360'}
 										{else}
 											{vtranslate($LISTVIEW_ENTRY_VALUE, $MODULE)}

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -218,7 +218,7 @@
 										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'reference'}
 											{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
 										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
-											{$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
+											{$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags|escape:'html'}
 										{else if $LISTVIEW_HEADER->get('uitype') eq '360'}
 										{else}
 											{vtranslate($LISTVIEW_ENTRY_VALUE, $MODULE)}

--- a/layouts/v7/modules/Vtiger/ModuleHeader.tpl
+++ b/layouts/v7/modules/Vtiger/ModuleHeader.tpl
@@ -40,12 +40,12 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')} &nbsp;&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags} &nbsp;&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;&nbsp;</a></p>
 				{/if}
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')}">&nbsp;&nbsp;{$RECORD->get('label')} &nbsp;&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{$RECORD->get('label')|decode_html|strip_tags} &nbsp;&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-lg-5 col-md-6 col-sm-7 col-xs-1 padding0 pull-right">

--- a/layouts/v7/modules/Vtiger/ModuleHeader.tpl
+++ b/layouts/v7/modules/Vtiger/ModuleHeader.tpl
@@ -40,12 +40,12 @@
 				{/if}
 				{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 				{if $RECORD and $REQ.view eq 'Edit'}
-					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags} &nbsp;&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('label')|decode_html|strip_tags|escape:'html'} &nbsp;&nbsp;</a></p>
 				{else if $REQ.view eq 'Edit'}
 					<p class="current-filter-name filter-name pull-left "><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a>&nbsp;&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;&nbsp;</a></p>
 				{/if}
 				{if $REQ.view eq 'Detail'}
-					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{$RECORD->get('label')|decode_html|strip_tags} &nbsp;&nbsp;</a></p>
+					<p class="current-filter-name filter-name pull-left"><span class="fa fa-angle-right pull-left" aria-hidden="true"></span><a title="{$RECORD->get('label')|decode_html|strip_tags|escape:'html'}">&nbsp;&nbsp;{$RECORD->get('label')|decode_html|strip_tags|escape:'html'} &nbsp;&nbsp;</a></p>
 				{/if}
 			</div>
 			<div class="col-lg-5 col-md-6 col-sm-7 col-xs-1 padding0 pull-right">

--- a/layouts/v7/modules/Vtiger/PopupContents.tpl
+++ b/layouts/v7/modules/Vtiger/PopupContents.tpl
@@ -98,7 +98,7 @@
                     {if isset($RECORD_DATA[$LISTVIEW_HEADERNAME])}
                         {assign var=RECORD_DATA_LISTVIEW_HEADERNAME value=$RECORD_DATA[$LISTVIEW_HEADERNAME]}
                     {/if}
-                    <td class="listViewEntryValue value textOverflowEllipsis {$WIDTHTYPE}" title="{$RECORD_DATA_LISTVIEW_HEADERNAME}">
+                    <td class="listViewEntryValue value textOverflowEllipsis {$WIDTHTYPE}" title="{$RECORD_DATA_LISTVIEW_HEADERNAME|decode_html|strip_tags|escape:'html'}">
                         {if $LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4'}
                             <a>{$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}</a>
                         {else if $LISTVIEW_HEADER->get('uitype') eq '72'}
@@ -118,6 +118,8 @@
                             {foreach item=MULTI_PICKLIST_VALUE key=MULTI_PICKLIST_INDEX from=$MULTI_RAW_PICKLIST_VALUES}
                                 <span {if !empty($LISTVIEW_ENTRY_VALUE)} class="picklist-color picklist-{$LISTVIEW_HEADER->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen(trim($MULTI_PICKLIST_VALUE))}" {/if}> {trim($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX])} </span>
                             {/foreach}
+                        {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
+                            {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
                         {else}
                             {vtranslate($LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME), $MODULE)}
                         {/if}

--- a/layouts/v7/modules/Vtiger/PopupContents.tpl
+++ b/layouts/v7/modules/Vtiger/PopupContents.tpl
@@ -119,7 +119,7 @@
                                 <span {if !empty($LISTVIEW_ENTRY_VALUE)} class="picklist-color picklist-{$LISTVIEW_HEADER->getId()}-{Vtiger_Util_Helper::convertSpaceToHyphen(trim($MULTI_PICKLIST_VALUE))}" {/if}> {trim($MULTI_PICKLIST_VALUES[$MULTI_PICKLIST_INDEX])} </span>
                             {/foreach}
                         {else if $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
-                            {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags}
+                            {$LISTVIEW_ENTRY_VALUE|decode_html|strip_tags|escape:'html'}
                         {else}
                             {vtranslate($LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME), $MODULE)}
                         {/if}

--- a/layouts/v7/modules/Vtiger/RelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedList.tpl
@@ -188,7 +188,7 @@
 												{if $RELATED_RECORD->get('visibility') == vtranslate('Private', $MODULE ) && $OWNER_ID != $CURRENT_USER_ID && !$CURRENT_USER_MODEL->isAdminUser()}
 													{else}
 														{if $HEADER_FIELD->getFieldDataType() eq 'text'}
-															{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+															{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}
 														{else}
 															{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
 															{* Documents list view special actions "view file" and "download file" *}

--- a/layouts/v7/modules/Vtiger/RelatedList.tpl
+++ b/layouts/v7/modules/Vtiger/RelatedList.tpl
@@ -131,7 +131,7 @@
 							{foreach item=HEADER_FIELD from=$RELATED_HEADERS}
 								{assign var=RELATED_HEADERNAME value=$HEADER_FIELD->get('name')}
 								{assign var=RELATED_LIST_VALUE value=$RELATED_RECORD->get($RELATED_HEADERNAME)}
-								<td class="relatedListEntryValues" title="{strip_tags($RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME))}" data-field-type="{$HEADER_FIELD->getFieldDataType()}" nowrap>
+								<td class="relatedListEntryValues" title="{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags|escape:'html'}" data-field-type="{$HEADER_FIELD->getFieldDataType()}" nowrap>
 									<span class="value textOverflowEllipsis">
 										{if $RELATED_MODULE_NAME eq 'Documents' && $RELATED_HEADERNAME eq 'document_source'}
 											<center>{$RELATED_RECORD->get($RELATED_HEADERNAME)}</center>
@@ -187,19 +187,23 @@
 											{else}
 												{if $RELATED_RECORD->get('visibility') == vtranslate('Private', $MODULE ) && $OWNER_ID != $CURRENT_USER_ID && !$CURRENT_USER_MODEL->isAdminUser()}
 													{else}
-														{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
-														{* Documents list view special actions "view file" and "download file" *}
-														{if $RELATED_MODULE_NAME eq 'Documents' && $RELATED_HEADERNAME eq 'filename' && isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId()) eq 'yes'}
-															<span class="actionImages">
-																{assign var=RECORD_ID value=$RELATED_RECORD->getId()}
-																{assign var="DOCUMENT_RECORD_MODEL" value=Vtiger_Record_Model::getInstanceById($RECORD_ID)}
-																{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus')}
-																	<a name="viewfile" href="javascript:void(0)" data-filelocationtype="{$DOCUMENT_RECORD_MODEL->get('filelocationtype')}" data-filename="{$DOCUMENT_RECORD_MODEL->get('filename')}" onclick="Vtiger_Header_Js.previewFile(event)"><i title="{vtranslate('LBL_VIEW_FILE', $RELATED_MODULE_NAME)}" class="icon-picture alignMiddle"></i></a>&nbsp;
-																	{/if}
-																	{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus') && $DOCUMENT_RECORD_MODEL->get('filelocationtype') eq 'I'}
-																	<a name="downloadfile" href="{$DOCUMENT_RECORD_MODEL->getDownloadFileURL()}"><i title="{vtranslate('LBL_DOWNLOAD_FILE', $RELATED_MODULE_NAME)}" class="icon-download-alt alignMiddle"></i></a>&nbsp;
-																	{/if}
-															</span>
+														{if $HEADER_FIELD->getFieldDataType() eq 'text'}
+															{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)|decode_html|strip_tags}
+														{else}
+															{$RELATED_RECORD->getDisplayValue($RELATED_HEADERNAME)}
+															{* Documents list view special actions "view file" and "download file" *}
+															{if $RELATED_MODULE_NAME eq 'Documents' && $RELATED_HEADERNAME eq 'filename' && isPermitted($RELATED_MODULE_NAME, 'DetailView', $RELATED_RECORD->getId()) eq 'yes'}
+																<span class="actionImages">
+																	{assign var=RECORD_ID value=$RELATED_RECORD->getId()}
+																	{assign var="DOCUMENT_RECORD_MODEL" value=Vtiger_Record_Model::getInstanceById($RECORD_ID)}
+																	{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus')}
+																		<a name="viewfile" href="javascript:void(0)" data-filelocationtype="{$DOCUMENT_RECORD_MODEL->get('filelocationtype')}" data-filename="{$DOCUMENT_RECORD_MODEL->get('filename')}" onclick="Vtiger_Header_Js.previewFile(event)"><i title="{vtranslate('LBL_VIEW_FILE', $RELATED_MODULE_NAME)}" class="icon-picture alignMiddle"></i></a>&nbsp;
+																		{/if}
+																		{if $DOCUMENT_RECORD_MODEL->get('filename') && $DOCUMENT_RECORD_MODEL->get('filestatus') && $DOCUMENT_RECORD_MODEL->get('filelocationtype') eq 'I'}
+																		<a name="downloadfile" href="{$DOCUMENT_RECORD_MODEL->getDownloadFileURL()}"><i title="{vtranslate('LBL_DOWNLOAD_FILE', $RELATED_MODULE_NAME)}" class="icon-download-alt alignMiddle"></i></a>&nbsp;
+																		{/if}
+																</span>
+															{/if}
 														{/if}
 												{/if}
 											{/if}

--- a/layouts/v7/modules/Vtiger/uitypes/StringDetailView.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/StringDetailView.tpl
@@ -42,5 +42,9 @@
 {else if  $FIELD_MODEL->get('name') eq 'signature'}
 	{decode_html($FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD))}
 {else}
-    {$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD)}
+    {if $FIELD_MODEL->getFieldDataType() eq 'text'}
+        {$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD, true)}
+    {else}
+        {$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD)}
+    {/if}
 {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/StringDetailView.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/StringDetailView.tpl
@@ -43,7 +43,7 @@
 	{decode_html($FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD))}
 {else}
     {if $FIELD_MODEL->getFieldDataType() eq 'text'}
-        {$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD, true)}
+        {$FIELD_MODEL->getUITypeModel()->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD, true)}
     {else}
         {$FIELD_MODEL->getDisplayValue($FIELD_MODEL->get('fieldvalue'), $RECORD->getId(), $RECORD)}
     {/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1510 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.HTMLタグが含まれる可能性があるテキストの表示の際にHTMLタグを含んだ状態で文字数制限などによりタグが画面上に表示される
2.title属性にHTMLエスケープが適用されておらず、値に`"`が含まれる場合にHTML属性が壊れる可能性がある


##  原因 / Cause
<!-- バグの原因を記述 -->
1.一覧・関連リスト・詳細画面において、text型フィールドの出力時にHTMLサニタイズが行われていなかった
2.title属性の出力時に`escape:'html'`によるHTMLエスケープが行われていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.各テンプレートのtitle属性に`decode_html|strip_tags|escape:'html'`を追加
2.一覧・関連リスト・ポップアップのtext型フィールドに`decode_html|strip_tags`を追加してプレーンテキストで表示
3.詳細画面（StringDetailView.tpl）のtext型フィールドに`$removeTags=true`を渡してHTMLタグを除去

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
一覧画面・関連リスト・ポップアップ・詳細画面のtext型フィールドの表示
title属性を持つ全画面のレコード名表示部分

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->