### PR TITLE
Fix/1534-一括でタグを付けた際に画面がリロードされないので タグが増えたことに気が付かない

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/List.js
+++ b/public/layouts/v7/modules/Vtiger/resources/List.js
@@ -2381,6 +2381,7 @@ Vtiger.Class("Vtiger_List_Js", {
 				self.addToExistingTagSelector(newTagEle.clone(true));
 			}
 			app.helper.showSuccessNotification({"message": ''});
+			window.location.reload();
 		});
 
 		app.event.trigger('Request.MassTag.show', container, recordParams);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1534 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
発注、受注などの画面で該当する項目にチェックを付けてその他からタグを追加した場合、一覧画面上に追加したタグが表示されないため追加したように見えない。

##  原因 / Cause
<!-- バグの原因を記述 -->
タグ保存処理完了時に、リロード処理が実装されていなかったため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
public/layouts/v7/modules/Vtiger/resources/List.js の showAllTags関数内に、リロード処理であるwindow.location.reload(); を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1619" height="305" alt="image" src="https://github.com/user-attachments/assets/f6a08e40-2b0a-4c28-984e-7943687c46b3" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->