### PR TITLE
fix: #1197 Vtiger_Base_Model::has()でTrackableObject渡し時のFatalエラーを修正

### DIFF
--- a/includes/runtime/BaseModel.php
+++ b/includes/runtime/BaseModel.php
@@ -84,7 +84,13 @@ class Vtiger_Base_Model {
 	 * @param String $key
 	 */
 	public function has($key) {
-		return array_key_exists($key, $this->valueMap);
+		if (is_array($this->valueMap)) {
+			return array_key_exists($key, $this->valueMap);
+		}
+		if ($this->valueMap instanceof ArrayAccess) {
+			return $this->valueMap->offsetExists($key);
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## 概要
issue #1197 の修正です。

`Vtiger_Base_Model::has()` が `array_key_exists($key, $this->valueMap)` を呼ぶが、`valueMap` が常に配列とは限らず、`TrackableObject`（`ArrayAccess` 実装）の場合に PHP 8.x で `TypeError`（Fatal）が発生していました。

## 根本原因
`Vtiger_Record_Model`（`Vtiger_Base_Model` のサブクラス）は `modules/Vtiger/models/Record.php` で `setData($focus->column_fields)` を呼んでおり、`column_fields` は `TrackableObject`（`data/CRMEntity.php`）です。そのため `has()` 呼び出し時に `array_key_exists()` へ配列以外が渡り、PHP 8.x で Fatal になります。

## 修正内容
- 配列の場合は従来どおり `array_key_exists()`
- `ArrayAccess` の場合は `offsetExists()` で存在判定
- それ以外は `false`

issue コメントの案 `is_array() && array_key_exists()` だと Fatal は止まりますが `TrackableObject` で常に `false` を返し、キー存在判定が壊れる別バグになるため、`offsetExists()` で正しさを維持しています。

## 動作確認
- 配列 / TrackableObject 双方で「存在キー / null値キー / 不在キー」のテストが全て期待通り PASS
- `php -l` 構文チェック OK

Closes #1197