### PR TITLE
fix/1568 iOS SafariでQuickCreateモーダルのフッターがブラウザ下部バーに被る問題を修正

### DIFF
--- a/assets/react-web-components/src/index.css
+++ b/assets/react-web-components/src/index.css
@@ -204,3 +204,10 @@
     border-collapse: collapse;
   }
 }
+
+/* iOS Safariのみ: ブラウザ下部ナビゲーションバーとの重なり修正 */
+@supports (-webkit-touch-callout: none) {
+  [data-slot="dialog-content"] {
+    max-height: 90svh !important;
+  }
+}


### PR DESCRIPTION
@supports (-webkit-touch-callout: none) ブロックで iOS Safari のみに
max-height: 90svh を適用し、ブラウザ下部ナビゲーションバーとの重なりを解消する。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1568 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. iOS Safariスケジュールのクイック作成時にクイック作成フッターとSafariのフッターが被っていた

##  原因 / Cause
<!-- バグの原因を記述 -->
1. iOS Safariでは vh（ビューポート高さ）がブラウザUIを含む画面全体の高さで計算されるため、max-h-[90vh]のモーダルが下部ナビゲーションバーと重なってしまう。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. iOS Safariのみが解釈する @supports (-webkit-touch-callout: none) ブロック内で、QuickCreateモーダルの最大高さを90vh から 90svh に変更

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- iOS Safari 環境
- QuickCreateモーダル

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->