### PR TITLE
fix: #1582 ReleaseからDLした際にtabdata.php/parent_tabdata.phpが無くインストールエラーに…

### DIFF
--- a/modules/Install/views/Index.php
+++ b/modules/Install/views/Index.php
@@ -27,6 +27,15 @@ class Install_Index_view extends Vtiger_View_Controller {
 		$this->exposeMethod('Step7');
 	}
 
+	// Release tarball does not ship tabdata.php / parent_tabdata.php; git clone does. Create empties so writable checks and later includes succeed.
+	protected function ensureRequiredFiles() {
+		foreach (array('tabdata.php', 'parent_tabdata.php') as $file) {
+			if (!file_exists($file)) {
+				@touch($file);
+			}
+		}
+	}
+
 	protected function applyInstallFriendlyEnv() {
 		// config.inc.php - will not be ready to control this yet.
 		version_compare(PHP_VERSION, '5.5.0') <= 0 ? error_reporting(E_ERROR & ~E_NOTICE & ~E_DEPRECATED) : error_reporting(E_ERROR & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
@@ -36,6 +45,7 @@ class Install_Index_view extends Vtiger_View_Controller {
 
 	public function preProcess(Vtiger_Request $request, $display = true) {
 		$this->applyInstallFriendlyEnv();
+		$this->ensureRequiredFiles();
 
 		date_default_timezone_set('Asia/Tokyo'); // to overcome the pre configuration settings
 


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1582 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リリース等にあるZipからF-RevoCRMをインストールしようとするとエラーがおきていた

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `tabdata.php` `parent_tabdata.php` が存在しないためのエラー

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. インストール時、自動生成するようにする

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
インストール時のみ

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->