### PR TITLE
Fix/1617-[不具合] グループスケジュールが重複表示される

### DIFF
--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -325,12 +325,14 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		$userIds = array_merge(array($eventUserId), $this->getGroupsIdsForUsers($eventUserId));
 		
 		$query.= " AND vtiger_crmentity.smownerid IN (".  generateQuestionMarks($userIds).")";
+		$query = preg_replace('/vtiger_activity.activityid/', 'vtiger_activity.invitee_parentid, vtiger_activity.activityid', $query, 1);
 		
 		$params = array($dbEndDate, $dbStartDate, $userIds);
 		$queryResult = $db->pquery($query, $params);
 
 		$creatorfield = Vtiger_Field_Model::getInstance('creator', $moduleModel);
 
+		$dedupResult = array();
 		while($record = $db->fetchByAssoc($queryResult)){
 			if(!array_key_exists($record['smownerid'], $this->cacheUser)) {
 				$this->cacheUser[$record['smownerid']] = Vtiger_functions::getUserRecordLabel($record['smownerid']);
@@ -454,6 +456,19 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 				$item['description'] = $record['description'].$inviteeMessage;
 			}
 
+			$invitee_parentid = $record['invitee_parentid'];
+			if (empty($invitee_parentid)) {
+				$invitee_parentid = $record['activityid'];
+			}
+			if (isset($dedupResult[$invitee_parentid])) {
+				if ($ownerId == $eventUserId) {
+					$dedupResult[$invitee_parentid] = $item;
+				}
+			} else {
+				$dedupResult[$invitee_parentid] = $item;
+			}
+		}
+		foreach ($dedupResult as $item) {
 			$result[] = $item;
 		}
 	}

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -303,7 +303,9 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		// }
 
 		$queryGenerator->setFields(array('subject', 'eventstatus', 'visibility','date_start','time_start','due_date','time_end','assigned_user_id','id','activitytype','recurringtype','parent_id','description', 'location', 'creator', 'modifiedby'));
-		$query = $queryGenerator->getQuery();
+		$query = "SELECT vtiger_activity.invitee_parentid, " . $queryGenerator->getSelectClauseColumnSQL();
+		$query .= $queryGenerator->getFromClause();
+		$query .= $queryGenerator->getWhereClause();
 
 		$query.= " AND vtiger_activity.activitytype NOT IN ('Emails','Task') AND ";
 		$hideCompleted = $currentUser->get('hidecompletedevents');
@@ -325,7 +327,6 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		$userIds = array_merge(array($eventUserId), $this->getGroupsIdsForUsers($eventUserId));
 		
 		$query.= " AND vtiger_crmentity.smownerid IN (".  generateQuestionMarks($userIds).")";
-		$query = preg_replace('/vtiger_activity.activityid/', 'vtiger_activity.invitee_parentid, vtiger_activity.activityid', $query, 1);
 		
 		$params = array($dbEndDate, $dbStartDate, $userIds);
 		$queryResult = $db->pquery($query, $params);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1617

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
担当をログインユーザーを含むグループ、参加者にログインユーザーを入れて活動を登録すると、グループの活動と自分の活動で見た目上重複表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
カレンダーのデータベース取得処理において、自分個人と自分が所属するグループの両方を検索条件に指定しているため、複数のレコードに合致してしまい、重複して取得されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
modules/Calendar/actions/Feed.php：レコード同士を紐づける親イベントID(invitee_parentid)を取得できるようにSQL文を書き換え。データベースからレコードをチェックし、同じ親IDを持つものは個人宛を優先して1つに絞るように変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="218" height="135" alt="image" src="https://github.com/user-attachments/assets/bb7a63e6-b7f6-4223-9275-480c80c22718" />

変更後
<img width="224" height="105" alt="image" src="https://github.com/user-attachments/assets/14f06c1f-dd59-420e-acd2-2a7ce06a2732" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->