### PR TITLE
空で入ってきたときにimplodeでエラーがでていたのを修正

### DIFF
--- a/modules/Settings/LayoutEditor/actions/Field.php
+++ b/modules/Settings/LayoutEditor/actions/Field.php
@@ -112,13 +112,15 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         
         if(isset($fieldDefaultValue) && $fieldDefaultValue !== null) {
             $fieldDataType = $fieldInstance->getFieldDataType();
+            $rawDefaultValue = $request->get('fieldDefaultValue');
             if($fieldDataType == 'multipicklist'){
-                $defaultValue = decode_html(implode(' |##| ', $request->get('fieldDefaultValue')));
+                $defaultValue = decode_html(is_array($rawDefaultValue) ? implode(' |##| ', $rawDefaultValue) : (string)$rawDefaultValue);
             }else{
-                $defaultValue = decode_html($request->get('fieldDefaultValue'));
+                $defaultValue = decode_html($rawDefaultValue);
             }
             $fieldInstance->set('defaultvalue', $defaultValue);
         }
+
 		$response = new Vtiger_Response();
         try{
             $fieldInstance->save();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1588 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. モジュール管理＞項目設定　の画面において、「選択肢（複数）」のカスタム項目を追加
・項目属性の有効化/無効化の設定をする
例）「主要項目に表示」にチェック
・「保存」すると、画面右上に「成功」と出るものの、該当の項目自体は項目設定の画面から一時的に消え、設定したはずの項目属性の有効化/無効化が反映されていない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. レイアウトエディタでフィールド既定値を保存する際、multipicklist で
何も選択されていない状態だとリクエスト値が空文字列 '' として送られてくる。
PHP 8.3 では implode() の第2引数に文字列を渡すと TypeError が発生するため、
既定値未選択のまま保存すると 500 エラーになっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 
modules/Settings/LayoutEditor/actions/Field.php の save() 内、
multipicklist 分岐における既定値組み立て処理を修正。
$request->get('fieldDefaultValue') を is_array() で判定し、
- 配列のときのみ implode(' |##| ', ...) を実行
- それ以外は (string) キャストして decode_html() に渡す
という分岐に変更した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->