### PR TITLE
Fix/1562-カレンダーの活動をドラッグしている最中に吹き出しが出て、移動先に指定できない時間帯がある

### DIFF
--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -2464,6 +2464,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	},
 	getCalendarConfigs: function () {
 		var thisInstance = this;
+		if (jQuery('#calendarDraggingStyle').length === 0) {
+			jQuery('<style id="calendarDraggingStyle">body.calendar-dragging .webui-popover { display: none !important; }</style>').appendTo('head');
+		}
 		var userDefaultActivityView = thisInstance.getDefaultCalendarView();
 		var userDefaultTimeFormat = thisInstance.getDefaultCalendarTimeFormat();
                 
@@ -2671,6 +2674,14 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			},
 			eventDrop: function (event, delta, revertFunc, jsEvent, ui, view) {
 				thisInstance.updateEventOnDrop(event, delta, revertFunc, jsEvent, ui, view);
+			},
+			eventDragStart: function (event, jsEvent, ui, view) {
+				jQuery('body').addClass('calendar-dragging');
+				jQuery('.webui-popover').hide();
+			},
+			eventDragStop: function (event, jsEvent, ui, view) {
+				jQuery('body').removeClass('calendar-dragging');
+				jQuery('.webui-popover').hide();
 			},
 			select: function (startDate, endDate, jsEvent, view){
 				thisInstance.performDayDragAction(startDate, endDate, jsEvent, view);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1562 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
カレンダー上で活動をドラッグして移動しているときに詳細を表示する吹き出しが表示され続け、移動先で見えなくなってしまい、指定できない時間帯がある。

##  原因 / Cause
<!-- バグの原因を記述 -->
吹き出しライブラリがドラッグ操作中のマウスの動きに対しても表示処理を実行してしまうため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
public/layouts/v7/modules/Calendar/resources/Calendar.js：ドラッグを開始した瞬間に吹き出しを消去する処理を追加。ドラッグ終了時には表示を再開させる処理も追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前はドラッグ中も吹き出しが表示される
<img width="1914" height="913" alt="2026-04-30 (3)" src="https://github.com/user-attachments/assets/f1e4672a-7034-44f0-84a3-fa00687a89d2" />

変更後はドラッグしていないときは表示、ドラッグ中は非表示
<img width="1920" height="913" alt="2026-04-30 (1)" src="https://github.com/user-attachments/assets/69566ac2-2acc-4aed-a568-c7d0029817ba" />
<img width="1927" height="919" alt="2026-04-30 (2)" src="https://github.com/user-attachments/assets/9c6fbcf9-2916-4475-a9f7-30360d5b83b1" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->