### PR TITLE
#1533 製品-発注の関連リスト重複を削除するマイグレーション追加

### DIFF
--- a/setup/migration/scripts/20260601082359_fix_duplicate_products_purchaseorder_relation.php
+++ b/setup/migration/scripts/20260601082359_fix_duplicate_products_purchaseorder_relation.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * マイグレーション: fix_duplicate_products_purchaseorder_relation
+ * 生成日時: 20260601082359
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+require_once dirname(__FILE__) . '/../../../include/utils/CommonUtils.php';
+
+class Migration20260601082359_FixDuplicateProductsPurchaseorderRelation extends FRMigrationClass {
+    public function process() {
+        global $adb;
+
+        // ---- Products と PurchaseOrder の tabid を取得 ----
+        $productsTabId = $this->getTabId('Products');
+        $poTabId       = $this->getTabId('PurchaseOrder');
+
+        // モジュールが存在しない場合は処理を中止
+        if (!$productsTabId || !$poTabId) {
+            return;
+        }
+
+        // ---- Products → PurchaseOrder の N:N 関係のみ取得（重複検出用）----
+        $sql = "SELECT relation_id FROM vtiger_relatedlists WHERE tabid = ? AND related_tabid = ? AND name = 'get_purchase_orders' AND relationfieldid IS NULL AND relationtype = 'N:N' ORDER BY relation_id ASC";
+        $result = $adb->pquery($sql, [$productsTabId, $poTabId]);
+        $count = $adb->num_rows($result);
+
+        // 重複が1件以下なら処理不要
+        if ($count < 1) {
+            return;
+        }
+
+        // ---- N:N 側はすべて削除（正規の 1:N 行は別条件で残存） ----
+        while ($row = $adb->fetch_array($result)) {
+            $adb->pquery(
+                "DELETE FROM vtiger_relatedlists WHERE relation_id = ?",
+                [$row['relation_id']]
+            );
+        }
+
+        $this->log("マイグレーション fix_duplicate_products_purchaseorder_relation が正常に完了しました");
+    }
+
+    /** モジュール名から tabid を取得する関数 */
+    private function getTabId($moduleName) {
+        global $adb;
+
+        $result = $adb->pquery("SELECT tabid FROM vtiger_tab WHERE name = ?", [$moduleName]);
+
+        if ($adb->num_rows($result) > 0) {
+            $row = $adb->fetch_array($result);
+            return $row['tabid'];
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1533

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 製品(Products)モジュールの詳細画面で、関連リスト「発注」タブが2つ表示される。どちらも同一の `get_purchase_orders` ハンドラを呼ぶため、返却されるレコードも同じ。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `modules/Migration/schema/660_to_700.php:1865` の `$productsInstance->setRelatedList($poInstance, 'PurchaseOrder', false, 'get_purchase_orders')` が、`vtiger_relatedlists` への重複チェックなしに INSERT を実行している。
2. その結果、`DefaultDataPopulator.php` で生成された正規の関連リスト行(relationfieldid 設定済み、relationtype='1:N')に加え、N:N の重複行が追加され、製品詳細画面で「発注」タブが2つ表示される状態となっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 新規マイグレーション `setup/migration/scripts/20260601082359_fix_duplicate_products_purchaseorder_relation.php` を追加。
2. `vtiger_relatedlists` から `tabid=Products AND related_tabid=PurchaseOrder AND name='get_purchase_orders' AND relationfieldid IS NULL AND relationtype='N:N'` の行を削除。
3. 正規行(relationfieldid 設定済み、relationtype='1:N')は条件外のため保持される。
4. 該当行が存在しない環境では何もせず終了する冪等な実装。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="2106" height="630" alt="image" src="https://github.com/user-attachments/assets/ddeb5e3f-5898-477a-812e-782aa14cc627" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 製品モジュール詳細画面の関連リスト「発注」タブの表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った  ※該当なし(マイグレーションのみ、言語ファイル変更なし)

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 先例 `setup/migration/scripts/20251127120006_fix_duplicate_helpdesk_assets_relation.php` (HelpDesk-Assets間の同種重複対応) と同パターン。ただし、今回は正規行が 1:N 側にあるため、N:N 行は全削除する実装としている。
- ローカル環境(`vtiger_relatedlists`)で修正前後の状態を SQL で確認済。修正後は正規 1:N 行(relation_id=41)のみ残存することを確認。
- マイグレーション根本原因(`modules/Migration/schema/660_to_700.php:1865` の `setRelatedList` 無条件INSERT) は過去バージョンの一度限り実行スクリプトであり、本PRでは修正対象外とした。