### PR TITLE
詳細画面で複数選択項目の値を消える 

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1397,6 +1397,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 							}
 							fieldBasicData.data('displayvalue',postSaveRecordDetails[fieldName].display_value);
 							fieldBasicData.data('value',postSaveRecordDetails[fieldName].value);
+							fieldBasicData.attr('data-value',postSaveRecordDetails[fieldName].value);
 							jQuery(currentTdElement).find('.input-group-addon').removeClass("disabled");
 
 							detailViewValue.css('display', 'inline-block');

--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1506,7 +1506,6 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			var fieldBasicData = editElement.find('.fieldBasicData');
 			var inputElement = editElement.find('.inputElement');
 			inputElement.attr('data-value', fieldBasicData.attr('data-value'));
-			inputElement.data('value', fieldBasicData.data('value'));
 			var fieldType = fieldBasicData.data('type');
 			var dataValue = inputElement.attr('data-value');
 			if (fieldType === 'multipicklist') {

--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1506,7 +1506,13 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			var inputElement = editElement.find('.inputElement');
 			inputElement.attr('data-value', fieldBasicData.attr('data-value'));
 			inputElement.data('value', fieldBasicData.data('value'));
-			inputElement.val(inputElement.attr('data-value'));
+			var fieldType = fieldBasicData.data('type');
+			var dataValue = inputElement.attr('data-value');
+			if (fieldType === 'multipicklist') {
+				inputElement.val(dataValue ? dataValue.split(' |##| ') : []);
+			} else {
+				inputElement.val(dataValue);
+			}
 			detailViewValue.css('display', 'inline-block');
 			editElement.addClass('hide');
 			editElement.find('.inputElement').trigger('Vtiger.Validation.Hide.Messsage')


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1517                                      
##  不具合の内容 / Bug
 1. 詳細画面のインライン編集で複数選択項目(multipicklist)の値を変更してキャンセルすると、選択値が空になる                                                                                                                                                                                               
  2. 詳細画面のインライン編集でpicklist/multipicklistの値を保存後、別の値に変更してキャンセルすると、保存した値ではなく初期値が表示される
  3.  picklistを繰り返し編集→cancelすると空になる
##  原因 / Cause
 1. Cancel時にinputElement.val()で文字列"A |##| B"をそのまま<select multiple>に渡していたが、
 　jQueryの.val()は<select multiple>に対して配列【inputElement.attr('data-value')】を期待するため、該当するoptionが見つからず空になっていた。
 　                                                                                                   
  2. AJAX保存成功後、fieldBasicData.data('value')(jQuery内部キャッシュ)のみ更新し、fieldBasicData.attr('data-value')(DOM属性)を更新していなかった。Cancel時は.attr('data-value')からDOM属性を読み取るため、保存前の古い値が復元されていた

  3.  cancel時のinputElement.data('value', ...)がjQueryキャッシュにvalueを書き込む → 再編集時にshowSelect2ElementViewがselectElement.data()で全キャッシュ（Select2内部状態含む）を読み取り、Select2初期化パラメータに混入 → 繰り返すと状態が汚染されSelect2が空になる   
##  変更内容 / Details of Change
 1. Cancel復元ロジック(Detail.js:1509-1515)でfieldTypeを判定し、multipicklistの場合は|##|区切りで分割した配列を.val()に渡すよう修正                                                                                                                                                                     
  2. AJAX保存成功後(Detail.js:1400)にfieldBasicData.attr('data-value')もDOMに同期するよう追加
  3. inputElement.data('value', ...)を削除。cancel復元には.attr('data-value') + .val()のみで十分


## 影響範囲  / Affected Area
詳細画面のインライン編集におけるpicklist、multipicklistフィールドのキャンセル操作       
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った