### PR TITLE
#1616 受注の繰り返し請求情報ブロック内の非必須項目が必須扱いとなる不具合を修正

### DIFF
--- a/cron/modules/SalesOrder/RecurringInvoice.service
+++ b/cron/modules/SalesOrder/RecurringInvoice.service
@@ -22,7 +22,9 @@ $sql="SELECT vtiger_salesorder.salesorderid, recurring_frequency, start_period, 
 		 payment_duration, invoice_status FROM vtiger_salesorder
 		 INNER JOIN vtiger_crmentity ON vtiger_salesorder.salesorderid = vtiger_crmentity.crmid AND vtiger_crmentity.deleted = 0
 		 INNER JOIN vtiger_invoice_recurring_info ON vtiger_salesorder.salesorderid = vtiger_invoice_recurring_info.salesorderid
-		 WHERE DATE_FORMAT(start_period,'%Y-%m-%d') <= ? AND DATE_FORMAT(end_period,'%Y-%m-%d') >= ?";
+		 WHERE DATE_FORMAT(start_period,'%Y-%m-%d') <= ?
+			AND (end_period IS NULL OR end_period = '0000-00-00'
+				OR DATE_FORMAT(end_period,'%Y-%m-%d') >= ?)";
 $result = $adb->pquery($sql, array($currentDate, $currentDate));
 $no_of_salesorder = $adb->num_rows($result);
 
@@ -37,7 +39,7 @@ for($i=0; $i<$no_of_salesorder;$i++) {
 		$recurring_date = $start_period;
 	}
 
-	$endDateStrTime = strtotime($end_period);
+	$endDateStrTime = (!empty($end_period) && $end_period !== '0000-00-00') ? strtotime($end_period) : PHP_INT_MAX;
 	$recurringDateStrTime = strtotime($recurring_date);
 
 	if($recurringDateStrTime < $currentDateStrTime) {

--- a/public/layouts/v7/modules/SalesOrder/resources/Edit.js
+++ b/public/layouts/v7/modules/SalesOrder/resources/Edit.js
@@ -48,11 +48,20 @@ Inventory_Edit_Js("SalesOrder_Edit_Js",{},{
 		var thisInstance = this;
 		var form = this.getForm();
 		var enableRecurrenceField = form.find('[name="enable_recurring"]');
-		// Recurring Invoice Informationブロック内のフィールドを動的に取得（enable_recurring以外）
 		var recurringBlock = form.find('[data-block="Recurring Invoice Information"]');
 		var validationToggleFields = recurringBlock.find('input, select, textarea')
 			.filter('[name]')
 			.not('[name="enable_recurring"]');
+
+		var requiredOnEnableFields = ['recurring_frequency','start_period','payment_duration','invoicestatus'];
+		validationToggleFields.each(function() {
+			var el = jQuery(this);
+			var name = el.attr('name');
+			var isRequired = el.attr('data-rule-required') === 'true'
+				|| requiredOnEnableFields.indexOf(name) !== -1;
+			el.data('original-required', isRequired);
+		});
+
 		enableRecurrenceField.on('change',function(e){
 			var element = jQuery(e.currentTarget);
 			var addValidation = element.is(':checked');
@@ -60,16 +69,19 @@ Inventory_Edit_Js("SalesOrder_Edit_Js",{},{
 		});
 		thisInstance.AddOrRemoveRequiredValidation(validationToggleFields, enableRecurrenceField.is(':checked'));
 	},
-	
+
 	AddOrRemoveRequiredValidation : function(dependentFieldsForValidation, addValidation) {
 		jQuery(dependentFieldsForValidation).each(function(key,value){
 			var relatedField = jQuery(value);
+			var isOriginallyRequired = relatedField.data('original-required') === true;
 			if(addValidation) {
-				relatedField.removeClass('ignore-validation').data('rule-required', true);
 				if(relatedField.is("select")) {
 					relatedField.attr('disabled',false);
 				}else {
 					relatedField.removeAttr('disabled');
+				}
+				if(isOriginallyRequired) {
+					relatedField.removeClass('ignore-validation').data('rule-required', true);
 				}
 			} else if(!addValidation) {
 				relatedField.addClass('ignore-validation').removeAttr('data-rule-required');


### PR DESCRIPTION
##  関連Issue / Related Issue
  <!-- 関連Issueをfix #(番号)で記述 -->
  - fix #1616

  ##  不具合の内容 / Bug
  <!-- バグ,要望やIssue内容を簡潔に記述 -->
  1. 受注モジュールの「Recurring Invoice Information（繰り返し請求情報）」ブロックに任意項目（非必須）を追加し、ブロック以外に値を入れて保存すると、追加した非必須項目に対して必須チェックエラーが発生して保存できない。
  2. 「終了時期」も必須である必要がないのに、enable_recurring=ON 時に必須扱いになる。

  ##  原因 / Cause
  <!-- バグの原因を記述 -->
  1. PR #1415 のデグレ。`public/layouts/v7/modules/SalesOrder/resources/Edit.js` の `registerEventForEnablingRecurrence` で、繰り返し請求情報ブロック内のフィールド取得方法が固定リストからブロック内全フィールド取得（`recurringBlock.find('input, select,
  textarea')`）に変更された。
  2. enable_recurring=ON 時、`AddOrRemoveRequiredValidation` でブロック内全フィールドに対し一律 `data-rule-required=true` を付与していたため、フィールド定義上は非必須なフィールド（カスタム追加項目・終了時期等）まで必須化されていた。
  3. 副次的に、終了時期を必須から外すと `cron/modules/SalesOrder/RecurringInvoice.service` の SQL が `DATE_FORMAT(end_period,'%Y-%m-%d') >= ?` で NULL を False 扱いとし、終了時期空のレコードは invoice 自動生成対象から永久に除外される問題を発見。

  ##  変更内容 / Details of Change
  <!-- 行った修正を記述 -->
  1. `registerEventForEnablingRecurrence` 初期化時に、各フィールドの HTML 初期 `data-rule-required` を `data('original-required')` に保存。
  2. ON 時の必須対象として固定リスト（`recurring_frequency` / `start_period` / `payment_duration` / `invoicestatus`）を保持し、PR #1415 前の仕様を維持。`end_period` のみ issue 要望通り必須対象から除外。
  3. `AddOrRemoveRequiredValidation` で ON 時、`data('original-required') === true` のフィールドのみ `data-rule-required=true` を再付与。カスタム追加項目はフィールド定義の mandatory に従い必須化されないことを保証。
  4. disable/enable 切替および ignore-validation の制御はブロック内全フィールド対象を維持（入力可否制御は従来通り）。
  5. cron 側修正:
     - SQL WHERE 句で `end_period IS NULL OR end_period = '0000-00-00'` を許容
     - PHP 側で `$endDateStrTime` を空時に `PHP_INT_MAX` にフォールバックし、無期限繰り返しが機能するよう変更

  ## スクリーンショット / Screenshot
  <!-- 変更のスクリーンショットを添付 -->
 <img width="2188" height="425" alt="image" src="https://github.com/user-attachments/assets/52116860-e993-4297-881c-14d0710fda0f" />
<img width="2148" height="405" alt="image" src="https://github.com/user-attachments/assets/849b9a82-1211-42bb-b896-95c3604e174e" />


  ## 影響範囲  / Affected Area
  <!-- このプルリクエストにより、影響が想定される範囲を記述 -->
  - 受注（SalesOrder）モジュールの編集画面 / 新規作成画面
    - 「繰り返し請求情報」ブロックの enable_recurring チェックボックス切替時の必須バリデーション挙動
  - 繰り返し請求 cron 処理
    - 終了時期が空の SalesOrder に対する Invoice 自動生成挙動

  ## チェックリスト / Check List
  <!-- カッコ内にxを記入 -->
  - [x] 自らテストを行った
  - [x] 不必要な変更が無い
  - [x] 影響範囲の検討を行った
  - [x] 言語対応（日・英）を行った

  ## 備考 / Remarks
  <!-- その他、特記すべき事項を記述 -->
