### PR TITLE
#1610 [不具合]顧客企業 番地（請求先）がテキストエリアなのに250文字以上入力できない

### DIFF
--- a/setup/migration/scripts/20260515014512_update_textarea_column.php
+++ b/setup/migration/scripts/20260515014512_update_textarea_column.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * マイグレーション: update_account_address
+ * 生成日時: 20260515014512
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260515014512_UpdateTextareaColumn extends FRMigrationClass {
+
+    /**
+     * 住所系 textarea カラム (uitype=21/24) と、メタデータ上 textarea (uitype=19)
+     * だが DB が varchar 固定長の項目を TEXT に拡張する。
+     * varchar(N) のままだと N 文字以上の入力がサイレントに切り捨てられるため。
+     * Issue: thinkingreed-inc/F-RevoCRM#1610
+     */
+    public function process() {
+        $db = PearDatabase::getInstance();
+        $this->log("マイグレーション update_textarea_column を開始しました");
+
+        $alterations = array(
+            // 顧客企業 (Accounts)
+            array('vtiger_accountbillads',  'bill_street'),
+            array('vtiger_accountshipads',  'ship_street'),
+            // 顧客担当者 (Contacts)
+            array('vtiger_contactaddress',  'mailingstreet'),
+            array('vtiger_contactaddress',  'otherstreet'),
+            // リード (Leads)
+            array('vtiger_leadaddress',     'lane'),
+            // 見積 (Quotes)
+            array('vtiger_quotesbillads',   'bill_street'),
+            array('vtiger_quotesshipads',   'ship_street'),
+            // 受注 (SalesOrder)
+            array('vtiger_sobillads',       'bill_street'),
+            array('vtiger_soshipads',       'ship_street'),
+            // 仕入注文 (PurchaseOrder)
+            array('vtiger_pobillads',       'bill_street'),
+            array('vtiger_poshipads',       'ship_street'),
+            // 請求書 (Invoice)
+            array('vtiger_invoicebillads',  'bill_street'),
+            array('vtiger_invoiceshipads',  'ship_street'),
+            // ユーザ (Users)
+            array('vtiger_users',           'address_street'),
+            // ModComments (コメント編集理由)
+            array('vtiger_modcomments',     'reasontoedit'),
+        );
+
+        foreach ($alterations as $target) {
+            list($table, $column) = $target;
+            $sql = "ALTER TABLE {$table} MODIFY COLUMN {$column} TEXT DEFAULT NULL";
+            $result = $db->pquery($sql, array());
+            if ($result === false) {
+                $this->log("[ERROR] {$table}.{$column} の TEXT 拡張に失敗しました: {$sql}");
+                continue;
+            }
+            $this->log("{$table}.{$column} を TEXT に拡張しました");
+        }
+
+        $this->log("マイグレーション update_textarea_column が正常に完了しました");
+    }
+}


### PR DESCRIPTION
他テキストエリアだが、varchar(x)併せて修正

##  関連Issue / Related Issue
- fix #1610

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 顧客企業の「番地 (請求先)」(bill_street) はテキストエリア (uitype=21) として表示されるが、
　テキストエリアの見た目から長文入力が可能と認識されるが、実際は250 文字までしか保持されない。

##  原因 / Cause
1. vtiger_field 上では uitype=19/21/24（textarea）として登録されているのに、
　対応する DB カラムが varchar(100) 〜varchar(250) の固定長で定義されている。

##  変更内容 / Details of Change
1. マイグレーションスクリプト setup/migration/scripts/20260515014512_update_textarea_column.php を追加。
2. textarea uitype + varchar 固定長になっていた 
　15 カラムを TEXT 型に拡張する ALTER TABLE ... MODIFY COLUMN <col> TEXT DEFAULT NULL  を順次発行する。
3. 対象カラム（9 モジュール / 14 テーブル / 15 カラム）:
    - 顧客企業 (Accounts): vtiger_accountbillads.bill_street, vtiger_accountshipads.ship_street
    - 顧客担当者 (Contacts): vtiger_contactaddress.mailingstreet, vtiger_contactaddress.otherstreet
    - リード (Leads): vtiger_leadaddress.lane
    - 見積 (Quotes): vtiger_quotesbillads.bill_street, vtiger_quotesshipads.ship_street
    - 受注 (SalesOrder): vtiger_sobillads.bill_street, vtiger_soshipads.ship_street
    - 仕入注文 (PurchaseOrder): vtiger_pobillads.bill_street, vtiger_poshipads.ship_street
    - 請求書 (Invoice): vtiger_invoicebillads.bill_street, vtiger_invoiceshipads.ship_street
    - ユーザ (Users): vtiger_users.address_street
    - ModComments: vtiger_modcomments.reasontoedit
4. 各 ALTER TABLE の pquery() 戻り値を === false で判定し、
　失敗時はテーブル名・カラム名・SQL をログに出力した上でcontinue で後続テーブルへ進む（部分適用は再実行で復旧可能）。

## スクリーンショット / Screenshot

## 影響範囲  / Affected Area
- 対象テーブル: 上記 14 テーブル（InnoDB / Dynamic row format / utf8mb3）。15 カラムが varchar(N) から TEXTに変更される。
- ALTER TABLE の実行時間:: MySQL では varchar → TEXT の変換は ALGORITHM=COPY となるケースが多く、
　行数の多いテーブル（vtiger_users / vtiger_modcomments 等）では一時的にテーブル書き込みロックが発生し得る。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

