### PR TITLE
Account／Contact の削除時に、関連する Quote／Potential の論理削除フラグが正しく同期されず、削除後も一覧に残…

### DIFF
--- a/modules/Accounts/Accounts.php
+++ b/modules/Accounts/Accounts.php
@@ -1347,8 +1347,8 @@ class Accounts extends CRMEntity {
 			$quo_id = $this->db->query_result($quo_res,$k,"crmid");
 			$quo_ids_list[] = $quo_id;
 			$sql = 'UPDATE vtiger_crmentity SET deleted = 1 WHERE crmid = ?';
-			CRMEntity::updateBasicInformation('Quotes', $quo_id);
 			$this->db->pquery($sql, array($quo_id));
+			CRMEntity::updateBasicInformation('Quotes', $quo_id);
 		}
 		//Backup deleted Account related Quotes.
 		$params = array($id, RB_RECORD_UPDATED, 'vtiger_crmentity', 'deleted', 'crmid', implode(",", $quo_ids_list));

--- a/modules/Contacts/Contacts.php
+++ b/modules/Contacts/Contacts.php
@@ -1393,8 +1393,8 @@ function get_contactsforol($user_name)
 			$pot_id = $this->db->query_result($pot_res,$k,"crmid");
 			$pot_ids_list[] = $pot_id;
 			$sql = 'UPDATE vtiger_crmentity SET deleted = 1 WHERE crmid = ?';
-			CRMEntity::updateBasicInformation('Potentials', $pot_id);
 			$this->db->pquery($sql, array($pot_id));
+			CRMEntity::updateBasicInformation('Potentials', $pot_id);
 		}
 		//Backup deleted Contact related Potentials.
 		$params = array($id, RB_RECORD_UPDATED, 'vtiger_crmentity', 'deleted', 'crmid', implode(",", $pot_ids_list));

--- a/setup/migration/scripts/20260422174357_sync_deleted_flag_for_cascaded_quotes_and_potentials.php
+++ b/setup/migration/scripts/20260422174357_sync_deleted_flag_for_cascaded_quotes_and_potentials.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * マイグレーション: sync_deleted_flag_for_cascaded_quotes_and_potentials
+ * 生成日時: 20260422174357
+ *
+ * Account / Contact の削除時にカスケード削除された Quote / Potential について、
+ * updateBasicInformation の呼び出し順序バグにより vtiger_crmentity.deleted=1 だが
+ * vtiger_quotes.deleted / vtiger_potential.deleted が 0 のままになっているレコードを
+ * vtiger_crmentity 側の値で上書きして整合性を回復する。
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260422174357_SyncDeletedFlagForCascadedQuotesAndPotentials extends FRMigrationClass {
+
+    public function process() {
+        $this->syncDeletedFlag('vtiger_quotes',    'quoteid',     'Quotes');
+        $this->syncDeletedFlag('vtiger_potential', 'potentialid', 'Potentials');
+    }
+
+    /**
+     * 指定モジュールの基本テーブルについて vtiger_crmentity.deleted と食い違っている
+     * レコードを crmentity 側の値で同期する。
+     *
+     * @param string $baseTable    基本テーブル名 (vtiger_quotes など)
+     * @param string $baseTableKey 基本テーブルの主キーカラム名 (quoteid など)
+     * @param string $moduleLabel  ログ用のモジュール名
+     */
+    private function syncDeletedFlag($baseTable, $baseTableKey, $moduleLabel) {
+        $countSql = "SELECT COUNT(*) AS cnt
+                     FROM {$baseTable} b
+                     INNER JOIN vtiger_crmentity e ON b.{$baseTableKey} = e.crmid
+                     WHERE b.deleted <> e.deleted";
+        $result = $this->db->pquery($countSql, array());
+        $target = (int) $this->db->query_result($result, 0, 'cnt');
+
+        if ($target === 0) {
+            $this->log("{$moduleLabel}: 不整合レコードなし。スキップします。");
+            return;
+        }
+
+        $this->log("{$moduleLabel}: 不整合レコード {$target} 件を同期します。");
+
+        $updateSql = "UPDATE {$baseTable} b
+                      INNER JOIN vtiger_crmentity e ON b.{$baseTableKey} = e.crmid
+                      SET b.deleted = e.deleted
+                      WHERE b.deleted <> e.deleted";
+        $this->db->pquery($updateSql, array());
+
+        $this->log("{$moduleLabel}: 同期完了。");
+    }
+}


### PR DESCRIPTION
…り続ける不具合を修正する。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1580 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 

##  原因 / Cause
<!-- バグの原因を記述 -->
1.F-RevoCRM では論理削除フラグを 2箇所で管理している
vtiger_crmentity.deleted ... 共通のエンティティテーブル
vtiger_{module}.deleted ... 各モジュールの基本テーブル（vtiger_quotes.deleted / vtiger_potential.deleted 等）
両者は CRMEntity::updateBasicInformation() によって crmentity → 基本テーブル の方向に同期される。したがって呼び出し順序は：

UPDATE vtiger_crmentity SET deleted = 1 ...
CRMEntity::updateBasicInformation(...)
でなければならない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 該当する二箇所について $this->db->pquery($sql, ...) と CRMEntity::updateBasicInformation(...) の呼び出し順を入れ替え、先に vtiger_crmentity.deleted = 1 を反映させてから基本テーブルへ同期するという本来の順序に揃えた。行の差し替えは各ファイル一行ずつの純粋な順序修正であり、ロジックやクエリの内容そのものには一切手を入れていない。

なお、この修正はコード側の挙動を正すものであり、既に不整合状態になっているデータを遡って補正するものではない。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->