### PR TITLE
Fix/945-Potentialsのclosingdateにデフォルト値で今日の日付を指定できるようにしてほしい

### DIFF
--- a/modules/Settings/LayoutEditor/models/Field.php
+++ b/modules/Settings/LayoutEditor/models/Field.php
@@ -220,6 +220,9 @@ class Settings_LayoutEditor_Field_Model extends Vtiger_Field_Model {
 	 * @return boolean
 	 */
 	public function isDefaultValueOptionDisabled() {
+		if ($this->getName() == 'closingdate' && $this->block->module->name == 'Potentials') {
+			return false;
+		}
 		if($this->isUneditableFields()){
 			return true;
 		}

--- a/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1036,21 +1036,30 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 				if (dateField.length > 0) {
 					vtUtils.registerEventForDateFields(dateField);
 					var datedefaultvaluebox = document.getElementsByClassName("inputElement dateField form-control")[0];
-					if(datedefaultvaluebox.value == 'TODAY'){
+					if(datedefaultvaluebox.value == 'TODAY' || datedefaultvaluebox.value == ''){
 						datedefaultvaluebox.classList.add('ignore-validation');
 						datedefaultvaluebox.classList.remove('input-error');
+						if (typeof vtUtils.hideValidationMessage != 'undefined') {
+							vtUtils.hideValidationMessage(jQuery(datedefaultvaluebox));
+						}
 					}
 					else{
 						datedefaultvaluebox.classList.remove('ignore-validation');
 					}
-					dateField.on("change",function (e) {
-						if(datedefaultvaluebox.value == 'TODAY'){
+					dateField.on("keyup change",function (e) {
+						if(datedefaultvaluebox.value == 'TODAY' || datedefaultvaluebox.value == ''){
 							datedefaultvaluebox.classList.add('ignore-validation');
 							datedefaultvaluebox.classList.remove('input-error');
+							if (typeof vtUtils.hideValidationMessage != 'undefined') {
+								vtUtils.hideValidationMessage(jQuery(datedefaultvaluebox));
+							}
 						}
 						else{
 							datedefaultvaluebox.classList.remove('ignore-validation');
 							datedefaultvaluebox.classList.remove('input-error');
+							if (typeof vtUtils.hideValidationMessage != 'undefined') {
+								vtUtils.hideValidationMessage(jQuery(datedefaultvaluebox));
+							}
 						}
 					});	
 				}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #945 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. システム設定>モジュール管理>項目設定の案件の完了予定日において、デフォルト値を設定するための入力欄が表示されていなかった。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 日付型項目は一律でデフォルト値の設定ができないように制限されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. modules/Settings/LayoutEditor/models/Field.php：案件モジュールの完了予定日について、デフォルト値を設定できるように処理を追加。
2. public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js：TODAYという文字のリアルタイム監視や警告を消去する処理を追加。TODAYから日付に書き換えた際も古い警告が残らないように処理を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="702" height="610" alt="image" src="https://github.com/user-attachments/assets/416623c7-062a-422b-8a6f-df3c27fa2bcf" />

<img width="1736" height="495" alt="image" src="https://github.com/user-attachments/assets/bc807892-80ae-40dd-afc7-b40cbb5d3852" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
案件モジュールの完了予定日のみに影響

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->