### PR TITLE
Fix/950-リスト表示でページを指定して遷移する際の総ページ数がおかしい

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/List.js
+++ b/public/layouts/v7/modules/Vtiger/resources/List.js
@@ -723,7 +723,7 @@ Vtiger.Class("Vtiger_List_Js", {
 		if (totalPageNumber === "") {
 			var totalCountElem = listViewContainer.find('#totalCount');
 			var totalRecordCount = totalCountElem.val();
-			if (totalRecordCount !== '') {
+			if (totalRecordCount !== '' && totalRecordCount !== '0') {
 				var recordPerPage = listViewContainer.find('#pageLimit').val();
 				if (recordPerPage === '0')
 					recordPerPage = 1;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #950 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
リスト表示において、データが20件を超えている状態で、画面右上「…」を押下しても、「ページ 1 - 1」と表示され、総ページ数が正しく表示されない。また、2ページ目に遷移はできるが「ページ 2 - 1」という表示になってしまっていた。

##  原因 / Cause
<!-- バグの原因を記述 -->
List.jsのpageJump関数内における判定漏れが原因。
画面を開いた直後は初期値として '0' を保持している。従来は if (totalRecordCount !== '') という判定しか持っていないため、未取得状態の '0' が入っている場合でも「空（''）ではない＝件数は取得済みである」と誤判定し、そのまま計算処理（0件 ÷ 20件 ＝ 0ページ）をしていた。結果として、画面には最低1ページというルールに基づいた「1」という数値が書き込まれ、かつ取得済みとされてしまうため、2ページ目に遷移しても正しい件数を取りに行かなくなっていた。


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
public/layouts/v7/modules/Vtiger/resources/List.js内の pageJump関数において、総件数の判定条件を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="235" height="113" alt="image" src="https://github.com/user-attachments/assets/828314f6-40be-44b7-a44c-45f7b8502756" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
すべての項目のリスト

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->