### PR TITLE
#1606 [不具合] インポート 非表示にした必須項目があるとすべて失敗になる

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -822,7 +822,8 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		if ($fieldData != null && $checkMandatoryFieldValues) {
 			foreach ($moduleFields as $fieldName => $fieldInstance) {
 				if($moduleName == "Calendar" && in_array($fieldName, $skippedCalendarFields)) continue;
-				if ((($fieldData[$fieldName] == '') || ($fieldData[$fieldName] == null)) && $fieldInstance->isMandatory()) {
+				if ((($fieldData[$fieldName] == '') || ($fieldData[$fieldName] == null))
+					&& $fieldInstance->isMandatory() && $fieldInstance->getPresence() != 1) { 
 					if($moduleName == "Calendar" && $fieldData["activitytype"] != "Task" && $fieldName == "eventstatus" && !empty($fieldData["taskstatus"])){
 						$fieldData["eventstatus"] == $fieldData["taskstatus"];
 					}else if($moduleName == "Calendar" && $fieldData["activitytype"] == "Task" && $fieldName == "taskstatus" && !empty($fieldData["eventstatus"])){


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1606 

##  不具合の内容 / Bug
1. インポート時に非表示にした必須項目があるとすべて失敗になる

##  原因 / Cause
1. 非表示の必須項目もエラー判定に含まれていたから

##  変更内容 / Details of Change
1. 非表示の必須項目もエラー判定から除外

## 影響範囲  / Affected Area
インポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
