### PR TITLE
fix: JoditEditorのenter設定を'p'から'br'に変更 (#1662)

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/JoditEditor.js
+++ b/public/layouts/v7/modules/Vtiger/resources/JoditEditor.js
@@ -160,7 +160,7 @@ jQuery.Class("Vtiger_Jodit_Js", {
         var joditLang = userLang ? userLang.split('_')[0] : 'ja';
         var joditConfig = {
             language: joditLang,
-            enter: 'p',
+            enter: 'br', // 旧CKEditorと同じ挙動（Enterキーで<br>挿入）。<p>のmarginによる余白発生を防止 #1662
             minHeight: false, // Joditデフォルト(200)を無効化。高さはapplyHeight()でworkplaceに直接設定
             maxHeight: false, // JoditのmaxHeight自動算出を無効化。高さはapplyHeight()でworkplaceに直接設定
             statusbar: true,


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1662

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リッチテキストエディタが CKEditor から Jodit に置き換わった際、Enter キーの挙動が変わった。旧 CKEditor では Enter キーで `<br>` が挿入されていたが、JoditEditor では `<p>...</p>` で段落が分割される。
1. 特にメールテンプレート本文で `<p>` 要素のデフォルト margin により、意図しない余白（行間）が発生する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. `public/layouts/v7/modules/Vtiger/resources/JoditEditor.js` の Jodit 設定で `enter: 'p'` が指定されているため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `JoditEditor.js` の Jodit 設定 `enter: 'p'` を `enter: 'br'` に変更し、旧 CKEditor と同じく Enter キーで `<br>` が挿入される挙動に戻した。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- JoditEditor を利用するすべての画面（メールテンプレート、PDF テンプレート等）の Enter キー挙動。
- 既に `<p>` タグで保存済みのテンプレートの表示は本変更では変わらない（必要に応じて本文先頭への `<style>p { margin: 0; padding: 0; }</style>` 追加、またはソースモードでの置換による暫定対応が可能）。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- 設定値の 1 行変更のみで、言語対応が必要なテキストの追加はない。
