### PR TITLE
Fix/1529-[不具合] 見積のインポートに失敗する

### DIFF
--- a/include/Webservices/LineItem/VtigerLineItemOperation.php
+++ b/include/Webservices/LineItem/VtigerLineItemOperation.php
@@ -323,14 +323,14 @@ class VtigerLineItemOperation extends VtigerActorOperation {
 		$quantity = $element['quantity'];
 		$discount_amount = $element['discount_amount'];
 		$discount_percent = $element['discount_percent'];
-		$productTotal = $listPrice * $quantity;
+		$productTotal = (double)$listPrice * (double)$quantity;
 		$total_after_discount = $productTotal;
 
 		if (!empty($discount_amount)) {
 			$total_after_discount -= $discount_amount;
 		}
 		if (!empty($discount_percent)) {
-			$percentage_discount = ($productTotal * $discount_percent) / 100;
+			$percentage_discount = ((double)$productTotal * (double)$discount_percent) / 100;
 			$total_after_discount -= $percentage_discount;
 		}
 
@@ -505,7 +505,7 @@ class VtigerLineItemOperation extends VtigerActorOperation {
 		if(!empty($parent['hdnDiscountAmount']) && ((double)$parent['hdnDiscountAmount']) > 0){
 			$discount = ($parent['hdnDiscountAmount']);
 		} elseif(!empty($parent['hdnDiscountPercent'])){
-			$discount = ($parent['hdnDiscountPercent']/100 * $parent['hdnSubTotal']);
+			$discount = ((double)$parent['hdnDiscountPercent']/100 * (double)$parent['hdnSubTotal']);
 		} else {
 			$discount = 0;
 		}
@@ -526,7 +526,7 @@ class VtigerLineItemOperation extends VtigerActorOperation {
 			}
 			$taxAmountsList = array();
 			foreach ($this->taxList as $taxName => $taxInfo) {
-				$taxAmountsList[$allTaxes[$taxName]['taxid']] = array('percentage' => $taxInfo['percentage'], 'amount' => ($taxTotal * $taxInfo['percentage']) / 100);
+				$taxAmountsList[$allTaxes[$taxName]['taxid']] = array('percentage' => $taxInfo['percentage'], 'amount' => ((double)$taxTotal * (double)$taxInfo['percentage']) / 100);
 			}
 
 			foreach ($taxAmountsList as $taxId => $taxInfo) {
@@ -535,7 +535,7 @@ class VtigerLineItemOperation extends VtigerActorOperation {
 					foreach ($compoundOn[$taxId] as $comTaxId) {
 						$amount += $taxAmountsList[$comTaxId]['amount'];
 					}
-					$taxInfo['amount'] = $taxAmountsList[$taxId]['amount'] = ($amount * $taxInfo['percentage']) / 100;
+					$taxInfo['amount'] = $taxAmountsList[$taxId]['amount'] = ((double)$amount * (double)$taxInfo['percentage']) / 100;
 				}
 
 				$taxAmount += $taxInfo['amount'];

--- a/include/utils/InventoryUtils.php
+++ b/include/utils/InventoryUtils.php
@@ -1378,14 +1378,24 @@ function createRecords($obj) {
 		}
 
 		if (!empty($lineItems)) {
-			if(method_exists($focus, 'importRecord')) {
+			$queryGenerator = new QueryGenerator($moduleName, $obj->user);
+			$queryGenerator->setFields(array('id'));
+			$queryGenerator->addCondition('subject', $row['subject'], 'e');
+			$checkQuery = $queryGenerator->getQuery();
+			$checkResult = $adb->pquery($checkQuery, array());
+
+			if ($adb->num_rows($checkResult) > 0) {
+				$entityInfo = array('status' => $obj->getImportRecordStatus('skipped'));
+			}
+
+			if(empty($entityInfo) && method_exists($focus, 'importRecord')) {
 				$entityInfo = $focus->importRecord($obj, $fieldData, $lineItems, $cache);
 			}
 		}
 
 		if($entityInfo == null) {
 			$entityInfo = array('id' => null, 'status' => $obj->getImportRecordStatus('failed'));
-		} else {
+		} else if ($entityInfo['status'] != $obj->getImportRecordStatus('skipped')) {
 			$entityIdComponents = vtws_getIdComponents($entityInfo['id']);
 			$createdRecords[] = $entityIdComponents[1];
 		}
@@ -1439,15 +1449,16 @@ function isRecordExistInDB($fieldData, $moduleMeta, $user, $cache) {
 				} else if (strpos($fieldValue, ':::') > 0) {
 					$fieldValueDetails = explode(':::', $fieldValue);
 				} else {
-					$fieldValueDetails = $fieldValue;
+					$fieldValueDetails = array($fieldValue);
 				}
+				$fieldDetails = array();
 				foreach($fieldValueDetails as $fieldValueDetail){
 					if (strpos($fieldValueDetail, '====') > 0) {
 						$fieldDetail = explode('====', $fieldValueDetail);
 						$fieldDetails[$fieldDetail[0]] = $fieldDetail[1];
 					}
 				}
-				if (php7_count($fieldValueDetails) > 1) {
+				if (php7_count($fieldValueDetails) > 1 && !empty($fieldDetails)) {
 					$referenceModuleName = trim($fieldValueDetails[0]);
 					$referenceValueList = $fieldDetails;
 					$entityId = getEntityIdByColumns($referenceModuleName, $referenceValueList, $cache);
@@ -1456,10 +1467,14 @@ function isRecordExistInDB($fieldData, $moduleMeta, $user, $cache) {
 					$entityLabel = $fieldValue;
 					foreach ($referencedModules as $referenceModule) {
 						$referenceModuleName = $referenceModule;
-						$referenceEntityId = getEntityIdByColumns($referenceModule, $entityLabel,$cache);
-						if ($referenceEntityId != 0) {
-							$entityId = $referenceEntityId;
-							break;
+						try {
+							$referenceEntityId = getEntityIdByColumns($referenceModule, $entityLabel,$cache);
+							if ($referenceEntityId != 0) {
+								$entityId = $referenceEntityId;
+								break;
+							}
+						} catch (ImportException $e) {
+							continue;
 						}
 					}
 				}
@@ -1659,6 +1674,9 @@ function getInventoryImportableMandatoryFeilds($module) {
 	$mandatoryFields = array();
 	foreach($moduleFields as $fieldName => $fieldInstance) {
 		if($fieldInstance->isMandatory() && $fieldInstance->getFieldDataType() != 'owner' && $moduleMeta->isEditableField($fieldInstance)) {
+			if ($module == 'SalesOrder' && $fieldName == 'invoicestatus') {
+				continue;
+			}
 			$mandatoryFields[$fieldName] = vtranslate($fieldInstance->getFieldLabelKey(), $module);
 		}
 	}

--- a/include/utils/ListViewUtils.php
+++ b/include/utils/ListViewUtils.php
@@ -675,23 +675,39 @@ function getEntityIdByColumns($module, $referenceValueList, $cache) {
 	}
 
     $matchedIds = [];
-    foreach ($cache[$module] as $recordModel) {
-        $filterCache = array_intersect_key($recordModel, $referenceValueList);
-		ksort($referenceValueList);
-		ksort($filterCache);
-        if ($filterCache === $referenceValueList) {
-            $cacheValues = array_values($recordModel);
-			$matchedIds[] = $cacheValues[0];
+    if (is_array($referenceValueList)) {
+        foreach ($cache[$module] as $recordModel) {
+            $filterCache = array_intersect_key($recordModel, $referenceValueList);
+            ksort($referenceValueList);
+            ksort($filterCache);
+            if ($filterCache === $referenceValueList) {
+                $cacheValues = array_values($recordModel);
+                $matchedIds[] = $cacheValues[0];
+            }
         }
+    } else {
+        $entityNameInfo = getEntityFieldNames($module);
+        $fieldNames = $entityNameInfo['fieldname'];
+        if (!is_array($fieldNames)) {
+            $fieldNames = array($fieldNames);
+        }
+        foreach ($cache[$module] as $recordModel) {
+            foreach ($fieldNames as $fieldName) {
+                if ((trim($recordModel[$fieldName] ?? '') === trim($referenceValueList))) {
+                    $cacheValues = array_values($recordModel);
+                    $matchedIds[] = $cacheValues[0];
+                    break;
+                }
+            }
+        	}
     }
 
 	if (count($matchedIds) !== 1) {
-		throw new ImportException("No reference exists");
-    }
+	        throw new ImportException("No reference exists");
+	}
 
-    return $matchedIds[0];
-}
-
+	return $matchedIds[0];
+	}
 function decode_emptyspace_html($str){
 	$str = str_replace("&nbsp;", "*#chr*#",$str); // (*#chr*#) used as jargan to replace it back with &nbsp;
 	$str = str_replace("\xc2", "*#chr*#",$str); // Ã (for special chrtr)

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -618,7 +618,11 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 								} elseif ($referenceModule == 'Currency') {
 									$referenceEntityId = getCurrencyId($entityLabel);
 								} else {
-									$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
+									try {
+										$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
+									} catch (ImportException $e) {
+										$referenceEntityId = 0;
+									}
 								}
 								if ($referenceEntityId != 0) {
 									$entityId = $referenceEntityId;
@@ -664,9 +668,14 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					if (isset($importDefaultValues[$fieldName]) && !empty($importDefaultValues[$fieldName])) {
 						$fieldValue = $importDefaultValues[$fieldName];
 					} else {
+						$skippedInventoryFields = array(
+							'SalesOrder' => array('invoicestatus')
+						);
 						// 必須項目で空の場合はエラー
 						if ($fieldInstance->isMandatory()) {
-							return null;
+							if (!(isset($skippedInventoryFields[$moduleName]) && in_array($fieldName, $skippedInventoryFields[$moduleName]))) {
+								return null;
+							}
 						}
 						// 必須でなければ空のまま
 						$fieldData[$fieldName] = '';
@@ -688,6 +697,13 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				foreach($allPicklistDetails as $picklistDetails){
 					if($fieldValue == $picklistDetails['label']){
 						$fieldValue = $picklistDetails['value'];
+						break;
+					}
+					// 翻訳後の値とも比較する（hdnTaxTypeなど の特殊なフィールド用）
+					$translatedValue = vtranslate($picklistDetails['value'], $moduleName);
+					if (trim($fieldValue) === trim($translatedValue)) {
+						$fieldValue = $picklistDetails['value'];
+						break;
 					}
 				}
 
@@ -735,7 +751,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					$valuesList = explode(' ', $fieldValue);
 					if(php7_count($valuesList) == 1) $fieldValue = '';
 					$fieldValue = getValidDBInsertDateTimeValue($fieldValue);
-					if (preg_match("/^[0-9]{2,4}[-][0-1]{1,2}?[0-9]{1,2}[-][0-3]{1,2}?[0-9]{1,2} ([0-1][0-9]|[2][0-3])([:][0-5][0-9]){1,2}$/",
+					if (preg_match("/^[0-9]{2,4}[-][0-1]{1,2}?[0-9]{1,2}[-][0-3]{1,2}?[0-9]{1,2}( ([0-1][0-9]|[2][0-3])([:][0-5][0-9]){1,2})?$/",
 							$fieldValue) == 0) {
 						$fieldValue = '';
 					}
@@ -818,10 +834,14 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		}
 
 		$skippedCalendarFields = array('contact_id', 'duration_hours', 'duration_minutes', 'recurringtype', 'reminder_time', 'smcreatorid');
+		$skippedInventoryFields = array(
+			'SalesOrder' => array('invoicestatus')
+		);
 
 		if ($fieldData != null && $checkMandatoryFieldValues) {
 			foreach ($moduleFields as $fieldName => $fieldInstance) {
 				if($moduleName == "Calendar" && in_array($fieldName, $skippedCalendarFields)) continue;
+				if(isset($skippedInventoryFields[$moduleName]) && in_array($fieldName, $skippedInventoryFields[$moduleName])) continue;
 				if ((($fieldData[$fieldName] == '') || ($fieldData[$fieldName] == null)) && $fieldInstance->isMandatory()) {
 					if($moduleName == "Calendar" && $fieldData["activitytype"] != "Task" && $fieldName == "eventstatus" && !empty($fieldData["taskstatus"])){
 						$fieldData["eventstatus"] == $fieldData["taskstatus"];
@@ -1294,13 +1314,25 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 		//関連項目が入っている項目を取得
 		$referenceColumns = array();
-		foreach($moduleFields as $fieldname => $moduleField){
-			if($moduleField != null){
-				$fieldDataType = $moduleField->getFieldDataType();
-				if ($fieldDataType == 'reference'){
-					array_push($referenceColumns, $fieldname);
-				}
-			}			
+		$allModuleFields = array($moduleFields);
+		$inventoryModules = array('Quotes', 'SalesOrder', 'PurchaseOrder', 'Invoice');
+		if (in_array($this->module, $inventoryModules)) {
+			$lineItemHandler = vtws_getModuleHandlerFromName('LineItem', $this->user);
+			$lineItemMeta = $lineItemHandler->getMeta();
+			$allModuleFields[] = $lineItemMeta->getModuleFields();
+		}
+
+		foreach ($allModuleFields as $mFields) {
+			foreach($mFields as $fieldname => $moduleField){
+				if($moduleField != null){
+					$fieldDataType = $moduleField->getFieldDataType();
+					if ($fieldDataType == 'reference'){
+						if (!in_array($fieldname, $referenceColumns)) {
+							array_push($referenceColumns, $fieldname);
+						}
+					}
+				}			
+			}
 		}
 
 		// 価格表の時はrelatedtoを追加
@@ -1325,29 +1357,53 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					} else if (strpos($referencevalue, ':::') > 0) {
 						$fieldValueDetails = explode(':::', $referencevalue);
 					} else {
-						$fieldValueDetails = $referencevalue;
+						$fieldValueDetails = array($referencevalue);
 					}
 
 					foreach($fieldValueDetails as $fieldValueDetail){
 						if (strpos($fieldValueDetail, '====') > 0) {
 							$fieldDetail = explode('====', $fieldValueDetail);
-							if ((!$columnsForCache[$fieldValueDetails[0]])){
+							if (!isset($columnsForCache[$fieldValueDetails[0]])){
 								$columnsForCache[$fieldValueDetails[0]] = array();
 							}
 							if (!in_array($fieldDetail[0],$columnsForCache[$fieldValueDetails[0]])){
 								array_push($columnsForCache[$fieldValueDetails[0]],$fieldDetail[0]);
+							}
+						} else if (php7_count($fieldValueDetails) == 1) {
+							$fieldInstance = null;
+							foreach ($allModuleFields as $mFields) {
+								if (isset($mFields[$referenceColumn])) {
+									$fieldInstance = $mFields[$referenceColumn];
+									break;
+								}
+							}
+							if ($fieldInstance) {
+								$referencedModules = $fieldInstance->getReferenceList();
+								foreach ($referencedModules as $refModule) {
+									$entityNameInfo = getEntityFieldNames($refModule);
+									if (!$entityNameInfo) continue;
+									$fieldNames = $entityNameInfo['fieldname'];
+									if (!is_array($fieldNames)) $fieldNames = array($fieldNames);
+									if (!isset($columnsForCache[$refModule])) $columnsForCache[$refModule] = array();
+									foreach ($fieldNames as $fn) {
+										if (!in_array($fn, $columnsForCache[$refModule])) {
+											array_push($columnsForCache[$refModule], $fn);
+										}
+									}
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-		
+
 		// キャッシュを作成
 		$cache = array();
 		foreach($columnsForCache as $module => $columns){
 			$query = "select fieldname,tablename,entityidfield from vtiger_entityname where modulename = ?";
 			$result = $adb->pquery($query, array($module));
+			if (!$result || $adb->num_rows($result) == 0) continue;
 			$tablename = $adb->query_result($result, 0, 'tablename');
 			$entityidfield = $adb->query_result($result, 0, 'entityidfield');
 
@@ -1355,20 +1411,18 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			$result = $adb->pquery($sql,array());
 
 			$noOfRows = $adb->num_rows($result);
-			$recordModels = [];
-			$recordModel = [];
 			for ($i = 0; $i < $noOfRows; ++$i) {	
-				$row = $adb->query_result_rowdata($result, $i,);
+				$row = $adb->query_result_rowdata($result, $i);
 				$recordId = $row[$entityidfield];
+				$recordModel = array();
 				$recordModel[$entityidfield] = $recordId;
 				foreach($columns as $column){
 					if(isset($row[$column])){
 						$recordModel[$column] = $row[$column];
 					}
 				}
-				$recordModels[] = $recordModel;
+				$cache[$module][] = $recordModel;
 			}
-			$cache[$module] = $recordModels; 
 		}
 
 		return $cache;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1529

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 見積、発注、受注、請求モジュールにおいて、エクスポートしたCSVファイルをインポートしても失敗する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インベントリ系は標準モジュールとは異なり、複数条件の配列が渡されることを前提としていたため、csvファイルとの互換性がなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. include/Webservices/LineItem/VtigerLineItemOperation.php：計算を行う変数に浮動小数点として扱うためのdoubleを追加
2. include/utils/InventoryUtils.php：関数内のデータ形式の統一、検索エラーの回避、タイトルが重複しているときに追加しない設定、受注において繰り返し有効の時のみ必須項目である項目に対して常に必須項目となっていることを修正
3. modules/Import/actions/Data.php：csvに翻訳済みラベルで入力されている時に失敗するのを回避
4. include/utils/ListViewUtils.php：配列か文字列かを判定、文字列検索の実装

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->