### PR TITLE
Fix/1520_React版 クイック作成 フォームに値がある状態で閉じる際に警告が表示されない

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -115,6 +115,9 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   // Form data（FieldValue型を使用）
   const [formData, setFormData] = useState<Record<string, FieldValue>>({});
 
+  // Track unsaved changes
+  const [isDirty, setIsDirty] = useState(false);
+
   // RecordType state（RecordTypeフィールドの選択値を管理）
   const [recordTypeFields, setRecordTypeFields] = useState<Record<string, string>>({});
 
@@ -240,6 +243,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   useEffect(() => {
     if (prevIsOpenRef.current && !isOpen) {
       isInitializedRef.current = false;
+      setIsDirty(false);
       if (successTimeoutRef.current) {
         clearTimeout(successTimeoutRef.current);
         successTimeoutRef.current = null;
@@ -247,6 +251,26 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
     }
     prevIsOpenRef.current = isOpen;
   }, [isOpen]);
+
+  /**
+   * Handle browser navigation (back button, refresh, close tab)
+   * when there are unsaved changes.
+   */
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (isOpen && isDirty && !successMessage) {
+        e.preventDefault();
+        // Chrome等、現代のブラウザではカスタムメッセージは表示されず
+        // ブラウザ標準の「変更が保存されない可能性があります」という文言が表示されます。
+        e.returnValue = ''; 
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isOpen, isDirty, successMessage]);
 
   /**
    * Cleanup on unmount
@@ -295,6 +319,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       });
 
       setFormData(initial);
+      setIsDirty(false);
       setValidationErrors({});
       setSuccessMessage(null);
       clearSaveError();
@@ -417,6 +442,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       }
 
       setValidationErrors({});
+      setIsDirty(false);
       setSuccessMessage(null);
       clearSaveError();
       isInitializedRef.current = true;
@@ -428,9 +454,30 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
   // ========================================
 
   /**
+   * 未保存の変更があるか確認し、あれば確認ダイアログを表示する
+   * @returns 続行してよい場合(変更なし、またはユーザーが承諾)はtrue
+   */
+  const checkUnsavedChanges = useCallback((): boolean => {
+    if (isDirty && !successMessage) {
+      const message = t('JS_CHANGES_WILL_BE_LOST');
+      return window.confirm(
+        message !== 'JS_CHANGES_WILL_BE_LOST' 
+          ? message 
+          : '変更内容が保存されません。よろしいですか？'
+      );
+    }
+    return true;
+  }, [isDirty, successMessage, t]);
+
+  /**
    * Handle modal open/close
    */
   const handleOpenChange = useCallback((open: boolean) => {
+    // 閉じようとしていて、未保存の変更がある場合は確認
+    if (!open && !checkUnsavedChanges()) {
+      return;
+    }
+
     if (externalIsOpen === undefined) {
       setInternalIsOpen(open);
     }
@@ -445,7 +492,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
     if (!open) {
       onCancel?.();
     }
-  }, [externalIsOpen, isCalendarVariant, onOpenChange, onCancel]);
+  }, [externalIsOpen, isCalendarVariant, onOpenChange, onCancel, isDirty, successMessage, t]);
 
   /**
    * Handle RecordType field change
@@ -464,11 +511,13 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       [fieldName]: value
     }));
 
+    setIsDirty(true);
+
     // バリデーションエラーをクリア
     setValidationErrors({});
     setSuccessMessage(null);
     clearSaveError();
-  }, [clearSaveError]);
+  }, [clearSaveError, setIsDirty]);
 
   /**
    * Handle field change (default variant)
@@ -490,6 +539,8 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       return updated;
     });
 
+    setIsDirty(true);
+
     if (validationErrors[fieldName]) {
       setValidationErrors(prev => {
         const next = { ...prev };
@@ -500,7 +551,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
 
     setSuccessMessage(null);
     clearSaveError();
-  }, [hasDependency, getFieldsToClear, validationErrors, clearSaveError]);
+  }, [hasDependency, getFieldsToClear, validationErrors, clearSaveError, setIsDirty]);
 
   /**
    * Handle field change (calendar variant)
@@ -511,6 +562,8 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       [fieldName]: value
     }));
 
+    setIsDirty(true);
+
     if (validationErrors[fieldName]) {
       setValidationErrors(prev => {
         const next = { ...prev };
@@ -521,7 +574,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
 
     setSuccessMessage(null);
     clearSaveError();
-  }, [setCurrentCalendarFormData, validationErrors, clearSaveError]);
+  }, [setCurrentCalendarFormData, validationErrors, clearSaveError, setIsDirty]);
 
   /**
    * Handle tab change (calendar variant)
@@ -595,6 +648,7 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       setSuccessMessage(
         baseMessage + (result.recordLabel ? ` - ${result.recordLabel}` : '')
       );
+      setIsDirty(false); // Clear dirty flag on success
 
       onSave?.(result);
 
@@ -620,6 +674,13 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
    */
   const handleSave = useCallback(async () => {
     if (!validateForm()) {
+      return;
+    }
+
+    // 編集モードかつ変更がない場合は、APIを叩かずにそのまま閉じるか何もしない
+    if (isEditMode && !isDirty) {
+      console.log('No changes detected, skipping save.');
+      handleOpenChange(false);
       return;
     }
 

--- a/assets/react-web-components/src/contexts/TranslationContext.tsx
+++ b/assets/react-web-components/src/contexts/TranslationContext.tsx
@@ -44,6 +44,7 @@ const DEFAULT_TRANSLATIONS: TranslationData = {
   LBL_FIELD_REQUIRED: '%sは必須です',
   LBL_FIELD_MAX_LENGTH: '%sは%s文字以内で入力してください',
   LBL_END_DATE_AFTER_START: '終了日時は開始日時より後に設定してください',
+  JS_CHANGES_WILL_BE_LOST: '変更が失われます。続行してもよろしいですか？',
 
   // 成功メッセージ
   LBL_CREATED_SUCCESS: '%sを作成しました',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1520 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. React版でクイック作成を開き、値を入力後 保存以外の方法で画面遷移をする際にSmarty版で出ていた警告「変更が失われます。続行してもよろしいですか？」が出ない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ブラウザの標準機能（戻る・閉じる）と、React UIの機能（モーダルを閉じる操作）の両方に対して、編集状態（isDirty）をチェックする仕様がなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx内
assets/react-web-components/src/contexts/TranslationContext.tsx内
1. キャンセル・枠外クリック・ESCキーなど、全ての閉じる操作に共通の未保存チェック
2. beforeunload イベントをフックし、モーダル内だけでなくページ更新やタブ閉じによるデータ消失も防止
3. エラーメッセージの翻訳データを追加

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="972" height="886" alt="image" src="https://github.com/user-attachments/assets/4067bfc4-5267-45d5-80dc-d3b3d228d997" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全てのクイック作成対象モジュール、モーダルを閉じる操作
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->