### PR TITLE
mailerバージョンアップ

### DIFF
--- a/setup/migration/scripts/20260413102051_upgrade_phpmailer_7x.php
+++ b/setup/migration/scripts/20260413102051_upgrade_phpmailer_7x.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * マイグレーション: upgrade_phpmailer_7x
+ *
+ * PHPMailer 5.2.27（バンドル版）→ PHPMailer 7.x（Composer管理）へのアップグレード
+ *
+ * 問題: PHPMailer 5.2.27 では $LE = "\n" がデフォルトで、
+ *       厳格なSMTPサーバ（plala.or.jp等）が CRLF 不備を拒否する。
+ * 解決: PHPMailer 7.x は $LE = "\r\n" がデフォルトで、RFC 5321 準拠。
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
+
+    private const PHPMAILER_PACKAGE = 'phpmailer/phpmailer:^7.0';
+
+    private static $composerPaths = ['/usr/local/bin/composer', '/usr/bin/composer'];
+
+    private $oldFiles = [
+        'modules/Emails/class.phpmailer.php',
+        'modules/Emails/class.smtp.php',
+        'cron/class.phpmailer.php',
+        'cron/class.smtp.php',
+    ];
+
+    /**
+     * ソースファイル書き換え定義
+     * 'autoload'  : 旧requireを置換する autoload文（nullの場合は削除のみ）
+     * 'use_after' : use文を挿入する基準行のキーワード（nullの場合はuse文不要）
+     */
+    private $sourceFilePatches = [
+        'cron/send_mail.php' => [
+            'autoload'  => "require_once dirname(__DIR__) . '/vendor/autoload.php';",
+            'use_after' => 'CommonUtils.php',
+        ],
+        'modules/Emails/mail.php' => [
+            'autoload'  => "require_once 'vendor/autoload.php';",
+            'use_after' => 'VTCacheUtils.php',
+        ],
+        'vtlib/Vtiger/Mailer.php' => [
+            'autoload'  => "require_once dirname(__DIR__, 2) . '/vendor/autoload.php';",
+            'use_after' => 'CommonUtils.php',
+        ],
+        'cron/SendReminder.service' => [
+            'autoload'  => null,
+            'use_after' => null,
+        ],
+        'modules/CustomerPortal/include.inc' => [
+            'autoload'  => null,
+            'use_after' => null,
+        ],
+    ];
+
+    private $backupDir = null;
+
+    public function process() {
+        $rootDir = realpath(dirname(__FILE__) . '/../../../') . '/';
+
+        // フェーズ1: composer require + 検証
+        $this->runComposerRequire($rootDir);
+        $this->verifyPhpmailer($rootDir);
+
+        // フェーズ2: ソースファイル書き換え
+        $this->updateSourceFiles($rootDir);
+
+        // フェーズ3: 旧ファイル退避・削除
+        $this->backupAndRemoveOldFiles($rootDir);
+
+        $this->log("PHPMailer 7.x アップグレード完了");
+    }
+
+    private function runComposerRequire($rootDir) {
+        if ($this->isPhpmailerInstalled($rootDir)) {
+            $this->log("composer: PHPMailer は既にインストール済み");
+            return;
+        }
+
+        $composerBin = $this->findComposerBin();
+        $this->log("composer require " . self::PHPMAILER_PACKAGE . " を実行中...");
+
+        $process = proc_open(
+            [$composerBin, 'require', self::PHPMAILER_PACKAGE, '--no-interaction'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes, $rootDir
+        );
+        if (!is_resource($process)) {
+            throw new Exception("composer プロセスの起動に失敗しました");
+        }
+
+        stream_get_contents($pipes[1]); fclose($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]); fclose($pipes[2]);
+        $returnCode = proc_close($process);
+
+        if ($returnCode !== 0) {
+            throw new Exception("composer require に失敗しました（終了コード: {$returnCode}）\n{$stderr}");
+        }
+        $this->log("composer require 完了（composer.json/lock 更新済み）");
+    }
+
+    private function verifyPhpmailer($rootDir) {
+        // composer require後にautoloaderが更新されているため、強制再読み込み
+        require $rootDir . 'vendor/autoload.php';
+
+        if (!class_exists('PHPMailer\PHPMailer\PHPMailer', true)) {
+            throw new Exception("PHPMailer\\PHPMailer\\PHPMailer クラスが見つかりません");
+        }
+        $this->log("PHPMailer v" . \PHPMailer\PHPMailer\PHPMailer::VERSION . " [OK]");
+
+        $ref = new \ReflectionProperty(\PHPMailer\PHPMailer\PHPMailer::class, 'LE');
+        $le = $ref->getValue(new \PHPMailer\PHPMailer\PHPMailer());
+        if ($le !== "\r\n") {
+            throw new Exception("CRLF設定が不正: LE=0x" . bin2hex($le) . " (期待値: 0x0d0a)");
+        }
+        $this->log("SMTP CRLF準拠 [OK]");
+    }
+
+    private function updateSourceFiles($rootDir) {
+        $useBlock = "\nuse PHPMailer\\PHPMailer\\PHPMailer;\nuse PHPMailer\\PHPMailer\\SMTP;\nuse PHPMailer\\PHPMailer\\Exception;\n";
+
+        foreach ($this->sourceFilePatches as $relPath => $patch) {
+            $file = $rootDir . $relPath;
+            if (!file_exists($file)) {
+                $this->log("スキップ（未存在）: {$relPath}");
+                continue;
+            }
+
+            $content = file_get_contents($file);
+            if (strpos($content, 'use PHPMailer\PHPMailer\PHPMailer;') !== false) {
+                $this->log("スキップ（変更済み）: {$relPath}");
+                continue;
+            }
+
+            $original = $content;
+
+            // 旧require/include行を削除または置換（1行目をautoloadに、残りを削除）
+            $content = preg_replace(
+                '/^(require_once|require|include_once)\s*[\(]?\s*["\'].*class\.(smtp|phpmailer)\.php["\'][\)]?\s*;\s*\n/m',
+                $patch['autoload'] ? $patch['autoload'] . "\n" : '',
+                $content, 1
+            );
+            $content = preg_replace(
+                '/^(require_once|require|include_once)\s*[\(]?\s*["\'].*class\.(smtp|phpmailer)\.php["\'][\)]?\s*;\s*\n/m',
+                '', $content
+            );
+
+            // use文の挿入
+            if ($patch['use_after']) {
+                $content = preg_replace(
+                    '/(.+' . preg_quote($patch['use_after'], '/') . '.+\n)/',
+                    "$1" . $useBlock, $content, 1
+                );
+            }
+
+            if ($content !== $original) {
+                file_put_contents($file, $content);
+                $this->log("更新: {$relPath}");
+            }
+        }
+    }
+
+    private function backupAndRemoveOldFiles($rootDir) {
+        $existing = array_filter($this->oldFiles, function ($f) use ($rootDir) {
+            return file_exists($rootDir . $f);
+        });
+
+        if (empty($existing)) {
+            $this->log("旧ファイル: 全て削除済み");
+            return;
+        }
+
+        $this->backupDir = $rootDir . 'migration_backup_' . date('YmdHis');
+        @mkdir($this->backupDir, 0755, true);
+
+        foreach ($existing as $rel) {
+            $destDir = $this->backupDir . '/' . dirname($rel);
+            if (!is_dir($destDir)) @mkdir($destDir, 0755, true);
+            copy($rootDir . $rel, $destDir . '/' . basename($rel));
+        }
+        $this->log("バックアップ: " . count($existing) . " ファイル -> {$this->backupDir}");
+
+        foreach ($existing as $rel) {
+            unlink($rootDir . $rel);
+            $this->log("削除: {$rel}");
+        }
+    }
+
+    private function isPhpmailerInstalled($rootDir) {
+        return file_exists($rootDir . 'vendor/phpmailer/phpmailer/src/PHPMailer.php');
+    }
+
+    private function findComposerBin() {
+        foreach (self::$composerPaths as $path) {
+            if (is_executable($path)) return $path;
+        }
+        throw new Exception("composer コマンドが見つかりません（検索: " . implode(', ', self::$composerPaths) . "）");
+    }
+}

--- a/setup/migration/scripts/20260413102051_upgrade_phpmailer_7x.php
+++ b/setup/migration/scripts/20260413102051_upgrade_phpmailer_7x.php
@@ -17,13 +17,6 @@ class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
 
     private static $composerPaths = ['/usr/local/bin/composer', '/usr/bin/composer'];
 
-    private $oldFiles = [
-        'modules/Emails/class.phpmailer.php',
-        'modules/Emails/class.smtp.php',
-        'cron/class.phpmailer.php',
-        'cron/class.smtp.php',
-    ];
-
     /**
      * ソースファイル書き換え定義
      * 'autoload'  : 旧requireを置換する autoload文（nullの場合は削除のみ）
@@ -52,8 +45,6 @@ class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
         ],
     ];
 
-    private $backupDir = null;
-
     public function process() {
         $rootDir = realpath(dirname(__FILE__) . '/../../../') . '/';
 
@@ -63,9 +54,6 @@ class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
 
         // フェーズ2: ソースファイル書き換え
         $this->updateSourceFiles($rootDir);
-
-        // フェーズ3: 旧ファイル退避・削除
-        $this->backupAndRemoveOldFiles($rootDir);
 
         $this->log("PHPMailer 7.x アップグレード完了");
     }
@@ -133,15 +121,19 @@ class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
 
             $original = $content;
 
-            // 旧require/include行を削除または置換（1行目をautoloadに、残りを削除）
-            $content = preg_replace(
-                '/^(require_once|require|include_once)\s*[\(]?\s*["\'].*class\.(smtp|phpmailer)\.php["\'][\)]?\s*;\s*\n/m',
-                $patch['autoload'] ? $patch['autoload'] . "\n" : '',
-                $content, 1
-            );
-            $content = preg_replace(
-                '/^(require_once|require|include_once)\s*[\(]?\s*["\'].*class\.(smtp|phpmailer)\.php["\'][\)]?\s*;\s*\n/m',
-                '', $content
+            // 旧require/include行をコメントアウトし、autoloadを追加
+            $replaced = false;
+            $content = preg_replace_callback(
+                '/^((require_once|require|include_once)\s*[\(]?\s*["\'].*class\.(smtp|phpmailer)\.php["\'][\)]?\s*;)\s*\n/m',
+                function ($match) use ($patch, &$replaced) {
+                    $commented = '// ' . $match[1] . "\n";
+                    if (!$replaced && $patch['autoload']) {
+                        $replaced = true;
+                        return $patch['autoload'] . "\n" . $commented;
+                    }
+                    return $commented;
+                },
+                $content
             );
 
             // use文の挿入
@@ -156,32 +148,6 @@ class Migration20260413102051_UpgradePhpmailer7x extends FRMigrationClass {
                 file_put_contents($file, $content);
                 $this->log("更新: {$relPath}");
             }
-        }
-    }
-
-    private function backupAndRemoveOldFiles($rootDir) {
-        $existing = array_filter($this->oldFiles, function ($f) use ($rootDir) {
-            return file_exists($rootDir . $f);
-        });
-
-        if (empty($existing)) {
-            $this->log("旧ファイル: 全て削除済み");
-            return;
-        }
-
-        $this->backupDir = $rootDir . 'migration_backup_' . date('YmdHis');
-        @mkdir($this->backupDir, 0755, true);
-
-        foreach ($existing as $rel) {
-            $destDir = $this->backupDir . '/' . dirname($rel);
-            if (!is_dir($destDir)) @mkdir($destDir, 0755, true);
-            copy($rootDir . $rel, $destDir . '/' . basename($rel));
-        }
-        $this->log("バックアップ: " . count($existing) . " ファイル -> {$this->backupDir}");
-
-        foreach ($existing as $rel) {
-            unlink($rootDir . $rel);
-            $this->log("削除: {$rel}");
         }
     }
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1424 

##  不具合の内容 / Bug
1. PHPMailer 5.2.27 のバージョンが低いため、メール本文を適切に処理できず、SMTPコマンドのDATA部が適切に送信されない
2. 相手側で拒否をしていなくてもメールが届かないことがある                                                                                                                                                                                                          
3. エラー: SMTP Error: The following recipients failed: test@example.com: End data with .

##  原因 / Cause
 1. バンドル版PHPMailer 5.2.27 の行末文字デフォルト値が $LE = "\n"（LF）であり、SMTPプロトコルが要求する "\r\n"（CRLF）ではない                                                                                                                                     
2. MIMEヘッダー・ボディの内部改行がLFのままとなり、厳格なSMTPサーバ（plala.or.jp等）に拒否される                                                                                                                                                                   
3. Gmail等の寛容なサーバは自動修正するため問題が表面化していなかった

##  変更内容 / Details of Change
 1. マイグレーションスクリプトを追加し、ComposerでPHPMailer 7.x（最新版）を導入                                                                                                                                                                                     
  2. メール送信に関わるソースファイル5個の旧require文をコメントアウトし、新しいautoload + use文を追加   
## 影響範囲  / Affected Area
メール送信機能全般（CRM画面送信、キュー送信、cronリマインダー、カスタマーポータル）               

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->