### PR TITLE
Fix/1558 日報モジュールの「日報/週報」の項目を選択できないように修正

### DIFF
--- a/modules/Settings/Picklist/models/Module.php
+++ b/modules/Settings/Picklist/models/Module.php
@@ -17,9 +17,17 @@ class Settings_Picklist_Module_Model extends Vtiger_Module_Model {
 	public function getFieldsByType($type) {
 		$presence = array('0','2');
 
+		$excludedFields = array(
+			'Dailyreports' => array('reportsterm'),
+		);
+		$moduleName = $this->getName();
+
 		$fieldModels = parent::getFieldsByType($type);
 		$fields = array();
 		foreach($fieldModels as $fieldName=>$fieldModel) {
+			if (isset($excludedFields[$moduleName]) && in_array($fieldName, $excludedFields[$moduleName])) {
+				continue;
+			}
 			if(($fieldModel->get('displaytype') != '1' && $fieldName != 'salutationtype') || !in_array($fieldModel->get('presence'),$presence)) {
 				continue;
 			}

--- a/public/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
+++ b/public/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
@@ -52,6 +52,15 @@ var Settings_Picklist_Js = {
 				jQuery('#modulePickListValuesContainer').html(data);
 				vtUtils.showSelect2ElementView(jQuery('#rolesList'));
 				Settings_Picklist_Js.registerItemActions();
+				
+				//「モジュール名：Dailyreports（日報）」と「フィールドID：834（日報/週報）」で判定する
+				var selectedModule = jQuery('#pickListModules').val();
+				var selectedFieldId = jQuery('#modulePickList').val();
+
+				if (selectedModule === 'Dailyreports' && selectedFieldId === '834') {
+					jQuery('#addItem').hide();
+					jQuery('.renameItem, .deleteItem').hide();
+				}
 				app.helper.hideProgress();
 			})
 		})

--- a/public/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
+++ b/public/layouts/v7/modules/Settings/Picklist/resources/Picklist.js
@@ -52,15 +52,6 @@ var Settings_Picklist_Js = {
 				jQuery('#modulePickListValuesContainer').html(data);
 				vtUtils.showSelect2ElementView(jQuery('#rolesList'));
 				Settings_Picklist_Js.registerItemActions();
-				
-				//「モジュール名：Dailyreports（日報）」と「フィールドID：834（日報/週報）」で判定する
-				var selectedModule = jQuery('#pickListModules').val();
-				var selectedFieldId = jQuery('#modulePickList').val();
-
-				if (selectedModule === 'Dailyreports' && selectedFieldId === '834') {
-					jQuery('#addItem').hide();
-					jQuery('.renameItem, .deleteItem').hide();
-				}
 				app.helper.hideProgress();
 			})
 		})


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1558 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 日報モジュールの「日報/週報」の選択肢を変更できてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 他のモジュールと同様に「選択肢項目の選択」で「日報/週報」が表示されていて、選択肢を追加・削除・編集が可能になっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1.  modules/Settings/Picklist/models/Module.php の getFieldsByType()で、日報モジュールを指定し、「日報/週報」を選択肢項目の選択に表示しないようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
**変更前**
<img width="298" height="106" alt="image" src="https://github.com/user-attachments/assets/b5c5603a-7b53-4ed5-888c-b044437df8b4" />


**変更後**
<img width="334" height="88" alt="image" src="https://github.com/user-attachments/assets/d60e647c-4f2e-484b-9daa-94de954c47bb" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
選択肢エディタのモジュール「日報」、選択肢「日報/週報」

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
「役割に割り当てる選択肢」の修正は行っていない。