### PR TITLE
インポート時に個別税モードで消費税未設定商品のtax値が0.000になるのを、手動入力と同じNULLに修正

### DIFF
--- a/include/Webservices/LineItem/VtigerLineItemOperation.php
+++ b/include/Webservices/LineItem/VtigerLineItemOperation.php
@@ -226,7 +226,15 @@ class VtigerLineItemOperation extends VtigerActorOperation {
 					$this->taxList = $this->providedTaxList;
 				}
 			} elseif ($found == false) {
-				array_merge($this->taxList, $productTaxList);
+				// 個別税モード・消費税未設定の商品：tax列をNULLに設定
+				foreach ($moduleFields as $fieldName => $field) {
+					if (preg_match('/tax\d+/', $fieldName) != 0) {
+						$this->taxList[$fieldName] = array(
+							'label' => $field->getFieldLabelKey(),
+							'percentage' => NULL
+						);
+					}
+				}
 			}
 		} else {
 			$meta = $this->getMeta();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1542 

##  不具合の内容 / Bug
1. インポート時に個別税モードで消費税未設定商品のtax値が0.000になる

##  原因 / Cause
 1. 手動作成時：画面のJavaScriptが税未設定を検知し、taxカラムに値を送信しないためDB既定値のNULLが適用される
 2. CSVインポート時：initTax()内でarray_merge()の戻り値が未代入（ノーオペレーション）のためtaxListが空のまま → updateTaxes()がtaxカラムを更新しない → INSERT時のdecimal(7,3)型変換で0.000が残る
  
##  変更内容 / Details of Change
 1. initTax()のelseif ($found == false)分岐で、無効だったarray_merge()を削除し、
 全taxフィールドのpercentageをNULLに設定するループに置き換え、updateTaxes()で明示的にNULLを書き込むように修正 

## スクリーンショット / Screenshot
<img width="1151" height="604" alt="image" src="https://github.com/user-attachments/assets/bdf5241a-a8f1-4b9a-aec9-41f1546db99a" />

## 影響範囲  / Affected Area
見積・受注・発注・請求書のCSVインポート（個別税モード＋税未設定商品）
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->