### PR TITLE
金額をカンマ付きで入れると途中で切れるバグを修正

### DIFF
--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -165,6 +165,8 @@ class Vtiger_Module_Model extends Vtiger_Module {
 
 				$fieldModel = $this->getField($fieldName);
 				if ($fieldModel && in_array($fieldModel->getFieldDataType(), array('currency', 'double', 'integer'))) {
+					// インライン編集後のAjaxレスポンスでは、このrecordModelの値が返却される。
+					// ブラウザでの描写用にこのrecordModelの値が返されるが、カンマが含まれると数値として認識されないため、カンマを削除してレスポンスする。保存に関してはUItyepeの変換処理でカンマを削除しているため、描写用の値のみカンマを削除する。
 					$value = str_replace(',', '', (string)$value);
 					$recordModel->set($fieldName, $value);
 				}

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -162,6 +162,12 @@ class Vtiger_Module_Model extends Vtiger_Module {
 				 */
 				$value = is_string($fieldValue) ? decode_html($fieldValue) : $fieldValue;
 				$focus->column_fields[$fieldName] = $value;
+
+				$fieldModel = $this->getField($fieldName);
+				if ($fieldModel && in_array($fieldModel->getFieldDataType(), array('currency', 'double', 'integer'))) {
+					$value = str_replace(',', '', (string)$value);
+					$recordModel->set($fieldName, $value);
+				}
 			}
 		}
 		$focus->mode = $recordModel->get('mode');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1527 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 金額項目のマウスオーバー編集で、金額入力時にカンマを含めるとカンマより前の数値しか保存されない。


##  原因 / Cause
<!-- バグの原因を記述 -->
1. Ajax保存時に、RecordModel内のデータがカンマを含んだままになっていること。
2. データベースには別の処理でカンマが消されて正しく保存されていたが、ブラウザに返す「表示用データ」の元になるメモリ上の値（RecordModel）が汚れたままであった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. /modules/Vtiger/models/Module.phpのsaveRecordメソッドにて、数値系項目の保存時にカンマを除去してRecordModelへセットし直す修正を行った。
2. getFieldDataType() による判定: すべての文字列からカンマを除去すると、テキストエリアなどの文章が壊れてしまうため、currency, double, integer の場合に限定。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="827" height="679" alt="image" src="https://github.com/user-attachments/assets/7b3ce9ed-dac3-4f32-a80d-1eb3f99d395b" />
変更後
<img width="880" height="680" alt="image" src="https://github.com/user-attachments/assets/7bf0c86e-6c92-4c80-a39b-351eecc50f44" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
データ型が currency（通貨）、double（浮動小数点）、integer（整数）の数値・金額項目

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->