### PR TITLE
空文字から半角0への変更が更新履歴に表示されない問題を修正 

### DIFF
--- a/data/VTEntityDelta.php
+++ b/data/VTEntityDelta.php
@@ -71,8 +71,8 @@ class VTEntityDelta extends VTEventHandler {
 		/** Detect field value changes **/
 		foreach($newData as $fieldName => $fieldValue) {
 			$isModified = false;
-			if(empty($oldData[$fieldName])) {
-				if(!empty($newData[$fieldName])) {
+			if(!isset($oldData[$fieldName]) || $oldData[$fieldName] === '' || $oldData[$fieldName] === null) {
+				if(isset($newData[$fieldName]) && $newData[$fieldName] !== '' && $newData[$fieldName] !== null) {
 					$isModified = true;
 				}
 			} elseif(str_replace(array("\r\n","\r","\n"), "", $oldData[$fieldName]) != str_replace(array("\r\n","\r","\n"), "", $newData[$fieldName])) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #151 

##  不具合の内容 / Bug
1. 空文字から半角0への変更が更新履歴に表示されない

##  原因 / Cause
1. PHPのempty()関数が半角"0"を空値として判定するため、空文字から"0"への変更が差分なしと処理され、更新履歴に表示されなかった。      

##  変更内容 / Details of Change
  1. data/VTEntityDelta.phpのcomputeDelta()メソッドにて、empty()をisset()および厳密比較(===)に置き換え、"0"が正しく値として認識されるよう修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="316" height="80" alt="image" src="https://github.com/user-attachments/assets/23ccbe60-e699-4bf7-9f90-eda63249267d" />

<img width="656" height="230" alt="image" src="https://github.com/user-attachments/assets/e0cb18df-50f8-465b-8d4e-c40e15ef3ef1" />

## 影響範囲  / Affected Area
  - 全モジュールのレコード更新履歴（変更差分検出処理）                                                                                                                                                                                                                                                   
  - "0"、0、falseなどempty()が真と判定する値への変更が、正しく履歴に記録されるようになる

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った
