### PR TITLE
Fix/1557-List画面を表示した際にエラーが表示される

### DIFF
--- a/modules/CustomView/CustomView.php
+++ b/modules/CustomView/CustomView.php
@@ -1991,6 +1991,8 @@ class CustomView extends CRMEntity {
 				if(!empty($module) && $module != $entityType) {
 					return 'no';
 				}
+			} else {
+				return 'no';
 			}
 
 			$status_userid_info = $this->getStatusAndUserid($record_id);

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -454,6 +454,14 @@ class Vtiger_List_View extends Vtiger_Index_View {
 				}
 			}
 		}
+
+		if (!$viewer->get_template_vars('CURRENT_CV_MODEL')) {
+			$allFilterModel = CustomView_Record_Model::getAllFilterByModule($moduleName);
+			if ($allFilterModel) {
+				$viewer->assign('CURRENT_CV_MODEL', $allFilterModel);
+				$viewer->assign('VIEWID', $allFilterModel->getId());
+			}
+		}
 	}
 
 	/**

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -440,7 +440,8 @@ class Vtiger_List_View extends Vtiger_Index_View {
 	}
 
 	protected function assignCustomViews(Vtiger_Request $request, Vtiger_Viewer $viewer) {
-		$allCustomViews = CustomView_Record_Model::getAllByGroup($request->getModule());
+		$moduleName = $request->getModule();
+		$allCustomViews = CustomView_Record_Model::getAllByGroup($moduleName);
 		if (!empty($allCustomViews)) {
 			$viewer->assign('CUSTOM_VIEWS', $allCustomViews);
 			$currentCVSelectedFields = array();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1557 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
リスト画面を表示した際、稀に画面が正常に表示されず、Fatal Errorが発生する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. セッション内に残っている古い cvid（カスタムビューID）や、他モジュールの cvidがリクエストに混入した場合、該当するカスタムビューが見つからず、 $CURRENT_CV_MODELがnull になってしまう。
2. テンプレート側はこの変数が常に「オブジェクト」であることを期待して isCvEditable()などのメソッドを実行するため、null に対して操作を行おうとしてエラーが発生していた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. modules/Vtiger/views/List.php：リクエストされた cvidが無効であったり、他モジュールのIDであるなど、「意図しないデータ」によって失敗した場合の共通処理を実装。テンプレートにデータを渡す最終段階で CURRENT_CV_MODELが空（null）であることを検知した場合、「すべて」のモデルを割り当て直す。
2. modules/CustomView/CustomView.php：不整合なデータが渡された場合に処理を強行せず、'no'を返す条件を追加した。これにより、上記のコントローラー側での判定（空なら「すべて」を表示する）へつなげることができる。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->