### PR TITLE
CLAUDE.md を整備する（最小構成）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,12 @@ compose.override.yaml
 /public/resources/web-components/*
 !/public/resources/web-components/.gitkeep
 /assets/react-web-components/coverage/*
+
+# Claude Code / superpowers が生成するドキュメント（コミットしない）
+/docs/superpowers/
+
+# playwright (E2E) 成果物（コミットしない）
+playwright-report/
+test-results/
+/assets/react-web-components/playwright-report
+/assets/react-web-components/test-results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ F-RevoCRM は vtiger ベースの PHP 製 CRM。`modules/` 配下に機能モジ
 - **JSON は必ず型付けする**: レスポンス／データには `src/types` に型定義を置き、`any` を避ける。
 - コミット前に **`npm run lint` / `npm run format`** を通す。
 
+### マイグレーション（DB 変更）
+
+- DB のスキーマ・データ変更は手動 SQL でなく `setup/migration/` のコマンドで行う。詳細は `setup/migration/README.md`。
+
 ## Do / Don't
 
 ### Do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+F-RevoCRM は vtiger ベースの PHP 製 CRM。`modules/` 配下に機能モジュールが並ぶ MVC 構成。フロントの一部は `assets/react-web-components/`（React + TypeScript）で実装。
+
+## ディレクトリ構成
+
+| ディレクトリ | 役割 |
+|---|---|
+| `modules/` | 機能モジュール本体。各モジュールが Model / View / Action を持つ |
+| `modules/Vtiger/` | 各モジュールの**デフォルト実装＝フォールバック元**（コア相当） |
+| `include/` | ユーティリティ・イベントハンドラ定義などの共通処理（カスタマイズ可） |
+| `includes/` | ランタイムローダー・基盤ローダー（コア） |
+| `vtlib/` | vtiger のモジュール基盤フレームワーク（コア） |
+| `layouts/` | テンプレート（Smarty）・JS・CSS |
+| `languages/` | 多言語ファイル |
+| `cron/` | 定期実行ジョブ |
+| `assets/react-web-components/` | React 製 Web コンポーネント（Vite / Vitest / Tailwind） |
+
+## 構造・命名規約
+
+各モジュールは `modules/<Module>/` 配下に役割別ディレクトリを持つ vtiger MVC 構造。
+
+| 役割 | 配置 | クラス名 | 基底クラス | 担当 |
+|---|---|---|---|---|
+| Model | `models/` | `<Module>_<Type>_Model` | `Vtiger_<Type>_Model` | データ・ビジネスロジック |
+| View | `views/` | `<Module>_<Name>_View` | `Vtiger_<Name>_View` | 画面表示 |
+| Action | `actions/` | `<Module>_<Name>_Action` | `Vtiger_<Name>_Action` | 保存・処理 |
+| Handler | `handlers/` | `<Name>Handler` | `VTEventHandler` | イベント処理 |
+
+実例:
+- `modules/Accounts/models/Record.php` → `class Accounts_Record_Model extends Vtiger_Record_Model`
+- `modules/Contacts/actions/Save.php` → `class Contacts_Save_Action extends Vtiger_Save_Action`
+- `modules/Leads/views/ConvertLead.php` → `class Leads_ConvertLead_View extends Vtiger_Index_View`
+
+**オートロード規約**（`includes/Loader.php`）: クラス名のアンダースコア区切りがディレクトリにマップされる。
+`Accounts_Record_Model` → `modules/Accounts/models/Record.php`。
+モジュール側に実装が無ければ `modules/Vtiger/` の同役割クラスへ**フォールバック**する。
+→ 新規実装・カスタマイズは、この命名と MVC パターンに合わせること。
+
+### API エンドポイント（apis 標準）
+
+- **JSON を返すエンドポイントは `modules/<Module>/apis/` に置く**（標準。`modules/Vtiger/apis` が基準）。
+- **`apis` は JSON のみを返す。HTML を返すことは許容しない。**
+- 一部モジュールに単数形 `api/`（例: `modules/Mobile/api`, `modules/WSAPP/api`）が残るが、新規は `apis/` に寄せる。
+
+### Web コンポーネント（`assets/react-web-components/`）
+
+- React + TypeScript + Vite。テストは **Vitest**、ビルドは `npm run build`（`tsc && vite build`）。
+- **JSON は必ず型付けする**: レスポンス／データには `src/types` に型定義を置き、`any` を避ける。
+- コミット前に **`npm run lint` / `npm run format`** を通す。
+
+## Do / Don't
+
+### Do
+- 既存モジュールの命名・MVC パターンに合わせて実装する
+- **コードを書いたら、自分で動作を確認する**（自己レビュー）。E2E（playwright）は現時点で必須ではないが、今後拡充する
+- 1 目的 1 コミット。コミット・PR・Issue は日本語で書く
+
+### Don't
+- **コア由来を直接改変しない**: `vtlib/` / `includes/` / `modules/Vtiger/`（アップグレードで上書き・フォールバック元のため）
+- `config*.php` の秘匿値をコミットしない
+- **テスト・ビルド系コマンド（`vitest` / `npm run build` 等）は、実行前に同じプロセスが動いていないか確認**してから実行する


### PR DESCRIPTION
## 概要
Claude Code 向けの `CLAUDE.md` を最小構成で新規追加する。`/init` のような全部盛りではなく、要点だけを小さく始める方針。

Closes #1649

## 追加内容
- **ディレクトリ構成** — トップレベル中心の概要（コア領域 `vtlib/`・`includes/`・`modules/Vtiger/` を明示）
- **構造・命名規約** — vtiger MVC（Model/View/Action/Handler）の配置・クラス名・基底クラス・オートロード規約
- **API（apis 標準）** — JSON を返すエンドポイントは `modules/<Module>/apis/` に置く。`apis` は JSON のみ返す（HTML 不可）
- **Web コンポーネント** — `assets/react-web-components/`（Vite/Vitest）。JSON は型付け、lint/format を通す、build/test は重複プロセス確認
- **マイグレーション（DB 変更）** — DB のスキーマ・データ変更は手動 SQL でなく `setup/migration/` のコマンドで行う（詳細は `setup/migration/README.md`）
- **Do / Don't** — コア由来ファイルの直接改変禁止、秘匿値コミット禁止、コードを書いたら自己確認 など

あわせて `.gitignore` に superpowers 生成 docs と playwright 成果物を追加。

## 方針
まずは叩き台として小さく入れ、運用しながら育てる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)