### PR TITLE
fix/1531 製品・価格表の選択ポップアップで発生するエラーを修正

### DIFF
--- a/layouts/v7/modules/PriceBooks/ProductPriceBookPopupContents.tpl
+++ b/layouts/v7/modules/PriceBooks/ProductPriceBookPopupContents.tpl
@@ -81,7 +81,7 @@
                         {/if}
 
                         {foreach item=LISTVIEW_ENTRY from=$LISTVIEW_ENTRIES name=popupListView}
-                            {assign var="RECORD_DATA" value="{$LISTVIEW_ENTRY->getRawData()}"}
+                            {assign var="RECORD_DATA" value=$LISTVIEW_ENTRY->getRawData()}
                             <tr class="listViewEntries" data-id="{$LISTVIEW_ENTRY->getId()}" data-name='{$LISTVIEW_ENTRY->getName()}' data-currency='{$LISTVIEW_ENTRY->get('currency_id')}'
                                 {if $GETURL neq '' } data-url='{$LISTVIEW_ENTRY->$GETURL()}' {/if} id="{$MODULE}_popUpListView_row_{$smarty.foreach.popupListView.index+1}">
                                 <td class="{$WIDTHTYPE}">

--- a/layouts/v7/modules/Products/ProductsPopupContents.tpl
+++ b/layouts/v7/modules/Products/ProductsPopupContents.tpl
@@ -69,7 +69,7 @@
                     </thead>
                     {foreach item=LISTVIEW_ENTRY from=$LISTVIEW_ENTRIES name=popupListView}
                         {assign var="COL_NUMBER" value={$smarty.foreach.popupListView.index}}
-                        {assign var="RECORD_DATA" value="{$LISTVIEW_ENTRY->getRawData()}"}
+                        {assign var="RECORD_DATA" value=$LISTVIEW_ENTRY->getRawData()}
                         {assign var=EDITED_VALUE value=$SELECTED_RECORDS[$LISTVIEW_ENTRY->getId()]}
                         <tr class="listViewEntries" data-id="{$LISTVIEW_ENTRY->getId()}" {if $MODULE eq 'EmailTemplates'} data-name="{$RECORD_DATA['subject']}" data-info="{$LISTVIEW_ENTRY->get('body')}" {else} data-name="{$LISTVIEW_ENTRY->getName()}" data-info='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($LISTVIEW_ENTRY->getRawData()))}' {/if}
                             {if $GETURL neq ''} data-url='{$LISTVIEW_ENTRY->$GETURL()}' {/if}  id="{$MODULE}_popUpListView_row_{$smarty.foreach.popupListView.index+1}">


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1531 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. [製品]-[価格表]タブを選択し、「選択価格表」を選ぶとエラーが表示される
2. 製品のバンドルで「選択 製品」を行った場合もエラー

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 文字列型の変数に対して $string['key'] のように配列形式でアクセスできないこと

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 変数の代入時に余計な型変換を行わないように修正
2. layouts/v7/modules/PriceBooks/ProductPriceBookPopupContents.tpl、ProductsPopupCintents.tpl内の文字列化"{}"を削除
                         変更前   {assign var="RECORD_DATA" value="{$LISTVIEW_ENTRY->getRawData()}"}
                         変更後   {assign var="RECORD_DATA" value=$LISTVIEW_ENTRY->getRawData()}

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="1626" height="532" alt="image" src="https://github.com/user-attachments/assets/109a5318-44a3-4743-a3ce-d604c5c04bd6" />
変更後
<img width="1304" height="594" alt="image" src="https://github.com/user-attachments/assets/7c52abf7-292c-4910-850d-6102ea3ebc5c" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
製品の価格表選択および他モジュールから参照されるすべてのポップアップ選択画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->