### PR TITLE
Fix/1638-[不具合] Inventory系のインポート画面で税種別のデフォルト値が英語

### DIFF
--- a/include/Webservices/WebserviceField.php
+++ b/include/Webservices/WebserviceField.php
@@ -368,8 +368,8 @@ class WebserviceField{
                 }
             } else {
 				$hardCodedPickListNames = array('hdntaxtype','email_flag');
-				$hardCodedPickListValues = array('hdntaxtype'=> array(	array('label' => 'Individual',	'value' => 'individual'),
-																		array('label' => 'Group',		'value' => 'group')),
+				$hardCodedPickListValues = array('hdntaxtype'=> array(	array('label' => 'individual',	'value' => 'individual'),
+																		array('label' => 'group',		'value' => 'group')),
 												 'email_flag'=> array(	array('label' => 'SAVED',		'value' => 'SAVED'),
 																		array('label' => 'SENT',		'value' => 'SENT'),
 																		array('label' => 'MAILSCANNER',	'value' => 'MAILSCANNER')));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1638

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  請求、受注などのインベントリ系モジュールのインポート設定画面（マッピングおよびデフォルト値の設定ステップ）において、「税種別」フィールドのデフォルト値を選択する際、プルダウン内の選択肢が英語で表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1.   include/Webservices/WebserviceField.php 内の getPicklistDetails メソッドにおいて、選択肢ラベルが "Individual"および "Group" と先頭大文字でハードコードされていた。日本語言語ファイル（languages/ja_jp/Vtiger.php）には先頭小文字のキーは定義されていたが、大文字ではないためマッチングに失敗し、ハードコードされた英語がそのまま表示されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. include/Webservices/WebserviceField.php：ハードコードされていたラベルを小文字に変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="658" height="137" alt="image" src="https://github.com/user-attachments/assets/0071dc6e-bf38-44bb-a0cf-1b3194989b6d" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->