### PR TITLE
feat(#1640): HealthCheck用のエンドポイントを追加 (Web + DB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Vtiger Public License 1.2
 <a href="https://example.com/{CRM_DIR}/index.php" rel="noreferrer">F-RevoCRM</a>​​​​​​
 ```
 
+## ヘルスチェック (HealthCheck)
+サーバー監視用に、Web・DB（MySQL）の疎通を確認できるエンドポイントを用意しています。  
+ロードバランサ（ALB/ELB 等）や外形監視からの定期的な死活監視に利用できます。認証は不要です。
+
+* エンドポイント: `https://example.com/{CRM_DIR}/healthcheck.php`
+* メソッド: 任意（GET でよい）
+* チェック内容:
+  * `web` … リクエストに PHP が応答できること
+  * `db` … MySQL へ接続し `SELECT 1` が成功すること
+
+### 返却条件
+* **正常（全チェック成功）**: HTTP `200` / `{"status":"ok","checks":{"web":"ok","db":"ok"}}`
+* **異常（いずれか失敗）**: HTTP `503` / `{"status":"error","checks":{"web":"ok","db":"error"}}`
+
+監視ツール側では基本的に **HTTPステータスコード（200=正常 / 503=異常）** で判定してください（ALB/ELB はボディを参照しません）。  
+レスポンスはホスト名・バージョン・エラー詳細を含まない最小構成です。
+
 ## PCの推奨環境
 * Windows 11 Google Chrome最新 / Microsoft Edge(Chronium)最新
 * 最低1366×768以上の解像度、推奨1920×1080以上

--- a/public/healthcheck.php
+++ b/public/healthcheck.php
@@ -1,0 +1,62 @@
+<?php
+/*+***********************************************************************************
+ * HealthCheck endpoint for F-RevoCRM (GitHub/OSS edition)
+ * See: https://github.com/thinkingreed-inc/F-RevoCRM/issues/1640
+ *
+ * Checks : web (this process responded) + db (MySQL "SELECT 1")
+ * Output : minimal JSON, HTTP 200 (healthy) / 503 (unhealthy). No auth.
+ *
+ * Design : docs/superpowers/specs/2026-06-11-healthcheck-endpoint-design.md
+ *************************************************************************************/
+
+// Never leak PHP warnings/notices into the JSON body.
+ini_set('display_errors', '0');
+error_reporting(0);
+
+// Buffer everything so any stray bootstrap output can't corrupt the JSON.
+ob_start();
+
+/**
+ * DB reachability check. Returns true only when "SELECT 1" succeeds.
+ * Never throws: any failure is reported as a false result.
+ */
+function frevo_healthcheck_db() {
+    try {
+        $adb = PearDatabase::getInstance();
+        $result = $adb->pquery('SELECT 1 AS healthcheck', array());
+        return ($result !== false) && ($adb->num_rows($result) >= 1);
+    } catch (\Throwable $e) {
+        return false;
+    }
+}
+
+// Reaching this line means the web layer (PHP) is responding.
+$checks = array('web' => 'ok');
+
+try {
+    chdir(dirname(__DIR__));
+    require_once 'vendor/autoload.php';
+    include_once 'config.php';                        // populates $dbconfig / $dbconfigoption
+    require_once 'include/database/PearDatabase.php'; // pulls logging + adodb, defines PearDatabase
+
+    $checks['db'] = frevo_healthcheck_db() ? 'ok' : 'error';
+} catch (\Throwable $e) {
+    // Bootstrap failed before/while checking DB: report error but stay alive.
+    if (!isset($checks['db'])) {
+        $checks['db'] = 'error';
+    }
+}
+
+$healthy = !in_array('error', $checks, true);
+
+// Discard any bootstrap noise, then emit a clean JSON document.
+ob_end_clean();
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store');
+http_response_code($healthy ? 200 : 503);
+
+echo json_encode(array(
+    'status' => $healthy ? 'ok' : 'error',
+    'checks' => $checks,
+));


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1640

##  不具合の内容 / Bug
<!-- 本Issueは要望(enhancement)です -->
1. サーバー監視の観点で、Web→DB（→将来 ElasticSearch 等）と関連システムを通る疎通をチェックできる HealthCheck 用エンドポイントが存在しない。ロードバランサ（ALB/ELB 等）や外形監視からの死活監視に利用できる仕組みが欲しい。

##  原因 / Cause
<!-- 要望のため不具合原因はなし -->
1. 該当なし（新規機能の追加要望）。

##  変更内容 / Details of Change
1. HealthCheck エンドポイント `public/healthcheck.php` を新規追加。
   - WebUI／認証／セッションを通さない軽量スタンドアロン PHP（`public/public.php` 等の既存前例に準拠）。
   - チェック内容: `web`（PHP が応答できること）+ `db`（MySQL へ接続し `SELECT 1` が成功すること）。
   - `$checks` 連想配列でチェック項目を集約しており、将来 ElasticSearch 等を1項目追加するだけで拡張可能。
   - 返却条件:
     - 正常（全チェック成功）: HTTP `200` / `{"status":"ok","checks":{"web":"ok","db":"ok"}}`
     - 異常（いずれか失敗）: HTTP `503` / `{"status":"error","checks":{"web":"ok","db":"error"}}`
   - 出力はホスト名・バージョン・エラー詳細を含まない最小構成。`display_errors` 抑止 + 出力バッファ破棄で PHP 警告の JSON 混入を防止。失敗時も fatal にせず必ず整形 JSON + 503 を返す。
2. `README.md` に「ヘルスチェック (HealthCheck)」節と返却条件を追記。

## スクリーンショット / Screenshot
<!-- 実サーバー (http://localhost/FR_Remicck/healthcheck.php) での確認結果 -->
正常系（DB 稼働時）:
```
HTTP=200
{"status":"ok","checks":{"web":"ok","db":"ok"}}
```
異常系（DB 接続不可時）:
```
HTTP=503
{"status":"error","checks":{"web":"ok","db":"error"}}
```
レスポンスヘッダ:
```
Content-Type: application/json
Cache-Control: no-store
```

## 影響範囲  / Affected Area
- 新規ファイル `public/healthcheck.php` の追加のみ。既存のコードフロー・画面・DB スキーマへの変更はなし。
- 監視ツール側は基本的に HTTP ステータスコード（200=正常 / 503=異常）で判定する想定（ALB/ELB はレスポンスボディを参照しない）。
- 無認証エンドポイントだが、公開されるのは DB の up/down（2値）のみで、資格情報・バージョン・PII 等は返さない。セキュリティレビュー実施済み（悪用可能な脆弱性なし）。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（ユーザー向け翻訳文字列なし。レスポンスは言語非依存の固定 JSON）

## 備考 / Remarks
- 現時点の GitHub（OSS）版コードベースには ElasticSearch 等の検索エンジン統合が無いため、初版のチェック対象は Web + DB とした。将来 ElasticSearch 等が追加された際は `$checks` に1項目足すだけで拡張できる構造としている。
- `.htaccess` のリライトにより、公開 URL は `https://example.com/{CRM_DIR}/healthcheck.php`（`public/` は透過）。
