### PR TITLE
#1614 同一ユーザーのインポートで古いキューを実行してしまう問題を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -148,7 +148,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			// ※処理済みのレコードが$pagingLimitの倍数でない場合を前回のインポートが完了していないとみなす
 			$configReader = new Import_Config_Model();
 			$pagingLimit = intval($configReader->get('importPagingLimit'));
-			$importTable = Import_Utils_Helper::getDbTableName($this->user);
+			$importTable = Import_Utils_Helper::getDbTableName($this->user, $this->id);
 			$finishedImportQuery = 'SELECT count(*) AS imported FROM '.$importTable.' WHERE `status` != ?';
 			$finishedImportResult = $adb->pquery($finishedImportQuery, array(Import_Data_Action::$IMPORT_RECORD_NONE));
 			$finishedImportCount = $adb->query_result($finishedImportResult, 0, 'imported');
@@ -179,7 +179,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			$entityIdComponents = vtws_getIdComponents($entityInfo['id']);
 			$recordId = $entityIdComponents[1];
 		}
-		$adb->pquery('UPDATE '.Import_Utils_Helper::getDbTableName($this->user).' SET status=?, recordid=? WHERE id=?', array($entityInfo['status'], $recordId, $entryId));
+		$adb->pquery('UPDATE '.Import_Utils_Helper::getDbTableName($this->user, $this->id).' SET status=?, recordid=? WHERE id=?', array($entityInfo['status'], $recordId, $entryId));
 	}
 
 	public function createRecords() {
@@ -209,7 +209,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 		$createdRecords = array();
 		$entityData = array();
-		$tableName = Import_Utils_Helper::getDbTableName($this->user);
+		$tableName = Import_Utils_Helper::getDbTableName($this->user, $this->id);
         $params = array();
 		$sql = 'SELECT * FROM '.$tableName.' WHERE status = ?';
         array_push($params, Import_Data_Action::$IMPORT_RECORD_NONE);
@@ -963,7 +963,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			$vtigerMailer->Send(true);
 
 			//未完了のインポートがない場合のみ終了する
-			$importTable = Import_Utils_Helper::getDbTableName($importDataController->user);			
+			$importTable = Import_Utils_Helper::getDbTableName($importDataController->user, $importDataController->id);
 			$unfinishedImportQuery = 'SELECT count(status) FROM ' . $importTable . ' WHERE status = 0 GROUP BY status';
 			$unfinishedImportResult = $adb->pquery($unfinishedImportQuery, array());
 			$unfinishedImportCount = $adb->query_result($unfinishedImportResult, 0, 'count(status)');
@@ -975,7 +975,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 	public function getNumberOfRecordsToImport($user){
 		$db = PearDatabase::getInstance();
-		$table = Import_Utils_Helper::getDbTableName($user);
+		$table = Import_Utils_Helper::getDbTableName($user, $this->id);
 		$query = "SELECT count(*) AS count FROM $table WHERE status = ?";
 		$result = $db->pquery($query,array(Import_Data_Action::$IMPORT_RECORD_NONE));
 		$rows = $db->num_rows($result);
@@ -1283,7 +1283,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		$adb = PearDatabase::getInstance();
 
 		$params = array();
-		$tableName = Import_Utils_Helper::getDbTableName($this->user);
+		$tableName = Import_Utils_Helper::getDbTableName($this->user, $this->id);
 		$sql = 'SELECT * FROM ' . $tableName . ' WHERE status = ?';
 		array_push($params, Import_Data_Action::$IMPORT_RECORD_NONE);
 		$result = $adb->pquery($sql, $params);

--- a/modules/Import/actions/Queue.php
+++ b/modules/Import/actions/Queue.php
@@ -157,7 +157,7 @@ class Import_Queue_Action extends Vtiger_Action_Controller {
 		$db = PearDatabase::getInstance();
 
 		if(Vtiger_Utils::CheckTable('vtiger_import_queue')) {
-			$queueResult = $db->pquery('SELECT * FROM vtiger_import_queue WHERE status != ? AND tabid=? AND userid=? ORDER BY importid ASC',
+			$queueResult = $db->pquery('SELECT * FROM vtiger_import_queue WHERE status != ? AND tabid=? AND userid=? ORDER BY importid DESC LIMIT 1',
 											array(self::$IMPORT_STATUS_COMPLETED, getTabid($module), $user->id));
 
 			if($queueResult && $db->num_rows($queueResult) > 0) {

--- a/modules/Import/actions/Queue.php
+++ b/modules/Import/actions/Queue.php
@@ -157,7 +157,7 @@ class Import_Queue_Action extends Vtiger_Action_Controller {
 		$db = PearDatabase::getInstance();
 
 		if(Vtiger_Utils::CheckTable('vtiger_import_queue')) {
-			$queueResult = $db->pquery('SELECT * FROM vtiger_import_queue WHERE status != ? AND tabid=? AND userid=?',
+			$queueResult = $db->pquery('SELECT * FROM vtiger_import_queue WHERE status != ? AND tabid=? AND userid=? ORDER BY importid ASC',
 											array(self::$IMPORT_STATUS_COMPLETED, getTabid($module), $user->id));
 
 			if($queueResult && $db->num_rows($queueResult) > 0) {
@@ -191,6 +191,7 @@ class Import_Queue_Action extends Vtiger_Action_Controller {
 			$query .= ' WHERE status = ?';
 			array_push($params, $status);
 		}
+		$query .= ' ORDER BY importid ASC';
 		$result = $db->pquery($query, $params);
 
 		$noOfImports = $db->num_rows($result);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1614

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 同一ユーザーのインポートで、status≠COMPLETED の古いキュー行（HALTED 等）が残存している状態で再度インポートを実行すると、新規アップロード分ではなく古いキューに紐づく一時テーブルを処理対象としてしまい、新規データが未処理のまま放置される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `Import_Queue_Action::getImportInfo()` に `ORDER BY` 指定がなく、MySQL の任意順序で古い行が返ることがあった。
2. `Import_Data_Action` 内の `Import_Utils_Helper::getDbTableName($user)` 呼び出しが第2引数（importId）未指定で、内部の
`getUserCurrentImportInfo()`（DESC=最新）にフォールバックしていたため、`Import_Data_Action::$id`（古いキューに由来）と、参照する一時テーブル名（最新キューに由来）が乖離する経路があった。
3. 当初の PR #1615 では `getImportInfo()` に `ORDER BY importid ASC`（最古優先）を追加したが、`FileReader::createTable/addRecordToDB` が
`getUserCurrentImportInfo()`（DESC=最新）経由でアップロードデータを最新テーブルに書き込むのと方向不整合となり、症状を確定的に再現させてしまうことを ChromeMCP 実環境再現で確認した。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. PR #1615 のコミット (`Import_Data_Action` 内 `getDbTableName` 第2引数に `$this->id` を明示渡し、`getAll` に `ORDER BY importid ASC`) は妥当として採用。
2. `Import_Queue_Action::getImportInfo()` の `ORDER BY importid ASC` を `ORDER BY importid DESC LIMIT 1` に変更し、`getUserCurrentImportInfo()`（DESC）および `FileReader` のテーブル決定経路（暗黙 DESC）と方向統一。これによりアップロード書き込み先テーブルと
triggerImport が処理するテーブルが必ず一致する。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- インポート機能全般（全モジュールの CSV インポート）
- スケジュールインポート（FIFO 順処理化）
- 変更ファイル:
- `modules/Import/actions/Data.php` (6箇所の `getDbTableName` に `$this->id` 明示渡し)
- `modules/Import/actions/Queue.php` (`getImportInfo` の最新優先化、`getAll` の FIFO 化)

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った  ※該当なし（文言追加なし）

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 検証手順（ChromeMCP実環境再現済）:
1. 任意モジュールで1回目インポート実行 → キュー行と一時テーブル作成
2. キュー行を `status=3 (HALTED)`、ロックを解除し、未完了行残存状態を模擬
3. 別CSVで2回目インポート実行
4. 修正前: 2回目のデータが未処理放置、`vtiger_contactdetails` に未登録（再現）
5. 修正後: 2回目のデータが正しく処理・登録される（解消）
- 既存PR #1615 の意図を尊重しつつ、`getImportInfo` のソート方向のみ最新優先 (DESC LIMIT 1) に修正した差分。Cherry-pick 元コミット作者表示は維持。
- 将来課題（任意）: `Import_Data_Action` 内の `getDbTableName($this->user, $this->id)` の繰り返し6箇所はプライベートヘルパー化候補。本PRはバグ修正最小差分のためスコープ外。