### PR TITLE
リスト表示のソートを参照項目でも可能になるように修正

### DIFF
--- a/includes/http/Request.php
+++ b/includes/http/Request.php
@@ -101,8 +101,17 @@ class Vtiger_Request implements ArrayAccess {
 	 * @param <Boolean> $skipEmpty - Skip the check if string is empty
 	 * @return Value for the given key
 	 */
-	public function getForSql($key, $skipEmtpy=true) {
-		return Vtiger_Util_Helper::validateStringForSql($this->get($key), $skipEmtpy);
+	public function getForSql($key, $skipEmtpy = true) {
+		$value = $this->get($key);
+		
+		$matches = [];
+		preg_match('/(\w+) ; \((\w+)\) (\w+)/', $value, $matches);
+		if(count($matches) > 0) {
+			// 参照項目の場合はそのまま返す
+			return $value;
+		}
+		
+		return Vtiger_Util_Helper::validateStringForSql($value, $skipEmtpy);
 	}
 
 	/**

--- a/includes/runtime/BaseModel.php
+++ b/includes/runtime/BaseModel.php
@@ -46,8 +46,17 @@ class Vtiger_Base_Model {
 	 * @param <Boolean> $skipEmpty - Skip the check if string is empty
 	 * @return Value for the given key
 	 */
-	public function getForSql($key, $skipEmtpy=true) {
-		return Vtiger_Util_Helper::validateStringForSql($this->get($key), $skipEmtpy);
+	public function getForSql($key, $skipEmtpy = true) {
+		$value = $this->get($key);
+		
+		$matches = [];
+		preg_match('/(\w+) ; \((\w+)\) (\w+)/', $value, $matches);
+		if(count($matches) > 0) {
+			// 参照項目の場合はそのまま返す
+			return $value;
+		}
+		
+		return Vtiger_Util_Helper::validateStringForSql($value, $skipEmtpy);
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1536 

##  不具合の内容 / Bug
 1. カスタムビューで参照先モジュールの項目（例: 担当者の姓）をリスト表示カラムに追加した場合、そのカラムヘッダーをクリックしてもソートが効かない

##  原因 / Cause
 1. 参照先項目のカラムをクリックすると、orderbyパラメータに (field_name ; (Module) column_name) 形式の値が送信される
  2. getForSql() → Vtiger_Util_Helper::validateStringForSql() → vtlib_purifyForSql() のバリデーションパターン /^[_a-zA-Z0-9.:\-]+$/ がスペース・セミコロン・括弧を許可しないため false が返される
  3. 結果としてORDER BYが生成されず、ソートが無視される

##  変更内容 / Details of Change
  1. includes/runtime/BaseModel.php および includes/http/Request.php の getForSql() メソッドに、参照項目パターン (\w+) ; \((\w+)\) (\w+) を検知するロジックを追加
  2. 参照項目パターンに一致する場合はバリデーションをスキップし、値をそのまま返すように修正

## 影響範囲  / Affected Area
  - リストビューでカスタムビューに参照先モジュールの項目を追加している全モジュールのソート機能
  - 対象: Vtiger_Request::getForSql(), Vtiger_Base_Model::getForSql()
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った