### PR TITLE
fix/1119-リストからタグの選択を解除できない

### DIFF
--- a/layouts/v7/modules/Vtiger/Tag.tpl
+++ b/layouts/v7/modules/Vtiger/Tag.tpl
@@ -8,7 +8,7 @@
  ************************************************************************************}
  
  <span class="tag {if $ACTIVE eq true} active {/if}" title="{$TAG_MODEL->getName()}" data-type="{$TAG_MODEL->getType()}" data-id="{$TAG_MODEL->getId()}">
-    <i class="activeToggleIcon fa {if $ACTIVE eq true} fa-circle-o {else} fa-circle {/if}"></i>
+    <i class="activeToggleIcon fa {if $ACTIVE eq true} fa-circle {else} fa-circle-o {/if}"></i>
     <span class="tagLabel display-inline-block textOverflowEllipsis" title="{$TAG_MODEL->getName()}">{$TAG_MODEL->getName()}</span>
     <input type="hidden" class="tagOwner" value="{getOwnerName($TAG_MODEL->get('owner'))}">
     {if !$NO_EDIT}

--- a/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
+++ b/layouts/v7/modules/Vtiger/partials/SidebarEssentials.tpl
@@ -140,6 +140,7 @@
                     <div id="listViewTagContainer" class="multiLevelTagList" 
                         {if $ALL_CUSTOMVIEW_MODEL} data-view-id="{$ALL_CUSTOMVIEW_MODEL->getId()}" {/if}
                         data-list-tag-count="{Vtiger_Tag_Model::NUM_OF_TAGS_LIST}">
+                        {assign var=CURRENT_TAGS value=explode(',', $CURRENT_TAG)}
                         {foreach item=TAG_MODEL from=$TAGS name=tagCounter}
                             {assign var=TAG_LABEL value=$TAG_MODEL->getName()}
                             {assign var=TAG_ID value=$TAG_MODEL->getId()}
@@ -147,7 +148,7 @@
                             {if $smarty.foreach.tagCounter.iteration gt Vtiger_Tag_Model::NUM_OF_TAGS_LIST}
                                 {break}
                             {/if}
-                            {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE= $CURRENT_TAG eq $TAG_ID}
+                            {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE=in_array($TAG_ID, $CURRENT_TAGS)}
                         {/foreach}
                         <div> 
                             <a class="moreTags {if (php7_count($TAGS) - Vtiger_Tag_Model::NUM_OF_TAGS_LIST) le 0} hide {/if}">
@@ -159,7 +160,8 @@
                                     {if $smarty.foreach.tagCounter.iteration le Vtiger_Tag_Model::NUM_OF_TAGS_LIST}
                                         {continue}
                                     {/if}
-                                    {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE= $CURRENT_TAG eq $TAG_ID}
+                                    {assign var=TAG_ID value=$TAG_MODEL->getId()}
+                                    {include file="Tag.tpl"|vtemplate_path:$MODULE NO_DELETE=true ACTIVE=in_array($TAG_ID, $CURRENT_TAGS)}
                                 {/foreach}
                             </div>
                         </div>

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -309,6 +309,15 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$tagParams = array();
 		}
 
+		if (empty($tagParams) && !empty($tag)) {
+			$tagIds = explode(',', $tag);
+			$tagParams = array(
+				array(
+					array('tags', 'e', $tagIds)
+				)
+			);
+		}
+
 		$searchAndTagParams = array_merge($searchParams, $tagParams);
 
 		$transformedSearchParams = $this->transferListSearchParamsToFilterCondition($searchAndTagParams, $listViewModel->getModule());
@@ -490,11 +499,21 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		$searchKey = $request->get('search_key');
 		$searchValue = $request->get('search_value');
 		$tagParams = $request->get('tag_params');
+		$tag = $request->get('tag');
 
 		$listViewModel = Vtiger_ListView_Model::getInstance($moduleName, $cvId);
 
 		if(empty($tagParams)){
 			$tagParams = array();
+		}
+
+		if (empty($tagParams) && !empty($tag)) {
+			$tagIds = explode(',', $tag);
+			$tagParams = array(
+				array(
+					array('tags', 'e', $tagIds)
+				)
+			);
 		}
 
 		$searchParams = $request->get('search_params');

--- a/public/layouts/v7/modules/Documents/resources/List.js
+++ b/public/layouts/v7/modules/Documents/resources/List.js
@@ -130,7 +130,7 @@ Vtiger_List_Js("Documents_List_Js", {
     
     unMarkAllTags : function() {
         var container = jQuery('#listViewTagContainer');
-        container.find('.tag').removeClass('active').find('i.activeToggleIcon').removeClass('fa-circle-o').addClass('fa-circle');
+        container.find('.tag').removeClass('active').find('i.activeToggleIcon').removeClass('fa-circle').addClass('fa-circle-o');
     },
     
     unMarkAllFolders : function() {

--- a/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
+++ b/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
@@ -239,39 +239,45 @@ Vtiger.Class('Vtiger_ListSidebar_Js',{},{
                 return;
             }
             var element = jQuery(e.currentTarget);
-            var isAlreadyActive = element.hasClass('active');
-            
             var tagId = element.data('id');
             var viewId = container.data('viewId');
             
             self.unMarkAllFilters();
-            self.unMarkAllTags();
             
-            if (isAlreadyActive) {
-                var params = {
-                    'tag' : '',
-                    'tag_params' : '',
-                    'search_params' : '',
-                    'page' : ''
-                };
-                self.loadListView(viewId, params);
-                return;
+            element.toggleClass('active');
+            if (element.hasClass('active')) {
+                element.find('i.activeToggleIcon').removeClass('fa-circle-o').addClass('fa-circle');
+            } else {
+                element.find('i.activeToggleIcon').removeClass('fa-circle').addClass('fa-circle-o');
             }
 
-            element.addClass('active');
-            element.find('i.activeToggleIcon').removeClass('fa-circle-o').addClass('fa-circle');
-            var listSearchParams = new Array();
-            listSearchParams[0] = new Array();
-            var tagSearchParams = new Array();
-            tagSearchParams.push('tags');
-            tagSearchParams.push('e');
-            tagSearchParams.push(tagId);
-            listSearchParams[0].push(tagSearchParams);
-            var params = {};
-            params.search_params = ''; 
-            params.tag_params = JSON.stringify(listSearchParams);
-            params.tag = tagId;
-            params.page = '';
+            var activeTags = container.find('.tag.active');
+            var tagIds = [];
+            activeTags.each(function() {
+                tagIds.push(jQuery(this).data('id'));
+            });
+
+            var params = {
+                'search_params' : '',
+                'page' : ''
+            };
+
+            if (tagIds.length > 0) {
+                var listSearchParams = new Array();
+                listSearchParams[0] = new Array();
+                var tagSearchParams = new Array();
+                tagSearchParams.push('tags');
+                tagSearchParams.push('e');
+                tagSearchParams.push(tagIds);
+                listSearchParams[0].push(tagSearchParams);
+                
+                params.tag_params = JSON.stringify(listSearchParams);
+                params.tag = tagIds.join(',');
+            } else {
+                params.tag = '';
+                params.tag_params = '';
+            }
+            
             self.loadListView(viewId, params);
         });
         

--- a/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
+++ b/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
@@ -152,7 +152,7 @@ Vtiger.Class('Vtiger_ListSidebar_Js',{},{
     
     unMarkAllTags : function() {
         var container = jQuery('#listViewTagContainer');
-        container.find('.tag').removeClass('active').find('i.activeToggleIcon').removeClass('fa-circle-o').addClass('fa-circle');
+        container.find('.tag').removeClass('active').find('i.activeToggleIcon').removeClass('fa-circle').addClass('fa-circle-o');
     },
     
     registerPopOverContent: function () {
@@ -259,7 +259,7 @@ Vtiger.Class('Vtiger_ListSidebar_Js',{},{
             }
 
             element.addClass('active');
-            element.find('i.activeToggleIcon').removeClass('fa-circle').addClass('fa-circle-o');
+            element.find('i.activeToggleIcon').removeClass('fa-circle-o').addClass('fa-circle');
             var listSearchParams = new Array();
             listSearchParams[0] = new Array();
             var tagSearchParams = new Array();

--- a/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
+++ b/public/layouts/v7/modules/Vtiger/resources/ListSidebar.js
@@ -239,11 +239,25 @@ Vtiger.Class('Vtiger_ListSidebar_Js',{},{
                 return;
             }
             var element = jQuery(e.currentTarget);
+            var isAlreadyActive = element.hasClass('active');
+            
             var tagId = element.data('id');
             var viewId = container.data('viewId');
             
             self.unMarkAllFilters();
             self.unMarkAllTags();
+            
+            if (isAlreadyActive) {
+                var params = {
+                    'tag' : '',
+                    'tag_params' : '',
+                    'search_params' : '',
+                    'page' : ''
+                };
+                self.loadListView(viewId, params);
+                return;
+            }
+
             element.addClass('active');
             element.find('i.activeToggleIcon').removeClass('fa-circle').addClass('fa-circle-o');
             var listSearchParams = new Array();

--- a/public/layouts/v7/skins/contact/style.css
+++ b/public/layouts/v7/skins/contact/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/inventory/style.css
+++ b/public/layouts/v7/skins/inventory/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/marketing/style.css
+++ b/public/layouts/v7/skins/marketing/style.css
@@ -4614,10 +4614,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4633,7 +4633,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4642,12 +4642,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/marketing_and_sales/style.css
+++ b/public/layouts/v7/skins/marketing_and_sales/style.css
@@ -4557,10 +4557,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4576,7 +4576,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4585,12 +4585,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/project/style.css
+++ b/public/layouts/v7/skins/project/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/sales/style.css
+++ b/public/layouts/v7/skins/sales/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/support/style.css
+++ b/public/layouts/v7/skins/support/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;

--- a/public/layouts/v7/skins/tools/style.css
+++ b/public/layouts/v7/skins/tools/style.css
@@ -4564,10 +4564,10 @@ form[name="notification_settings"] .select2-choice {
 }
 .tag {
   display: inline-block;
-  border: 1px solid #5ea9dd;
-  background-color: #5ea9dd;
+  border: 1px solid black;
+  background-color: #FFFFFF;
   width: auto;
-  color: #FFFFFF;
+  color: black;
   padding: 1px 3px 1px;
   margin: 0px 2px;
   border-radius: 20px 0px 0px 20px;
@@ -4583,7 +4583,7 @@ form[name="notification_settings"] .select2-choice {
   vertical-align: bottom;
 }
 .tag i {
-  color: #FFFFFF;
+  color: black;
 }
 .tag i.deleteTag {
   margin-right: 5px;
@@ -4592,12 +4592,12 @@ form[name="notification_settings"] .select2-choice {
   font-size: 9px;
 }
 .tag.active {
-  background-color: #FFFFFF;
-  border-color: black;
-  color: black;
+  background-color: #5ea9dd;
+  border-color: #5ea9dd;
+  color: #FFFFFF;
 }
 .tag.active i {
-  color: black;
+  color: #FFFFFF;
 }
 .tag .editTag {
   opacity: 0;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1119 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
案件や製品などにおいて、リスト画面のタグを一度選択すると同じタグを再クリックしても絞り込みを解除できない

##  原因 / Cause
<!-- バグの原因を記述 -->
タグクリック処理において、現在の選択状態を評価する分岐などが存在しなかったため。同じタグを再クリックしても解除処理には入らず、毎回「そのタグを選択する処理」が実行されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
ListSidebar.jsのクリック処理の冒頭で「現在そのタグが選択されているか」を判定する分岐を追加。すでに選択済みのタグがクリックされた場合、検索パラメータ（tag,tag_params 等）を空に設定して再読み込みする解除処理を実行。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
タグAクリック時
<img width="609" height="351" alt="image" src="https://github.com/user-attachments/assets/93d6e86a-bab4-4fd2-9158-968cda905a2d" />

タグA再クリック時
<img width="612" height="333" alt="image" src="https://github.com/user-attachments/assets/42519902-b933-44e7-bbcc-e430497e5c35" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->