### PR TITLE
Fix/723 メールテンプレートの翻訳漏れ

### DIFF
--- a/languages/en_us/EmailTemplates.php
+++ b/languages/en_us/EmailTemplates.php
@@ -23,6 +23,7 @@ $languageStrings = array(
 	'LBL_EMAIL_TEMPLATE_DESCRIPTION'=>'Manage templates for E-Mail module',
 	'LBL_NO_PERMISSIONS_TO_DELETE_SYSTEM_TEMPLATE' => 'No Permissions to delete System Template',
 	'LBL_RECORD_ID' => 'Record ID',
+	'LBL_MESSAGE' => 'Message',
 	
 	'Current Date' => 'Current Date',
 	'Current Time' => 'Current Time',
@@ -35,7 +36,41 @@ $languageStrings = array(
 	'Portal Url' => 'Portal Login URL',
 
 	'Email Template - Properties of ' => 'Email Template - Properties of ',
+	
+	// Email Template Names, Subjects, and Descriptions
+	'Invite Users' => 'Invite Users',
+	'Invitation' => 'Invitation',
+	'ToDo Reminder' => 'ToDo Reminder',
+	'Activity Reminder' => 'Activity Reminder',
+	'Reminder' => 'Reminder',
+	'Support end notification before a month' => 'Support end notification before a month',
+	'VtigerCRM Support Notification' => 'VtigerCRM Support Notification',
+	'Send Notification mail to customer before a month of support end date' => 'Send Notification mail to customer before a month of support end date',
+	'Support end notification before a week' => 'Support end notification before a week',
+	'Send Notification mail to customer before a week of support end date' => 'Send Notification mail to customer before a week of support end date',
+	'Customer Login Details' => 'Customer Login Details',
+	'Send Portal login details to customer' => 'Send Portal login details to customer',
+	'Thanks Note' => 'Thanks Note',
+	'Note of thanks' => 'Note of thanks',
+	'Target Crossed!' => 'Target Crossed!',
+	'Fantastic Sales Spree!' => 'Fantastic Sales Spree!',
+	'Follow Up' => 'Follow Up',
+	'Follow Up of meeting' => 'Follow Up of meeting',
+	'Address Change' => 'Address Change',
+	'Change of Address' => 'Change of Address',
+	'Accept Order' => 'Accept Order',
+	'Acknowledgement/Acceptance of Order' => 'Acknowledgement/Acceptance of Order',
+	'Goods received acknowledgement' => 'Goods received acknowledgement',
+	'Acknowledged Receipt of Goods' => 'Acknowledged Receipt of Goods',
+	'Acceptance Proposal' => 'Acceptance Proposal',
+	'Acceptance of Proposal' => 'Acceptance of Proposal',
+	'Pending Invoices' => 'Pending Invoices',
+	'Invoices Pending' => 'Invoices Pending',
+	'Payment Due' => 'Payment Due',
+	'Announcement for Release' => 'Announcement for Release',
+	'Announcement of a release' => 'Announcement of a release',
 );
+
 
 $jsLanguageStrings = array(
     'LBL_CUTOMER_LOGIN_DETAILS_TEMPLATE_DELETE_MESSAGE' => 'You will not be able to send the customer portal login details to the contact if you delete "Customer Login Details" template. Do you wish to continue ?',

--- a/languages/ja_jp/EmailTemplates.php
+++ b/languages/ja_jp/EmailTemplates.php
@@ -15,14 +15,15 @@ $languageStrings = array(
 	'LBL_EMAIL_TEMPLATE' => 'メールテンプレート',
 	
 	'LBL_TEMPLATE_NAME' => 'テンプレート名',
-	'LBL_DESCRIPTION' => '内容',
-	'LBL_SUBJECT' => '件名',
+	'LBL_DESCRIPTION' => '詳細内容',
+	'LBL_SUBJECT' => 'タイトル',
 	'LBL_SELECT_FIELD_TYPE' => 'モジュールと項目の選択',
 	'LBL_MODULE_NAME' => 'モジュール名',
 	
 	'LBL_EMAIL_TEMPLATE_DESCRIPTION'=>'メールのテンプレートを管理	',
 	'LBL_NO_PERMISSIONS_TO_DELETE_SYSTEM_TEMPLATE' => 'システムテンプレートを削除する権限がありません',
 	'LBL_RECORD_ID' => 'レコードID',
+	'LBL_MESSAGE' => 'メール本文',
 
 	'Current Date' => '現在日',
 	'Current Time' => '現在時刻',
@@ -35,6 +36,39 @@ $languageStrings = array(
 	'Portal Url' => 'ポータルのログインURL',
 
 	'Email Template - Properties of ' => 'メールテンプレート ',
+
+	// Email Template Names, Subjects, and Descriptions
+	'Invite Users' => 'ユーザーを招待',
+	'Invitation' => '招待状',
+	'ToDo Reminder' => 'ToDoリマインダー',
+	'Activity Reminder' => '活動リマインダー',
+	'Reminder' => 'リマインダー',
+	'Support end notification before a month' => 'サポート終了の1ヶ月前通知',
+	'VtigerCRM Support Notification' => 'F-RevoCRMサポート通知',
+	'Send Notification mail to customer before a month of support end date' => 'サポート終了の1ヶ月前に顧客へ通知メールを送信',
+	'Support end notification before a week' => 'サポート終了の1週間前通知',
+	'Send Notification mail to customer before a week of support end date' => 'サポート終了の1週間前に顧客へ通知メールを送信',
+	'Customer Login Details' => '顧客ポータル ログイン詳細',
+	'Send Portal login details to customer' => '顧客にポータルログインの詳細を送信',
+	'Thanks Note' => 'お礼状',
+	'Note of thanks' => 'お礼のメッセージ',
+	'Target Crossed!' => '目標達成！',
+	'Fantastic Sales Spree!' => '素晴らしい販売実績！',
+	'Follow Up' => 'フォローアップ',
+	'Follow Up of meeting' => '会議後のフォローアップ',
+	'Address Change' => '住所変更',
+	'Change of Address' => '住所の変更',
+	'Accept Order' => '注文の受付',
+	'Acknowledgement/Acceptance of Order' => '注文の確認・受付',
+	'Goods received acknowledgement' => '商品受領の確認',
+	'Acknowledged Receipt of Goods' => '商品の受領を確認しました',
+	'Acceptance Proposal' => 'プロポーザルの受諾',
+	'Acceptance of Proposal' => 'プロポーザルの受諾を確認',
+	'Pending Invoices' => '未払いの請求書',
+	'Invoices Pending' => '請求書の保留',
+	'Payment Due' => 'お支払期日',
+	'Announcement for Release' => 'リリースのご案内',
+	'Announcement of a release' => '新リリースのご案内',
 );
 
 $jsLanguageStrings = array(

--- a/layouts/v7/modules/EmailTemplates/DetailViewFullContents.tpl
+++ b/layouts/v7/modules/EmailTemplates/DetailViewFullContents.tpl
@@ -15,17 +15,17 @@
 			<div class="block">
 				{assign var=WIDTHTYPE value=$USER_MODEL->get('rowheight')}
 				<div>
-					<h4>{vtranslate('Email Template - Properties of ', $MODULE_NAME)} " {$RECORD->get('templatename')} "</h4>
+					<h4>{vtranslate('Email Template - Properties of ', $MODULE_NAME)} " {vtranslate($RECORD->get('templatename'), $MODULE_NAME)} "</h4>
 				</div>
 				<hr>
 				<table class="table detailview-table no-border">
 					<tbody> 
 						<tr>
-							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('Templatename', $MODULE_NAME)}</label></td>
+							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('LBL_TEMPLATE_NAME', $MODULE_NAME)}</label></td>
 							<td class="fieldValue {$WIDTHTYPE}">{vtranslate($RECORD->get('templatename'), $MODULE_NAME)}</td>
 						</tr>
 						<tr>
-							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('Description', $MODULE_NAME)}</label></td>
+							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('LBL_DESCRIPTION', $MODULE_NAME)}</label></td>
 							<td class="fieldValue {$WIDTHTYPE}">{vtranslate(nl2br($RECORD->get('description')), $MODULE_NAME)}</td>
 						</tr>
 						<tr>
@@ -33,11 +33,11 @@
 							<td class="fieldValue {$WIDTHTYPE}">{if $RECORD->get('module')} {vtranslate($RECORD->get('module'), $RECORD->get('module'))}{/if}</td>
 						</tr>
 						<tr>
-							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('Subject',$MODULE_NAME)}</label></td>
-							<td class="fieldValue {$WIDTHTYPE}">{$RECORD->get('subject')}</td>
+							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('LBL_SUBJECT',$MODULE_NAME)}</label></td>
+							<td class="fieldValue {$WIDTHTYPE}">{vtranslate($RECORD->get('subject'), $MODULE_NAME)}</td>
 						</tr>
 						<tr>
-							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('Message',$MODULE_NAME)}</label></td>
+							<td class="fieldLabel {$WIDTHTYPE}"><label class="muted marginRight10px">{vtranslate('LBL_MESSAGE',$MODULE_NAME)}</label></td>
 							<td class="fieldValue {$WIDTHTYPE}">
 								<iframe id="TemplateIFrame" style="height:400px;" class="col-sm-12 col-xs-12 overflowScrollBlock"></iframe>
 							</td>

--- a/layouts/v7/modules/EmailTemplates/DetailViewHeaderTitle.tpl
+++ b/layouts/v7/modules/EmailTemplates/DetailViewHeaderTitle.tpl
@@ -13,8 +13,8 @@
         <div class="recordBasicInfo">
             <div class="info-row">
                 <h4>
-                    <span class="recordLabel pushDown" title="{htmlentities($RECORD->getName())}">
-                        <span class="templatename">{$RECORD->getName()}</span>&nbsp;
+                    <span class="recordLabel pushDown" title="{vtranslate($RECORD->getName(), $MODULE)}">
+                        <span class="templatename">{vtranslate($RECORD->getName(), $MODULE)}</span>&nbsp;
                     </span>
                 </h4>
             </div>

--- a/layouts/v7/modules/EmailTemplates/EditView.tpl
+++ b/layouts/v7/modules/EmailTemplates/EditView.tpl
@@ -22,7 +22,7 @@
 							<div class="col-lg-12 col-md-12 col-lg-pull-0">
 								{assign var=SINGLE_MODULE_NAME value='SINGLE_'|cat:$MODULE}
 								{if $RECORD_ID neq ''}
-									<h4 class="editHeader" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {$RECORD->getName()}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {$RECORD->getName()}</h4>
+									<h4 class="editHeader" title="{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} {vtranslate($RECORD->getName(), $MODULE)}">{vtranslate('LBL_EDITING', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)} - {vtranslate($RECORD->getName(), $MODULE)}</h4>
 								{else}
 									<h4 class="editHeader" >{vtranslate('LBL_CREATING_NEW', $MODULE)} {vtranslate($SINGLE_MODULE_NAME, $MODULE)}</h4>
 								{/if}

--- a/layouts/v7/modules/EmailTemplates/ModuleHeader.tpl
+++ b/layouts/v7/modules/EmailTemplates/ModuleHeader.tpl
@@ -22,10 +22,10 @@
 					{/if}
 					&nbsp;
 					{if $REQ.view eq 'Detail'}
-						<a title="{$RECORD->get('templatename')}">&nbsp;{$RECORD->get('templatename')}&nbsp;</a>
+						<a title="{vtranslate($RECORD->get('templatename'), $MODULE)}">&nbsp;{vtranslate($RECORD->get('templatename'), $MODULE)}&nbsp;</a>
 					{/if}
 					{if $RECORD and $REQ.view eq 'Edit'}
-						<a title="{$RECORD->get('templatename')}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {$RECORD->get('templatename')} &nbsp;</a>
+						<a title="{vtranslate($RECORD->get('templatename'), $MODULE)}">&nbsp;{vtranslate('LBL_EDITING', $MODULE)} : {vtranslate($RECORD->get('templatename'), $MODULE)} &nbsp;</a>
 					{else if $REQ.view eq 'Edit'}
 						<a>&nbsp;{vtranslate('LBL_ADDING_NEW', $MODULE)}&nbsp;</a>
 					{/if}

--- a/layouts/v7/modules/EmailTemplates/partials/EditViewContents.tpl
+++ b/layouts/v7/modules/EmailTemplates/partials/EditViewContents.tpl
@@ -21,13 +21,13 @@
                     <tr>
                         <td class="fieldLabel {$WIDTHTYPE} alignMiddle">{vtranslate('LBL_TEMPLATE_NAME', $MODULE)}&nbsp;<span class="redColor">*</span></td>
                         <td class="fieldValue {$WIDTHTYPE}">
-                            <input id="{$MODULE}_editView_fieldName_templatename" type="text" class="inputElement" data-rule-required="true" name="templatename" value="{$RECORD->get('templatename')}">
+                            <input id="{$MODULE}_editView_fieldName_templatename" type="text" class="inputElement" data-rule-required="true" name="templatename" value="{vtranslate($RECORD->get('templatename'), $MODULE)}">
                         </td>
                     </tr>
                     <tr>
                         <td class="fieldLabel {$WIDTHTYPE} alignMiddle">{vtranslate('LBL_DESCRIPTION', $MODULE)}</td>
                         <td class="fieldValue {$WIDTHTYPE}">
-                            <textarea class="inputElement col-lg-12" id="description" name="description">{$RECORD->get('description')}</textarea>
+                            <textarea class="inputElement col-lg-12" id="description" name="description">{vtranslate($RECORD->get('description'), $MODULE)}</textarea>
                         </td>
                     </tr>
                 </tbody>
@@ -85,7 +85,7 @@
                         <td class="fieldLabel {$WIDTHTYPE}">{vtranslate('LBL_SUBJECT', $MODULE)}&nbsp;<span class="redColor">*</span></td>
                         <td class="fieldValue {$WIDTHTYPE}">
                             <div class="col-sm-6 col-xs-6">
-                                <input id="{$MODULE}_editView_fieldName_subject" type="text" {if $IS_SYSTEM_TEMPLATE_EDIT} disabled="disabled" {/if} class="inputElement col-lg-12" data-rule-required="true" name="subject" value="{$RECORD->get('subject')}"  spellcheck="true" />
+                                <input id="{$MODULE}_editView_fieldName_subject" type="text" {if $IS_SYSTEM_TEMPLATE_EDIT} disabled="disabled" {/if} class="inputElement col-lg-12" data-rule-required="true" name="subject" value="{vtranslate($RECORD->get('subject'), $MODULE)}"  spellcheck="true" />
                             </div>
                         </td>
                     </tr>

--- a/modules/EmailTemplates/models/ListView.php
+++ b/modules/EmailTemplates/models/ListView.php
@@ -136,6 +136,9 @@ class EmailTemplates_ListView_Model extends Vtiger_ListView_Model {
 				if($key=="module"){
 					$value = vtranslate($value,$value);
 				}
+				if(in_array($key, array('templatename', 'subject', 'description'))){
+					$value = vtranslate($value, 'EmailTemplates');
+				}
 				if(in_array($key,$this->listViewColumns)){
 					$value = textlength_check($value);
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #723 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. メールテンプレート機能において、一覧、詳細、編集画面の表示に日本語訳がされていない部分がある。
2. 一覧画面と詳細画面で翻訳の不一致があり、表記がバラバラの状態であった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 日本語言語ファイル（ja_jp/EmailTemplates.php）や英語の言語ファイル（en_us/EmailTemplates.php）に、各テンプレートの名前や件名に対応する翻訳定義が存在していなかった。
2. 一覧画面と詳細画面で参照する翻訳キーやラベルの定義が統一されていない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 言語ファイルへの定義追加 (en_us/EmailTemplates.php、ja_jp/EmailTemplates.php)
2. tplファイルにおいてvtranslate(翻訳関数)を適用
3. 表示の統一

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1835" height="626" alt="image" src="https://github.com/user-attachments/assets/25bc453c-53c4-404c-a494-75c099543dce" />
<img width="1096" height="275" alt="image" src="https://github.com/user-attachments/assets/d8c78bd4-bace-4079-af2b-d46285d7a1a9" />
<img width="1571" height="463" alt="image" src="https://github.com/user-attachments/assets/553d015f-2d37-4673-b428-5e4e16598c4c" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->