### PR TITLE
Fix/1657-[要望] カレンダーに共有メモを表示してほしい

### DIFF
--- a/languages/en_us/Calendar.php
+++ b/languages/en_us/Calendar.php
@@ -282,4 +282,6 @@ $jsLanguageStrings = array(
 	'JS_MONTHTITLEFORMAT' => 'YYYY-MM',
 	'JS_DAYTITLEFORMAT' => 'YYYY-MM-DD',
 	'JS_WEEKTITLEFORMAT' => 'YYYY-MM-DD',
+	'LBL_DESCRIPTION' => 'Description',
+	'Common Memo' => 'Common Memo',
 );

--- a/languages/ja_jp/Calendar.php
+++ b/languages/ja_jp/Calendar.php
@@ -281,4 +281,6 @@ $jsLanguageStrings = array(
 	'JS_MONTHTITLEFORMAT' => 'YYYY年MM月',
 	'JS_DAYTITLEFORMAT' => 'YYYY年MM月DD日',
 	'JS_WEEKTITLEFORMAT' => 'YYYY年MM月DD日',
+	'LBL_DESCRIPTION' => '詳細内容',
+	'Common Memo' => '共有メモ',
 );

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -447,12 +447,10 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 				if(count($inviteeDetails) == 1 && array_key_exists($currentUser->getId(), $inviteeDetails)) {
 					$inviteeMessage = '';
 				} else {
-					$inviteeMessage = '<br>'.vtranslate('LBL_INVITE_USERS', 'Events').'<br>'.implode(', ', $inviteeDetails).'';
+					$inviteeMessage = implode(', ', $inviteeDetails);
 				}
-				if(!empty($record['description']) && !empty($inviteeMessage)) {
-					$inviteeMessage ='<br>'.$inviteeMessage;
-				}
-				$item['description'] = $record['description'].$inviteeMessage;
+				$item['invitees_field_label'] = vtranslate('LBL_INVITE_USERS', 'Events');
+				$item['invitees'] = $inviteeMessage;
 			}
 
 			$result[] = $item;
@@ -588,12 +586,10 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 				if(count($inviteeDetails) == 1 && array_key_exists($currentUser->getId(), $inviteeDetails)) {
 					$inviteeMessage = '';
 				} else {
-					$inviteeMessage = '<br>'.vtranslate('LBL_INVITE_USERS', 'Events').'<br>'.implode(', ', $inviteeDetails).'';
+					$inviteeMessage = implode(', ', $inviteeDetails);
 				}
-				if(!empty($record['description']) && !empty($inviteeMessage)) {
-					$inviteeMessage ='<br>'.$inviteeMessage;
-				}
-				$item['description'] = $record['description'].$inviteeMessage;
+				$item['invitees_field_label'] = vtranslate('LBL_INVITE_USERS', 'Events');
+				$item['invitees'] = $inviteeMessage;
 			}
 
 			$result[] = $item;

--- a/modules/Calendar/actions/Feed.php
+++ b/modules/Calendar/actions/Feed.php
@@ -302,7 +302,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			$queryGenerator = new QueryGenerator($moduleModel->get('name'), $currentUser);
 		// }
 
-		$queryGenerator->setFields(array('subject', 'eventstatus', 'visibility','date_start','time_start','due_date','time_end','assigned_user_id','id','activitytype','recurringtype','parent_id','description', 'location', 'creator', 'modifiedby'));
+		$queryGenerator->setFields(array('subject', 'eventstatus', 'visibility','date_start','time_start','due_date','time_end','assigned_user_id','id','activitytype','recurringtype','parent_id','description', 'location', 'creator', 'modifiedby', 'common_memo'));
 		$query = $queryGenerator->getQuery();
 
 		$query.= " AND vtiger_activity.activitytype NOT IN ('Emails','Task') AND ";
@@ -435,6 +435,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 			}
 			$item['location'] = $record['location'];
 			$item['description'] = $record['description'];
+			$item['common_memo'] = $record['common_memo'];
 
 			$inviteeDetails = $this->getInviteeNames($record['activityid']);
 			$group = Settings_Groups_Record_Model::getInstance($ownerId);
@@ -479,7 +480,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 		$userAndGroupIds = array_merge(array($userid),$this->getGroupsIdsForUsers($userid));
 		$queryGenerator = new QueryGenerator($moduleModel->get('name'), $user);
 
-		$queryGenerator->setFields(array('activityid','subject', 'taskstatus','activitytype', 'date_start','time_start','due_date','time_end','id', 'assigned_user_id','parent_id','description','visibility','taskpriority'));
+		$queryGenerator->setFields(array('activityid','subject', 'taskstatus','activitytype', 'date_start','time_start','due_date','time_end','id', 'assigned_user_id','parent_id','description','visibility','taskpriority', 'common_memo'));
 		$query = $queryGenerator->getQuery();
 
 		$currentUser = Users_Record_Model::getCurrentUserModel();
@@ -575,6 +576,7 @@ class Calendar_Feed_Action extends Vtiger_BasicAjax_Action {
 
 			$ownerId = $record['smownerid'];
 			$item['assigned_user_id'] = $this->cacheUser[$record['smownerid']];
+			$item['common_memo'] = $record['common_memo'];
 
 			$inviteeDetails = $this->getInviteeNames($record['activityid']);
 			$group = Settings_Groups_Record_Model::getInstance($ownerId);

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -2257,6 +2257,10 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				popOverHTML += '<div class="calendar-popover-common-memo">' + app.vtranslate('Common Memo') + ': ' + eventObj.common_memo + '</div>';
 			}
 
+			if(eventObj.invitees && eventObj.invitees != '') {
+				popOverHTML += '<div class="calendar-popover-invitees">' + eventObj.invitees_field_label + ': ' + eventObj.invitees + '</div>';
+			}
+
 			if(event.creator && event.creator != '' || event.modifiedby && event.modifiedby != '') {
 				popOverHTML += '<div class="calendar-space">';
 

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -2250,7 +2250,11 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			}
 
 			if(eventObj.description && eventObj.description != '') {
-				popOverHTML += '<div class="calendar-popover-description">' + eventObj.description + '</div>';
+				popOverHTML += '<div class="calendar-popover-description">' + app.vtranslate('LBL_DESCRIPTION') + ': ' + eventObj.description + '</div>';
+			}
+
+			if(eventObj.common_memo && eventObj.common_memo != '') {
+				popOverHTML += '<div class="calendar-popover-common-memo">' + app.vtranslate('Common Memo') + ': ' + eventObj.common_memo + '</div>';
 			}
 
 			if(event.creator && event.creator != '' || event.modifiedby && event.modifiedby != '') {

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -1844,7 +1844,8 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
    説明文のみスクロール可能にし、完了・編集等のアイコンは常に表示する。
    モバイル表示では二重スクロール回避のため制限を適用しない */
 @media (min-width: 769px) {
-    .webui-popover .calendar-popover-description {
+    .webui-popover .calendar-popover-description,
+    .webui-popover .calendar-popover-common-memo {
         max-height: 200px;
         overflow-y: auto;
         margin-bottom: 4px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1657

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダー上で活動をマウスオーバーした際に「詳細内容」項目しか表示されないため、共有メモも表示してほしい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. カレンダー用のデータ取得クエリに common_memo フィールドが含まれていない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. modules/Calendar/actions/Feed.php：イベントおよびタスクの取得フィールドに common_memo を追加。
2. public/layouts/v7/modules/Calendar/resources/Calendar.js：マウスオーバー時に詳細内容と共有メモの内容がどちらかわからないため、「詳細内容：」と「共有メモ：」の表示行を追加。
3. languages/*/Calendar.php：LBL_DESCRIPTION（詳細内容）と Common Memo（共有メモ）の訳語を追加。
4. public/resources/styles.css：共有メモの表示エリアに対し、詳細内容と同様のスクロール設定を適用。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="456" height="276" alt="2026-06-17 (1)" src="https://github.com/user-attachments/assets/b8218caa-055c-4145-be21-cb670c35f50c" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->