### PR TITLE
fix_1566_カレンダーで時間を範囲指定して活動登録できない

### DIFF
--- a/public/layouts/v7/lib/jquery/fullcalendar/fullcalendar.js
+++ b/public/layouts/v7/lib/jquery/fullcalendar/fullcalendar.js
@@ -11174,7 +11174,7 @@ Calendar.defaults = {
 	dragRevertDuration: 500,
 	dragScroll: true,
 	
-	//selectable: false,
+	selectable: true,
 	unselectAuto: true,
 	
 	dropAccept: '*',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1566

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーでドラッグして時間を範囲指定して活動の登録画面を開くことができない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. /public/layouts/v7/lib/jquery/fullcalendar/fullcalendar.js内の
fullcalendar.js内のselectableというクリックやドラッグして、範囲選択を有効にするための設定がコメントアウトされていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. selectableのパラメータをtrueにして有効にした

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="277" height="432" alt="image" src="https://github.com/user-attachments/assets/b17bd0b5-5193-4526-a8d0-3a72ffb9519f" />
変更後
<img width="419" height="532" alt="image" src="https://github.com/user-attachments/assets/395171a8-7550-4c6e-b2b4-a0a2885666fe" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダーモジュール内の全てのカレンダー

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
fullcalendar.js内の11178行目のunselectAutoは、
現状のtrueだと活動が保存されなかった際に選択範囲が消える。
falseにすることで保存されなかった場合でも選択範囲が保持される。

selectHelper(selectMirror)というパラメータを追加すれば、選択範囲を表示するかどうかが決められる。