### PR TITLE
カレンダー一覧画面のモバイル表示を調整

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -169,23 +169,6 @@ td.listViewEntryValue  .fieldValue .value {
   div.CalendarViewPageDiv {
     padding-top: 30px;
   }
-  .main-container.main-container-Calendar{
-    display: flex;
-    flex-wrap: nowrap;
-    flex-direction: column;
-  }
-  .main-container.main-container-Calendar 
-  .sidebar-essentials {
-    order: 0;
-  }  
-  .main-container.main-container-Calendar 
-  .listViewPageDiv {
-    order: 1;
-  }  
-  .main-container.main-container-Calendar 
-  .module-nav {
-    order: 2;
-  }  
   .list-menu-content.calendar_view_events .mCustomScrollBox {
     max-height: none!important;
     overflow: scroll;
@@ -233,12 +216,43 @@ td.listViewEntryValue  .fieldValue .value {
   position: static !important;
 }
 }
-@media (max-width: 991px) { 
+@media (max-width: 991px) {
   .main-container.calendarview{
     display: flex;
     flex-wrap: nowrap;
     flex-direction: column-reverse;
-  } 
+  }
+  .main-container.main-container-Calendar {
+    display: flex;
+    flex-wrap: nowrap;
+    flex-direction: column;
+  }
+  .main-container.main-container-Calendar .sidebar-essentials {
+    order: 0;
+  }
+  .main-container.main-container-Calendar .listViewPageDiv {
+    order: 1;
+  }
+  .main-container.main-container-Calendar .module-nav {
+    order: 2;
+    width: 100%;
+    z-index: 1100;
+    background-color: #2C3B49;
+    background: #2C3B49;
+  }
+  .main-container.main-container-Calendar .module-nav div.modules-menu {
+    position: relative;
+    left: auto;
+  }
+  .main-container.main-container-Calendar .module-nav div.mod-switcher-container {
+    width: 100%;
+  }
+  .main-container.main-container-Calendar .modules-menu ul li {
+    display: inline-block;
+  }
+  .main-container.main-container-Calendar .modules-menu ul li.module-qtip a > span {
+    display: none;
+  }
   .list-menu-content .activitytypes .activitytype-indicator {
     padding: 14px 5%;
     margin: 8px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1600 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 769px～991pxの間の横幅で表示を行うと、カレンダーの一覧画面においてサイドバーが画面を埋め尽くしてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. CSSの適用バグ

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 991px以下で、768px以下と同様、サイドバーを画面下部に移動するよう修正

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1512" height="1101" alt="image" src="https://github.com/user-attachments/assets/d2153afc-5ff7-4f22-8d8c-3302a7fdae0b" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
カレンダー一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->