### PR TITLE
品目に税金が未設定の場合に「税金はありません」メッセージを表示する機能を追加

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -340,7 +340,7 @@ $languageStrings = array(
 	'LBL_DIRECT_AMOUNT_DISCOUNT' => '金額指定割引',
 	'LBL_FINAL_DISCOUNT_AMOUNT' => '総割引額',
 	'LBL_MORE_CURRENCIES' => '他の通貨',
-	'LBL_SET_TAX_FOR' => '課税対象：',
+	'LBL_SET_TAX_FOR' => '課税対象',
 	'LBL_GROUP_TAX' => 'グループ課税',
 	'LBL_BILLING_ADDRESS_FROM' => '次から請求先住所からコピーする：',
 	'LBL_SHIPPING_ADDRESS_FROM' => '次から発送先住所からコピーする：',
@@ -1722,6 +1722,7 @@ $languageStrings = array(
 	'LBL_PLACEHOLDER_SEARCH' => '%sを検索...',
 	'LBL_PLACEHOLDER_SEARCH_AND_ADD' => '%sを検索して追加...',
 	'LBL_PLACEHOLDER_SEARCH_TITLE' => '%sを検索',
+	'JS_NO_TAXES_EXISTS' => '税金はありません',
 );
 
 $jsLanguageStrings = array(

--- a/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
@@ -279,6 +279,10 @@
 								{/foreach}
 							</table>
 						</div>
+					{else}
+						<div class="textAlignCenter">
+							{vtranslate('JS_NO_TAXES_EXISTS',$MODULE)}
+						</div>
 					{/if}
 				</div>
 			</span>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1543 

##  不具合の内容 / Bug
品目に税金が未設定の場合、税金ポップアップが空表示になる
「課税対象：」二重表示「課税対象：：」になった

##  原因 / Cause
1. テンプレートに税データなしの分岐がなく、ポップアップが空表示になる                                                                                                                                                                                              
2. 翻訳キーが$jsLanguageStringsのみに定義され、テンプレート側のvtranslateが参照する$languageStringsになかった
3. LBL_SET_TAX_FORの翻訳値「課税対象：」にコロンが含まれており、テンプレート側の:と重複して「課税対象： : 200」と表示されていた                                  

##  変更内容 / Details of Change
1. LineItemsContent.tplに{else}ブロックを追加し、税データなし時に「税金はありません」を表示                                                                                                                                                                        
2. Vtiger.phpの$languageStringsにJS_NO_TAXES_EXISTSを追加
  
## スクリーンショット / Screenshot
 修正前：<img width="382" height="182" alt="image" src="https://github.com/user-attachments/assets/b4f10ea0-0ea2-408c-887d-465f650ef3ae" />
 修正後：<img width="409" height="193" alt="image" src="https://github.com/user-attachments/assets/18668262-25d3-47fc-b469-354d4a10a4ae" />


## 影響範囲  / Affected Area
見積・受注・発注・請求書の編集画面（品目の税金ポップアップ表示）
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->