### PR TITLE
カレンダーにおいて活動の複製時、開始・終了時刻の選択肢がカレンダー設定の内容に応じた選択肢となっていない問題の修正

### DIFF
--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -2111,6 +2111,10 @@ Vtiger.Class("Calendar_Calendar_Js", {
 						// WebComponents版では record-id から GetRecord API でデータを取得するため、
 						// ここのデータは initialData として使われるが、recordData が優先される
 						// Note: eventObj.title は表示用（ステータス付き）のため使用しない
+						// 複製モードでも時刻選択肢をユーザーのカレンダー設定（活動時間）刻みにするため、
+						// 新規作成パスと同じく defaultCallDuration / defaultOtherEventDuration を渡す
+						var defaultCallDurationEl = document.getElementById('defaultCallDuration');
+						var defaultOtherEventDurationEl = document.getElementById('defaultOtherEventDuration');
 						triggerParams.data = {
 							// subject は eventObj.title ではなく eventObj.subject を使用
 							// eventObj.subject が undefined の場合もあるため、その場合は空文字
@@ -2128,7 +2132,9 @@ Vtiger.Class("Calendar_Calendar_Js", {
 							description: eventObj.description,
 							location: eventObj.location,
 							parent_id: eventObj.parent_id,
-							contact_id: eventObj.contact_id
+							contact_id: eventObj.contact_id,
+							defaultCallDuration: defaultCallDurationEl ? parseInt(defaultCallDurationEl.value, 10) || 5 : 5,
+							defaultOtherEventDuration: defaultOtherEventDurationEl ? parseInt(defaultOtherEventDurationEl.value, 10) || 5 : 5
 						};
 					}
 				}


### PR DESCRIPTION
##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 既存活動をカレンダー上から複製する際、開始・終了時刻にカレンダー設定のデフォルト単位が反映されていない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 活動の新規作成時と同様、カレンダー設定の「デフォルトの活動時間」を使用した選択肢とするよう修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->