### PR TITLE
バグ修正: ドキュメントの選択状態とフォルダ絞り込みの不具合を修正 (#1623)

### DIFF
--- a/layouts/v7/modules/Documents/MoveDocuments.tpl
+++ b/layouts/v7/modules/Documents/MoveDocuments.tpl
@@ -14,8 +14,8 @@
 		<form class="form-horizontal contentsBackground" id="moveDocuments" method="post" action="index.php">
 			<input type="hidden" name="module" value="{$MODULE}" />
 			<input type="hidden" name="action" value="MoveDocuments" />
-			<input type="hidden" name="selected_ids" value={ZEND_JSON::encode($SELECTED_IDS)} />
-			<input type="hidden" name="excluded_ids" value={ZEND_JSON::encode($EXCLUDED_IDS)} />
+			<input type="hidden" name="selected_ids" value='{ZEND_JSON::encode($SELECTED_IDS)}' />
+			<input type="hidden" name="excluded_ids" value='{ZEND_JSON::encode($EXCLUDED_IDS)}' />
 			<input type="hidden" name="viewname" value="{$VIEWNAME}" />
             <input type="hidden" name="search_key" value= "{$SEARCH_KEY}" />
             <input type="hidden" name="operator" value="{$OPERATOR}" />

--- a/modules/Documents/views/List.php
+++ b/modules/Documents/views/List.php
@@ -96,12 +96,8 @@ class Documents_List_View extends Vtiger_List_View {
 		if(empty($listHeaders)) {
 			$listHeaders = $orderParams['list_headers'];
 		}
-		global $log;
-		$log->fatal(var_export($_REQUEST,true));
 		if(empty($orderBy) && empty($searchValue) && empty($pageNumber)) {
 			$orderParams = Vtiger_ListView_Model::getSortParamsSession($listViewSessionKey);
-			$log->fatal(var_export($orderParams,true));
-			$log->fatal($listViewSessionKey);
 			if($orderParams) {
 				$pageNumber = $orderParams['page'];
 				$orderBy = $orderParams['orderby'];

--- a/public/layouts/v7/modules/Documents/resources/List.js
+++ b/public/layouts/v7/modules/Documents/resources/List.js
@@ -8,12 +8,15 @@
  ************************************************************************************/
 
 Vtiger_List_Js("Documents_List_Js", {
-    
+
     massMove : function(url) {
-        var self = new Documents_List_Js();
+        // チェックボックスのクリックハンドラは app.controller() が返すインスタンスの
+        // tracker に紐付いている。new で別インスタンスを作ると別 tracker を参照することになり、
+        // 「未選択」誤判定の原因になるため、必ず app.controller() を使う。
+        var self = app.controller();
         self.massMove(url);
     }
-    
+
 }, {
     
     registerSearchEvent : function(container) {
@@ -68,7 +71,20 @@ Vtiger_List_Js("Documents_List_Js", {
                         });
                     }
                     app.helper.hideModal();
-                    self.loadListViewRecords();
+                    // 移動済みドキュメントが選択トラッカーに残ったままだと、
+                    // 次回の選択時に併せて再送信されてしまうため、ここでクリアする。
+                    // tracker は app.controller() 側に紐付いているのでそちらを使う。
+                    var listInstance = app.controller();
+                    if (listInstance && typeof listInstance.clearList === 'function') {
+                        listInstance.clearList();
+                    }
+                    jQuery('.listViewEntriesMainCheckBox').prop('checked', false);
+                    jQuery('.listViewEntriesCheckBox').prop('checked', false);
+                    if (listInstance && typeof listInstance.loadListViewRecords === 'function') {
+                        listInstance.loadListViewRecords();
+                    } else {
+                        self.loadListViewRecords();
+                    }
                 });
             } else {
                 app.helper.showAlertNotification({
@@ -86,7 +102,10 @@ Vtiger_List_Js("Documents_List_Js", {
     
     massMove : function(url) {
         var self = this;
-        var listInstance = Vtiger_List_Js.getInstance();
+        // Vtiger_List_Js.getInstance() は app.controller() と別のシングルトンを返してしまう。
+        // ユーザーのチェック操作は app.controller() の tracker に反映されるため、
+        // 検証もこちらの tracker で行う必要がある。
+        var listInstance = app.controller();
 		var validationResult = listInstance.checkListRecordSelected();
 		if(!validationResult){
 			var selectedIds = listInstance.readSelectedIds(true);
@@ -194,7 +213,11 @@ Vtiger_List_Js("Documents_List_Js", {
     registerFiltersClickEvent : function() {
         var self = this;
         var filters = jQuery('#module-filters');
-        filters.on('click', '.listViewFilter', function() {
+        // mousedown を使い、サイドバーの click ハンドラ（loadFilter → getDefaultParams で
+        // .documentFolder.active を参照）より前にフォルダの active を解除する。
+        // そうしないと「すべて」クリック直後の getDefaultParams が前回の folder_value を拾い、
+        // 「すべて」リストなのに前のフォルダで絞り込まれてしまう。
+        filters.on('mousedown', '.listViewFilter', function() {
             self.unMarkAllFolders();
         });
     },


### PR DESCRIPTION
fix #1623 
ドキュメントモジュールのリスト上で、フォルダ移動操作を行うと
意図しないドキュメントが移動される／「すべて」をクリックしても
直前のフォルダで絞り込まれる、といった不具合を修正する。

##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1623

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. Issue二記載

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
- 「すべて」クリック時のフォルダフィルタ漏れを修正 サイドバーの click ハンドラより前に folder の active を解除する必要があったため、 mousedown で同期的に解除するよう変更。これにより getDefaultParams が古い folder_value を拾わなくなる。
- 選択トラッカーの整合性を修正 Vtiger_List_Js.getInstance() と app.controller() は別シングルトンを返すため、 チェックボックスのクリックを受け取る tracker と検証時に参照される tracker が 食い違い、「未選択」誤判定や意図しない一括移動が起きていた。 Documents 側の massMove / registerMoveDocumentsEvent では app.controller() に統一し、移動完了後に clearList を呼んで残留状態を消すようにした。
- 移動先テンプレートの hidden input をクォート value 属性が引用符無しで JSON を出力していたため、HTML5 パーサの parse error を踏んでいた。シングルクォートで囲んで明示。
- 残置していたデバッグログを削除 views/List.php の $log->fatal による $_REQUEST ダンプを削除。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
