### PR TITLE
Fix/1569-クイック作成のドキュメント吹き出しのデザイン崩れを修正

### DIFF
--- a/public/layouts/v7/skins/contact/style.css
+++ b/public/layouts/v7/skins/contact/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/inventory/style.css
+++ b/public/layouts/v7/skins/inventory/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/marketing/style.css
+++ b/public/layouts/v7/skins/marketing/style.css
@@ -6729,8 +6729,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6834,8 +6835,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7227,6 +7229,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/marketing_and_sales/style.css
+++ b/public/layouts/v7/skins/marketing_and_sales/style.css
@@ -6666,8 +6666,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6771,8 +6772,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7164,6 +7166,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/project/style.css
+++ b/public/layouts/v7/skins/project/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/sales/style.css
+++ b/public/layouts/v7/skins/sales/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/support/style.css
+++ b/public/layouts/v7/skins/support/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/tools/style.css
+++ b/public/layouts/v7/skins/tools/style.css
@@ -6673,8 +6673,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -6778,8 +6779,9 @@ li.select2-search-choice div {
 #quickCreateModules .quickcreateMoreDropdown {
   left: 85%;
   top: 0px;
-  min-width: 170px;
+  min-width: 230px;
   padding: 4%;
+  white-space: nowrap;
 }
 #quickCreateModules .quickcreateMoreDropdown li {
   padding: 1%;
@@ -7171,6 +7173,23 @@ input:focus:-ms-input-placeholder {
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 #sharedcalendar .fc-event-container .vicon-meeting,
 #mycalendar .fc-event-container .vicon-meeting {

--- a/public/layouts/v7/skins/vtiger/style.less
+++ b/public/layouts/v7/skins/vtiger/style.less
@@ -7477,8 +7477,9 @@ li.select2-search-choice div{
 #quickCreateModules .quickcreateMoreDropdown {
     left: 85%;
     top: 0px;
-    min-width: 170px;
+    min-width: 230px;
     padding: 4%;
+    white-space: nowrap;
 }
 
 #quickCreateModules .quickcreateMoreDropdown li{
@@ -7595,8 +7596,9 @@ li.select2-search-choice div{
 #quickCreateModules .quickcreateMoreDropdown {
     left: 85%;
     top: 0px;
-    min-width: 170px;
+    min-width: 230px;
     padding: 4%;
+    white-space: nowrap;
 }
 
 #quickCreateModules .quickcreateMoreDropdown li{
@@ -8014,6 +8016,23 @@ input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
   border-bottom: 6px solid #ffffff;
   border-left: 6px solid transparent;
   content: '';
+}
+.global-actions .quickcreateMoreDropdown:before,
+.global-actions .quickcreateMoreDropdown:after {
+  display: none;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .quickcreateMoreDropdown > li > a {
+    color: #333;
+  }
+  .global-actions .dropdown.open > .quickCreateDropdown,
+  .global-actions .quickcreateMoreDropdown {
+    box-shadow: none;
+  }
+  #quickCreateModules .quickcreateMoreDropdown {
+    min-width: 0;
+    white-space: normal;
+  }
 }
 
 #sharedcalendar .fc-event-container .vicon-meeting,


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1569

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. クイック作成 → ドキュメントのサブメニュー（吹き出し）で、上向きの矢印が表示されており不自然
2. 日本語メニュー項目（「外部のドキュメントとリンク」等）が枠からはみ出していた
3. モバイル表示時、サブメニュー項目の文字色が薄いグレー（#999）で読みにくく、浮いた box-shadow が不自然

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `.global-actions .dropdown-menu:before/:after` による上向き矢印が、メインドロップダウン用として定義されているがサブメニュー（`.quickcreateMoreDropdown`）にも適用されていた。サブメニューは親項目の右側に展開するため、上向き矢印は位置的に不自然
2. サブメニューの `min-width: 170px` が日本語翻訳（例：「外部のドキュメントとリンク」13文字）の幅に対して不足していた
3. モバイル時、Bootstrap の `.navbar-inverse .navbar-nav .open .dropdown-menu > li > a` が文字色を `#999` で上書きしていた。また `.dropdown-menu` の `box-shadow` がナビ内展開時に浮いて見えていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `public/layouts/v7/skins/vtiger/style.less` および各スキンのコンパイル済み `style.css` に対して下記を修正:
   - `.global-actions .quickcreateMoreDropdown:before/:after { display: none }` を追加し、サブメニュー側の矢印のみ非表示（メインドロップダウンの矢印は維持）
   - `#quickCreateModules .quickcreateMoreDropdown` の `min-width: 170px` → `230px`、`white-space: nowrap` を追加し日本語の折り返し・はみ出しを防止
   - モバイル（`max-width: 767px`）向けに、サブメニューリンク色を `#333` に戻し、`.quickCreateDropdown` / `.quickcreateMoreDropdown` の `box-shadow` を除去、サブメニューの `min-width` をリセット

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
デスクトップ（修正後）: サブメニュー右側展開時に上向き矢印が消え、長い日本語もはみ出さない
モバイル（修正後）: サブメニュー項目の文字色が通常のダーク色に、余分な影が消えた

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- トップバー「+」クイック作成 → ドキュメント のサブメニュー表示のみ
- 主要ドロップダウン（クイック作成本体、ユーザーメニュー等）の見た目は従来通り維持
- 全 v7 スキン（vtiger / contact / inventory / marketing / marketing_and_sales / project / sales / support / tools）に同じ修正を反映

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
CSS のみの修正。Playwright で PC / モバイル表示のいずれも動作確認済み。
