### PR TITLE
#1637 マイグレーション時にロゴファイルをpublic/logo/配下へ移動

### DIFF
--- a/setup/migration/scripts/20260604171138_move_logo_to_public.php
+++ b/setup/migration/scripts/20260604171138_move_logo_to_public.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * マイグレーション: move_logo_to_public
+ * 生成日時: 20260604171138
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260604171138_MoveLogoToPublic extends FRMigrationClass {
+    
+    /**
+     * Issue #1637: publicディレクトリ移行前にアップロードされたロゴファイルが
+     * test/logo/ に残り表示されなくなる問題への対応。
+     * test/logo/ 配下のファイルを public/logo/ へ移動する。
+     * 移動先に同名ファイルが既に存在する場合は上書きせずスキップする。
+     */
+    public function process() {
+        $rootDir = realpath(dirname(__FILE__) . '/../../../');
+        $srcDir  = $rootDir . '/test/logo';
+        $destDir = $rootDir . '/public/logo';
+
+        if (!is_dir($srcDir)) {
+            $this->log("test/logo/ が存在しないためスキップ");
+            return;
+        }
+
+        if (!is_dir($destDir)) {
+            if (!mkdir($destDir, 0755, true) && !is_dir($destDir)) {
+                $this->log("public/logo/ の作成に失敗: {$destDir}");
+                return;
+            }
+        }
+
+        $movedCount = 0;
+        $skippedCount = 0;
+        $failedCount = 0;
+
+        $files = glob($srcDir . '/*');
+        if ($files === false) {
+            $this->log("test/logo/ の読み込みに失敗");
+            return;
+        }
+
+        foreach ($files as $srcPath) {
+            if (!is_file($srcPath)) {
+                continue;
+            }
+            $basename = basename($srcPath);
+            $destPath = $destDir . '/' . $basename;
+
+            if (file_exists($destPath)) {
+                $this->log("移動先に同名ファイル存在のためスキップ: {$basename}");
+                $skippedCount++;
+                continue;
+            }
+
+            if (@rename($srcPath, $destPath)) {
+                $this->log("移動完了: {$basename}");
+                $movedCount++;
+            } else {
+                $this->log("移動失敗: {$basename}");
+                $failedCount++;
+            }
+        }
+
+        $this->log("ロゴファイル移動完了 - 移動: {$movedCount}, スキップ: {$skippedCount}, 失敗: {$failedCount}");
+
+        if ($failedCount > 0) {
+            throw new Exception("ロゴファイル移動に {$failedCount} 件失敗しました。test/logo/ および public/logo/ の権限を確認のうえ、マイグレーションを再実行してください。");
+        }
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1637

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. publicディレクトリ移行前のバージョンで企業ロゴをアップロード済みの環境を、publicディレクトリ移行後のバージョンへマイグレーションすると、ロゴファイルが `test/logo/` 配下に残り `public/logo/` 配下に存在しないため、システム上でロゴが表示されなくなる。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. publicディレクトリ移行（PR #1352 / コミット `60261cdd2`）でロゴ格納先を `test/logo/` から `public/logo/` へ変更。リポジトリ内の同梱ファイルは git mv で移動されたが、稼働環境でユーザーがアップロード済みの実ロゴファイル（DB `vtiger_organizationdetails.logoname`
で参照）に対する移動処理が用意されていなかった。
2. ロゴ参照側（`modules/Vtiger/models/CompanyDetails.php` 等）は `public/logo/{logoname}` を見るため、ファイル不在で表示不可となる。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. マイグレーションスクリプト `setup/migration/scripts/20260604171138_move_logo_to_public.php` を追加。
2. `test/logo/` 配下のファイルを `public/logo/` 配下へ `rename()` で移動。
3. 移動先に同名ファイルが既に存在する場合は上書きせずスキップ（移行後にユーザーが新規アップロードしたロゴの保護）。
4. ファイル移動失敗が発生した場合は例外を送出し、`com_vtiger_migrations` テーブルに「実行済み」として登録されないようにする。これにより権限修正後にマイグレーションの再実行で残ファイルを救済可能。
5. 集計ログ（移動／スキップ／失敗の件数）を出力。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
（必要に応じてユーザーで添付してください）

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 企業ロゴ表示

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った  ※今回は該当なし（マイグレーションスクリプト追加のみ）

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 動作確認（手動）:
- 通常パス: `test/logo/logo.png`（移動先に同名既存） + `test/logo/new_unique_logo_test1637.png`（新規）配置 → 実行 → 既存は md5 不変でスキップ、新規は `public/logo/` へ移動。
- 失敗パス: `public/logo/` を `555` に変更し書き込み不可状態で実行 → 例外送出 → `com_vtiger_migrations` 未登録を確認 → パーミッション復旧後に再実行可能であることを確認。
- 全件移動成功後の `test/logo/` ディレクトリ自体の `rmdir()` は未実施。空ディレクトリ残置の実害なしのため見送り。
