### PR TITLE
Fix/1422-戻るを押すと、レポート条件画面の次へボタンが無効化される

### DIFF
--- a/public/layouts/v7/modules/Reports/resources/ChartEdit2.js
+++ b/public/layouts/v7/modules/Reports/resources/ChartEdit2.js
@@ -45,5 +45,13 @@ Reports_Edit3_Js("Reports_ChartEdit2_Js",{},{
 			}
 		);
 		return aDeferred.promise();
+	},
+
+	registerSubmitEvent : function(){
+		var thisInstance = this;
+		var form = this.getContainer();
+		form.submit(function(e){
+			thisInstance.calculateValues();
+		});
 	}
 });

--- a/public/layouts/v7/modules/Reports/resources/Edit.js
+++ b/public/layouts/v7/modules/Reports/resources/Edit.js
@@ -136,7 +136,6 @@ Vtiger_Edit_Js("Reports_Edit_Js",{
 		container.remove();
 		this.initiateStep(prevStep);
 		this.currentInstance.getContainer().removeClass('hide').css('display','block');
-		this.currentInstance.getContainer().find('input[type="submit"], button[type="submit"]').prop('disabled', false);
 	},
 
 	/*

--- a/public/layouts/v7/modules/Reports/resources/Edit.js
+++ b/public/layouts/v7/modules/Reports/resources/Edit.js
@@ -136,6 +136,7 @@ Vtiger_Edit_Js("Reports_Edit_Js",{
 		container.remove();
 		this.initiateStep(prevStep);
 		this.currentInstance.getContainer().removeClass('hide').css('display','block');
+		this.currentInstance.getContainer().find('input[type="submit"], button[type="submit"]').prop('disabled', false);
 	},
 
 	/*


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1422 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポート画面からレポートの追加>グラフの作成をするときに「3.グラフの選択」の画面まで行き、戻るを押して「2.フィルタ」に戻ると「3.グラフの選択」へ遷移する次へのボタンが表示されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
レポート機能の最終ステップには、ボタン連打によるデータの重複登録を防ぐため、「送信ボタンを押した瞬間に、そのボタンを無効化（disabled="true"）する」という仕組みがあり、この機能が有効になっていたため。 
グラフの作成の「2.フィルタ」は、詳細レポートの作成の最終ステップである「3.フィルタ」を継承しているため、最終ステップと同じく次へのボタンの連打を防ぐロックがかかり1度しか押せないため、戻っても解除されていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
public/layouts/v7/modules/Reports/resources/Edit.js：戻る処理についての関数であるback関数に次へボタンの有効化を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1871" height="894" alt="image" src="https://github.com/user-attachments/assets/e0fca64d-466e-4db2-995d-b304f1ec9405" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->