### PR TITLE
Fix/1425-[質問]ユーザー新規作成でインポートで使う導入出来るcsvファイルを知りたい

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -1758,9 +1758,11 @@ class Users extends CRMEntity {
 					} else if($fieldName == 'roleid') {
 						foreach($allRoles as $role) {
 							$roleLabelKey = $role->getName();
-							// 「役割」は翻訳後の値での比較、default_languageを見て比較する
-							$translatedRoleName = Vtiger_Language_Handler::getTranslatedString($roleLabelKey, 'Settings:Roles', $default_language);
-							if(strtolower($fieldValue) == strtolower($translatedRoleName)) {
+							// 「役割」は翻訳後の値での比較。現在の言語、またはデフォルト言語のいずれかに一致すればOKとする。
+							$translatedRoleNameCurrent = vtranslate($roleLabelKey, 'Settings:Roles');
+							$translatedRoleNameDefault = Vtiger_Language_Handler::getTranslatedString($roleLabelKey, 'Settings:Roles', $default_language);
+							if(strtolower($fieldValue) == strtolower($translatedRoleNameCurrent) || 
+							   strtolower($fieldValue) == strtolower($translatedRoleNameDefault)) {
 								$roleId = $role->getId();
 								break;
 							}

--- a/modules/Users/actions/ExportData.php
+++ b/modules/Users/actions/ExportData.php
@@ -25,6 +25,9 @@ class Users_ExportData_Action extends Vtiger_ExportData_Action {
 									'title'			=> 'Title',
 									'last_name'		=> 'Last Name',
 									'first_name'	=> 'First Name',
+									'roleid'		=> 'Role',
+									'user_password'	=> 'Password',
+									'confirm_password'	=> 'Confirm Password',
 									'email1'		=> 'Email',
 									'email2'		=> 'Other Email',
 									'secondaryemail'=> 'Secondary Email',
@@ -58,7 +61,18 @@ class Users_ExportData_Action extends Vtiger_ExportData_Action {
 
 			$entries = array();
 			for ($i=0; $i<$db->num_rows($result); $i++) {
-				$entries[] = $db->fetchByAssoc($result, $i);
+				$raw_row = $db->fetchByAssoc($result, $i);
+				$row = array();
+				foreach (array_keys($this->exportableFields) as $fieldName) {
+					if ($fieldName == 'user_password' || $fieldName == 'confirm_password') {
+						$row[$fieldName] = 'password';
+					} else if ($fieldName == 'roleid') {
+						$row[$fieldName] = Vtiger_Language_Handler::getTranslatedString(getRoleName($raw_row['roleid']), 'Settings:Roles');
+					} else {
+						$row[$fieldName] = $raw_row[$fieldName];
+					}
+				}
+				$entries[] = $row;
 			}
 
 			return $this->output($request, $translatedHeaders, $entries);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1425 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 新規ユーザ作成時にユーザのインポートができない。一覧からエクスポートしたcsvファイルを使用しても必須項目のマッピングエラーになる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ユーザ新規作成時の必須項目である「役割」、「パスワード」、「パスワードの確認」がエクスポートファイルに含まれていないため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. modules/Users/actions/ExportData.php：必須項目である「役割」をエクスポートする項目に追加。「パスワード」、「パスワードの確認」の列を追加し、仮の初期値を出力するように設定。
2. modules/Users/Users.php：英語環境でエクスポートしたファイルを英語環境でインポートした際に「役割」が認識されなかったため、デフォルト言語に加えて現在の使用言語も照合対象に含めるように修正。

[エクスポートされるファイル例.csv](https://github.com/user-attachments/files/28448800/default.csv)
[インポート可能ファイル例.csv](https://github.com/user-attachments/files/28448804/default.csv)


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
<img width="537" height="116" alt="image" src="https://github.com/user-attachments/assets/3f09309f-cc9d-4009-b80d-2f5dc5a6118d" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
システム使用上インポート時にパスワードが必須となるため、仮の初期値を自動設定する方式になっているが、インポート完了後各ユーザにパスワード変更を促す必要がある。パスワードが空の状態でもインポートを許容するアプローチなども考えられる。