### PR TITLE
#1660 [不具合]項目設定 関連 もしくは 重複防止 タブを選択した状態で モジュールを切り替えるとエラーになる

### DIFF
--- a/modules/Settings/LayoutEditor/views/Index.php
+++ b/modules/Settings/LayoutEditor/views/Index.php
@@ -160,6 +160,8 @@ class Settings_LayoutEditor_Index_View extends Settings_Vtiger_Index_View {
 		$viewer->assign('RELATION_FIELDS', $relationFields);
 		$viewer->assign('HIDDEN_TAB_EXISTS', $hiddenRelationTabExists);
 		$viewer->assign('MODULE_MODEL', $moduleModel);
+		// Index.tpl で参照する SELECTED_MODULE_MODEL を assign（未設定だとモジュール切替時に null 参照で Fatal になる #1660）
+		$viewer->assign('SELECTED_MODULE_MODEL', $moduleModel);
 		$viewer->assign('QUALIFIED_MODULE', $qualifiedModule);
 
 		if ($request->isAjax() && !$request->get('showFullContents')) {
@@ -228,6 +230,8 @@ class Settings_LayoutEditor_Index_View extends Settings_Vtiger_Index_View {
 		$viewer->assign('SOURCE_MODULE', $sourceModuleName);
 		$viewer->assign('QUALIFIED_MODULE', $qualifiedModule);
 		$viewer->assign('SOURCE_MODULE_MODEL', $moduleModel);
+		// Index.tpl で参照する SELECTED_MODULE_MODEL を assign（未設定だとモジュール切替時に null 参照で Fatal になる #1660）
+		$viewer->assign('SELECTED_MODULE_MODEL', $moduleModel);
 		$viewer->assign('ACTIONS', Vtiger_Module_Model::getSyncActionsInDuplicatesCheck());
 		$viewer->assign('USER_MODEL', Users_Record_Model::getCurrentUserModel());
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1660

##  不具合の内容 / Bug
1. 項目設定（レイアウトエディタ）画面で「関連」もしくは「重複防止」タブを選択した状態でモジュールを切り替えると、画面が表示されず Fatal error になる。

##  原因 / Cause
1. `Index.tpl`（34行目）は `$SELECTED_MODULE_MODEL->isEditreadonlydisplay()` を参照しているが、`Index.tpl`をフルページ描画する各メソッドのうち `SELECTED_MODULE_MODEL` を assign していたのは `showFieldLayout()` のみだった。
1. モジュール切替時はフルページ（非Ajax）で `showRelatedListLayout()` / `showDuplicationHandling()` が `Index.tpl`を描画するが、両メソッドは `SELECTED_MODULE_MODEL` を assign していないため、テンプレート内で `null` となり`null->isEditreadonlydisplay()` で Fatal error になっていた。

##  変更内容 / Details of Change
1. `modules/Settings/LayoutEditor/views/Index.php` の `showRelatedListLayout()` と `showDuplicationHandling()`に、正常系 `showFieldLayout()` と同様に既存の `$moduleModel` を `SELECTED_MODULE_MODEL` として assignする処理を追加した。

## スクリーンショット / Screenshot

## 影響範囲  / Affected Area
- システム設定 → 項目とリレーションの管理（LayoutEditor）画面のみ。
- 追加した assign は描画時のテンプレート変数のみで、showFieldLayout()（項目タブ）の挙動・他画面には影響なし。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
