### PR TITLE
fix: 検索パネルのモジュール変更時にフッターボタンのリスナーが累積するバグを修正 (#1594)

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/AdvanceSearch.js
+++ b/public/layouts/v7/modules/Vtiger/resources/AdvanceSearch.js
@@ -349,6 +349,7 @@ Vtiger_BasicSearch_Js("Vtiger_AdvanceSearch_Js",{
         }
         this.initiateSearch().then(function() {
             self.selectBasicSearchValue();
+            self.registerFooterEvents();
         });
     },
     
@@ -379,6 +380,19 @@ Vtiger_BasicSearch_Js("Vtiger_AdvanceSearch_Js",{
                 thisInstance.selectBasicSearchValue();
             });
 		});
+
+		//DO nothing on submit of filter form
+		this.getFilterForm().on('submit',function(e){
+			e.preventDefault();
+		})
+
+		//To set the search module with the currently selected values.
+		this.setSearchModule(jQuery('#searchModuleList').val());
+	},
+
+	registerFooterEvents : function() {
+		var thisInstance = this;
+		var container = this.getContainer();
 
 		jQuery('#advanceSearchButton').on('click', function(e){
 			var searchModule = thisInstance.getSearchModule();
@@ -435,13 +449,5 @@ Vtiger_BasicSearch_Js("Vtiger_AdvanceSearch_Js",{
 				thisInstance.saveAndViewFilter(params);
 			});
 		});
-
-		//DO nothing on submit of filter form
-		this.getFilterForm().on('submit',function(e){
-			e.preventDefault();
-		})
-
-		//To set the search module with the currently selected values.
-		this.setSearchModule(jQuery('#searchModuleList').val());
 	}
 })


### PR DESCRIPTION
registerEvents()内のフッターボタン（#advanceSearchButton・#advanceIntiateSave・#advanceSave）のリスナー登録処理をregisterFooterEvents()として切り出し、パネル初回オープン時の1回のみ呼ばれるよう修正

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1594 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 検索パネルのモジュール変更時にフッターボタンのリスナーが累積する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. フッターDOMが置き換えられないにも関わらず、モジュール変更のたびにフッターのリスナーを登録している。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. フッターのリスナー登録を初回表示時のみ呼ぶように変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 検索パネルを利用するモジュール
  - 検索ボタンの動作
  - リストに保存ボタンの動作

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->