### PR TITLE
#1625 [不具合] PDFテンプレート 一覧画面の一括削除が動作しない（PHP 8 環境）

### DIFF
--- a/modules/PDFTemplates/actions/MassDelete.php
+++ b/modules/PDFTemplates/actions/MassDelete.php
@@ -39,20 +39,27 @@ class PDFTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 		$selectedIds = $request->get('selected_ids');
 		$excludedIds = $request->get('excluded_ids');
 
+		// $systemTemplate は「選択レコードにシステムテンプレートが含まれていた」フラグ。
+		// PHP 8 では未定義変数の参照が Warning（display_errors=on で JSON レスポンスを破壊）になるため
+		// 必ず先に初期化する。
+		$systemTemplate = false;
+
 		if($selectedIds == 'all' && empty($excludedIds)){
 			$recordModel->deleteAllRecords();
 		}else{
-			$recordIds = $this->getRecordsListFromRequest($request, $recordModel);
-			foreach($recordIds as $recordId) {
-				$recordModel = PDFTemplates_Record_Model::getInstanceById($recordId);
-				if($recordModel->isSystemTemplate()) {
-                    $systemTemplate = true;
-                } else {
-                    $recordModel->delete();
-                }
+			$recordIds = $this->getRecordsListFromRequest($request);
+			if (is_array($recordIds)) {
+				foreach($recordIds as $recordId) {
+					$recordModel = PDFTemplates_Record_Model::getInstanceById($recordId);
+					if($recordModel->isSystemTemplate()) {
+						$systemTemplate = true;
+					} else {
+						$recordModel->delete();
+					}
+				}
 			}
 		}
-		
+
 		$response = new Vtiger_Response();
 		if($systemTemplate) {
 			 $response->setError('502', vtranslate('LBL_NO_PERMISSIONS_TO_DELETE_SYSTEM_TEMPLATE', $moduleName));
@@ -61,20 +68,32 @@ class PDFTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 		}
 		$response->emit();
 	}
-	
-	public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel) {
+
+	/**
+	 * 親 Vtiger_Mass_Action::getRecordsListFromRequest と同シグネチャでオーバーライドする。
+	 *
+	 * PHP 8 では子クラスのメソッドシグネチャを親と非互換に変更すると Fatal Error になる。
+	 * 以前は第2引数 $recordModel を受け取っていたが、PHP 8 で互換性違反となり MassDelete
+	 * アクションのロード自体が失敗し、ボタン押下時に何も削除されない不具合となっていた。
+	 * 必要な ModuleModel はメソッド内で再構築する。
+	 *
+	 * @param Vtiger_Request $request
+	 * @return array|null
+	 */
+	protected function getRecordsListFromRequest(Vtiger_Request $request) {
 		$selectedIds = $request->get('selected_ids');
 		$excludedIds = $request->get('excluded_ids');
-		
+
 		if(!empty($selectedIds) && $selectedIds != 'all') {
-			if(!empty($selectedIds) && php7_count($selectedIds) > 0) {
+			if(php7_count($selectedIds) > 0) {
 				return $selectedIds;
 			}
 		}
 		if(!empty($excludedIds)){
-			$moduleModel = $recordModel->getModule();
-			$recordIds  = $moduleModel->getRecordIds($excludedIds);
+			$moduleModel = Vtiger_Module_Model::getInstance('PDFTemplates');
+			$recordIds = $moduleModel->getRecordIds($excludedIds);
 			return $recordIds;
 		}
+		return null;
 	}
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1625 

##  不具合の内容 / Bug
  1. PDFテンプレート一覧画面（`?module=PDFTemplates&view=List`）でレコードのチェックボックスを ON にし、一括削除ボタン
  (`PDFTemplates_listView_massAction_LBL_DELETE`)
  を押下、確認ダイアログ「削除しますか？」で「Yes」を押下しても、選択したレコードが削除されない。PHP 8.x 環境で発生。

  ##  原因 / Cause
  <!-- バグの原因を記述 -->
  1. `PDFTemplates_MassDelete_Action::getRecordsListFromRequest()` のメソッドシグネチャが、親クラス
  `Vtiger_Mass_Action::getRecordsListFromRequest()` と非互換だった。
     - 親: `protected function getRecordsListFromRequest(Vtiger_Request $request)`
     - 子: `public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel)`（余分な第 2 引数あり）
  2. PHP 7.x ではこれは Warning のみで処理は続行されていたが、PHP 8.0+ ではクラスロード時点で Fatal Error
  となり、MassDelete アクション自体が起動できない状態であった。
  3. クライアント側 (`PDFTemplates_List_Js.massDeleteRecords`) は Ajax レスポンスのエラーを検査せず、成功時と同じく
  `clearList()` → `loadListViewRecords()`
  を呼んでリストを再描画するため、ユーザには「削除されない」現象として観測される。

  ##  変更内容 / Details of Change
  <!-- 行った修正を記述 -->
  1. `modules/PDFTemplates/actions/MassDelete.php` の `getRecordsListFromRequest()` を親と同シグネチャ (`protected
  function getRecordsListFromRequest(Vtiger_Request $request)`) に修正。第 2 引数 `$recordModel` を撤去し、メソッド内で
  `Vtiger_Module_Model::getInstance('PDFTemplates')` から再取得するよう変更。
  2. `$systemTemplate` 変数を `process()` 冒頭で `false`
  に初期化。選択レコードがすべて非システムテンプレートの場合に未定義参照になり、PHP 8 で Warning が発生して
  `display_errors=on` の環境では JSON レスポンスが破壊される問題を防止。
  3. `$recordIds` が null の場合の `foreach` 警告を避けるため、`is_array($recordIds)` ガードを追加。

  ## スクリーンショット / Screenshot

  ## 影響範囲  / Affected Area
  <!-- このプルリクエストにより、影響が想定される範囲を記述 -->
  - 影響モジュール: PDFテンプレート（`PDFTemplates`）のみ
  - 影響機能: 一括削除（MassDelete）。個別レコード削除（DeleteAjax）は影響なし
  - 影響 PHP バージョン: PHP 8.0 以上で動作復活、PHP 7.x では従来通り（既に動作していたため挙動変化なし）
  - システムテンプレート（`systemtemplate=1`）の削除制限は維持

  ## チェックリスト / Check List
  <!-- カッコ内にxを記入 -->
  - [x] 自らテストを行った
  - [x] 不必要な変更が無い
  - [x] 影響範囲の検討を行った
  - [x] 言語対応（日・英）を行った（※新規文言追加なし。既存翻訳に影響なし）
## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->