### PR TITLE
fix/226-役割作成機能内の日本語訳漏れ 

### DIFF
--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -1526,7 +1526,6 @@ $languageStrings = array(
 	'Profile Related to Sales' => 'Sales Profile',
 	'Profile Related to Support' => 'Support Profile',
 	'Guest Profile for Test Users' => 'Guest Profile for Test Users',
-	'管理者' => 'Administrator',
 	// User Management > Login History
 	'Signed in' => 'Signed In',
 	'Signed off' => 'Signed Off',

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -1518,10 +1518,15 @@ $languageStrings = array(
 	'UserId ' => 'User ID',
 	'ConvertLead' => 'Convert Lead',
 	// Profile Details
+	'Administrator' => 'Administrator',
+	'Sales Profile' => 'Sales Profile',
+	'Support Profile' => 'Support Profile',
+	'Guest Profile' => 'Guest Profile',
 	'Admin Profile' => 'Admin Profile',
 	'Profile Related to Sales' => 'Sales Profile',
 	'Profile Related to Support' => 'Support Profile',
 	'Guest Profile for Test Users' => 'Guest Profile for Test Users',
+	'管理者' => 'Administrator',
 	// User Management > Login History
 	'Signed in' => 'Signed In',
 	'Signed off' => 'Signed Off',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1523,6 +1523,10 @@ $languageStrings = array(
 	'UserId ' => 'ユーザーID',
 	'ConvertLead' => 'リード変換',
 	//プロファイル詳細内容
+	'Administrator' => '管理者',
+	'Sales Profile' => 'セールス',
+	'Support Profile' => 'サポート',
+	'Guest Profile' => 'ゲスト',
 	'Admin Profile' => '管理者のプロファイル',
 	'Profile Related to Sales' => 'セールスに関するプロファイル',
 	'Profile Related to Support' => 'サポートに関するプロファイル',

--- a/layouts/v7/modules/Settings/Profiles/DetailView.tpl
+++ b/layouts/v7/modules/Settings/Profiles/DetailView.tpl
@@ -30,13 +30,13 @@
 						<div class="col-lg-2 col-md-2 col-sm-2 control-label fieldLabel">
 							<label>{vtranslate('LBL_PROFILE_NAME', $QUALIFIED_MODULE)}</label>
 						</div>
-						<div class="fieldValue col-lg-6 col-md-6 col-sm-12"  name="profilename" id="profilename" value="{$RECORD_MODEL->getName()}"><strong>{$RECORD_MODEL->getName()}</strong></div>
+						<div class="fieldValue col-lg-6 col-md-6 col-sm-12"  name="profilename" id="profilename" value="{$RECORD_MODEL->getName()}"><strong>{vtranslate($RECORD_MODEL->getName(), $QUALIFIED_MODULE)}</strong></div>					
 					</div>
 					<div class="row form-group">
 						<div class="col-lg-2 col-md-2 col-sm-2 control-label fieldLabel">
 							<label>{vtranslate('LBL_DESCRIPTION', $QUALIFIED_MODULE)}:</label>
 						</div>
-						<div class="fieldValue col-lg-6 col-md-6 col-sm-12" name="description" id="description"><strong>{$RECORD_MODEL->getDescription()}</strong></div>
+						<div class="fieldValue col-lg-6 col-md-6 col-sm-12" name="description" id="description"><strong>{vtranslate($RECORD_MODEL->getDescription(), $QUALIFIED_MODULE)}</strong></div>
 					</div>
 					<br>
 					{assign var="ENABLE_IMAGE_PATH" value="{vimage_path('Enable.png')}"}

--- a/layouts/v7/modules/Settings/Profiles/EditView.tpl
+++ b/layouts/v7/modules/Settings/Profiles/EditView.tpl
@@ -43,7 +43,7 @@
 									<strong>{vtranslate('LBL_PROFILE_NAME', $QUALIFIED_MODULE)}</strong>&nbsp;<span class="redColor">*</span>:&nbsp;
 								</label></div>
 							<div class="fieldValue col-lg-6 col-md-6 col-sm-6" > 
-								<input type="text" class="inputElement" name="profilename" id="profilename" value="{$RECORD_MODEL->getName()}" data-rule-required="true" />
+								<input type="text" class="inputElement" name="profilename" id="profilename" value="{vtranslate($RECORD_MODEL->getName(), $QUALIFIED_MODULE)}" data-rule-required="true" />
 							</div>
 						</div>
 
@@ -52,7 +52,7 @@
 									<strong>{vtranslate('LBL_DESCRIPTION', $QUALIFIED_MODULE)}&nbsp;:&nbsp;</strong>
 								</label></div>
 							<div class="fieldValue col-lg-6 col-md-6 col-sm-6">
-								<textarea name="description" class="inputElement" id="description" style="height:50px; resize: vertical;padding:5px 8px;">{$RECORD_MODEL->getDescription()}</textarea>
+								<textarea name="description" class="inputElement" id="description" style="height:50px; resize: vertical;padding:5px 8px;">{vtranslate($RECORD_MODEL->getDescription(), $QUALIFIED_MODULE)}</textarea>
 							</div>
 						</div>
 						{include file='EditViewContents.tpl'|vtemplate_path:$QUALIFIED_MODULE}

--- a/layouts/v7/modules/Settings/Profiles/EditViewContents.tpl
+++ b/layouts/v7/modules/Settings/Profiles/EditViewContents.tpl
@@ -21,7 +21,7 @@
 				<option></option>
 				{foreach from=$ALL_PROFILES item=PROFILE}
 					{if $PROFILE->isDirectlyRelated() eq false}
-						<option value="{$PROFILE->getId()}" {if $RECORD_ID eq $PROFILE->getId()} selected="" {/if} >{$PROFILE->getName()}</option>
+						<option value="{$PROFILE->getId()}" {if $RECORD_ID eq $PROFILE->getId()} selected="" {/if} >{vtranslate($PROFILE->getName(), $QUALIFIED_MODULE)}</option>					
 					{/if}
 				{/foreach}
 			</select>

--- a/layouts/v7/modules/Settings/Roles/EditView.tpl
+++ b/layouts/v7/modules/Settings/Roles/EditView.tpl
@@ -106,7 +106,7 @@
                                 <select class="select2 inputElement col-lg-12 hide" multiple="true" id="profilesList" name="profiles[]" data-placeholder="{vtranslate('LBL_CHOOSE_PROFILES',$QUALIFIED_MODULE)}" style="width: 460px" data-rule-required="true">
                                     {foreach from=$ALL_PROFILES item=PROFILE}
                                         {if $PROFILE->isDirectlyRelated() eq false}
-                                            <option value="{$PROFILE->getId()}" {if isset($ROLE_PROFILES[$PROFILE->getId()])}selected="true"{/if}>{$PROFILE->getName()}</option>
+                                            <option value="{$PROFILE->getId()}" {if isset($ROLE_PROFILES[$PROFILE->getId()])}selected="true"{/if}>{vtranslate($PROFILE->getName(), $QUALIFIED_MODULE)}</option>
                                         {/if}
                                     {/foreach}
                                 </select>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #226 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
「ホーム > ユーザー管理  > 役割（Roles）> 役割の追加（作成） > ”権限をコピーしてくる”の”プロファイルの選択”プルダウン」において日本語訳漏れがある。ほかにも、プロファイル名、役割名、説明などにおいて日本語訳漏れが起きていた。


##  原因 / Cause
<!-- バグの原因を記述 -->
1. tplファイルにおいてデータベースから取得したプロファイル名や説明を翻訳関数（vtranslate）を通さずに直接出力していた。
2. 日本語翻訳ファイル（ja_jp）および英語翻訳ファイル（en_us）に、初期設定のプロファイル名（"Administrator"など）や役割名（"管理者"など）の翻訳キーと値が定義されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 以下のファイルにおいて、プロファイル名や説明を直接出力していた箇所を vtranslate()関数を使用するように変更。
   * `layouts/v7/modules/Settings/Profiles/DetailView.tpl`: プロファイル詳細画面での名称と説明
   * `layouts/v7/modules/Settings/Profiles/EditViewContents.tpl`:プロファイル編集画面（複製元選択など）での名称
   * `layouts/v7/modules/Settings/Roles/EditView.tpl`: 役割作成・編集画面でのプロファイル選択肢  
2.  日本語設定 (`languages/ja_jp/Vtiger.php`):
      Administrator → 管理者、Sales Profile → セールス などの不足していた翻訳定義を追加。
3.  英語設定 (`languages/en_us/Vtiger.php`):
      DBに直接書き込まれている日本語データへの対策として、日本語から英語という逆引き定義を追加。これにより、英語環境でも一貫して英語が表示されるよう担保

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="586" height="169" alt="image" src="https://github.com/user-attachments/assets/f3a66382-9576-4358-837a-e7821f9510b9" />
<img width="908" height="159" alt="image" src="https://github.com/user-attachments/assets/e36920a2-a341-4391-96a2-93f7100390fb" />

<img width="873" height="508" alt="image" src="https://github.com/user-attachments/assets/b06e0f5d-ab55-416a-a190-8f9ecb4ada22" />
<img width="960" height="518" alt="image" src="https://github.com/user-attachments/assets/e96ec923-2c31-4d21-a5e2-1e670b94a2a1" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
英語表示に戻した際、HOME > User Management > Roles の「管理者」だけが日本語のまま表示される事象を確認した。
<img width="375" height="245" alt="image" src="https://github.com/user-attachments/assets/03bbd849-dd60-49f3-b711-726e9a0496a3" />

                                                                                                                                                      
原因は翻訳ファイルではなく、DB の `vtiger_role.rolename` に管理者ロールが日本語で保存されているため。        
<img width="1294" height="319" alt="スクリーンショット (3)" src="https://github.com/user-attachments/assets/6eb96ee6-a64c-416c-b0da-44bd614aca71" />

そのため、 英語設定ファイル languages/en_us/Vtiger.php に、DB に直接書き込まれている日本語データを英語表示へ戻すための逆引き定義を追加した。   

