### PR TITLE
#1664 クイック作成参照フィールドのハーフモーダル一覧を更新日時順に変更

### DIFF
--- a/modules/Vtiger/apis/SearchRecords.php
+++ b/modules/Vtiger/apis/SearchRecords.php
@@ -195,16 +195,17 @@ class Vtiger_SearchRecords_Api extends Vtiger_Api_Controller {
             $first = false;
         }
 
-        // クエリ実行（limit+1件取得）
+        // モジュールのIDフィールド名を取得
+        $focus = CRMEntity::getInstance($moduleName);
+        $idColumn = $focus->table_index ?? 'crmid';
+
+        // クエリ実行（limit+1件取得、basetable側で更新日時降順ソート）
         $query = $queryGenerator->getQuery();
+        $query .= $this->getOrderByClause($focus, $query);
         $query .= " LIMIT " . (int)$offset . ", " . (int)($limit + 1);
 
         global $adb;
         $queryResult = $adb->pquery($query, array());
-
-        // モジュールのIDフィールド名を取得
-        $focus = CRMEntity::getInstance($moduleName);
-        $idColumn = $focus->table_index ?? 'crmid';
 
         $records = array();
         $hasNextPage = false;
@@ -247,6 +248,47 @@ class Vtiger_SearchRecords_Api extends Vtiger_Api_Controller {
             'records' => $records,
             'hasNextPage' => $hasNextPage
         );
+    }
+
+    /**
+     * ソート用 ORDER BY 句を生成
+     * basetable に modifiedtime カラムがあれば modifiedtime 降順、なければ主キー降順
+     * @param Vtiger_CRMEntity $focus
+     * @param string $existingQuery 既存クエリ（既に ORDER BY / UNION を含む場合は注入をスキップ）
+     * @return string ORDER BY 句（先頭スペース付き、注入不可時は空文字）
+     */
+    private function getOrderByClause($focus, $existingQuery = '') {
+        global $adb;
+        $baseTable = $focus->table_name ?? '';
+        $idColumn = $focus->table_index ?? 'crmid';
+
+        // 識別子バリデーション（深層防御：basetable/idColumn は通常モジュールクラスのハードコード値）
+        if (!preg_match('/^[A-Za-z0-9_]+$/', $baseTable) || !preg_match('/^[A-Za-z0-9_]+$/', $idColumn)) {
+            return '';
+        }
+
+        // 既存クエリに ORDER BY / UNION が含まれる場合は注入をスキップ
+        // （末尾連結だと UNION 全体に効かず、ORDER BY 重複は構文エラーになるため）
+        if (!empty($existingQuery)) {
+            if (stripos($existingQuery, ' ORDER BY ') !== false || stripos($existingQuery, ' UNION ') !== false) {
+                return '';
+            }
+        }
+
+        // basetable に modifiedtime カラムがあるか確認（リクエスト内 static cache）
+        static $hasModifiedTimeCache = array();
+        if (!isset($hasModifiedTimeCache[$baseTable])) {
+            $columnResult = $adb->pquery(
+                "SHOW COLUMNS FROM " . $baseTable . " LIKE 'modifiedtime'",
+                array()
+            );
+            $hasModifiedTimeCache[$baseTable] = ($columnResult && $adb->num_rows($columnResult) > 0);
+        }
+
+        if ($hasModifiedTimeCache[$baseTable]) {
+            return " ORDER BY " . $baseTable . ".modifiedtime DESC, " . $baseTable . "." . $idColumn . " DESC";
+        }
+        return " ORDER BY " . $baseTable . "." . $idColumn . " DESC";
     }
 
     /**
@@ -421,17 +463,18 @@ class Vtiger_SearchRecords_Api extends Vtiger_Api_Controller {
         // ListView_Modelを使用してクエリを生成（モジュール固有の処理を適用）
         $listViewModel = Vtiger_ListView_Model::getInstanceForPopup($moduleName);
 
-        // クエリ取得
+        // モジュールのIDフィールド名を取得
+        $focus = CRMEntity::getInstance($moduleName);
+        $idColumn = $focus->table_index ?? 'crmid';
+
+        // クエリ取得 + basetable側で更新日時降順ソート
         $query = $listViewModel->getQuery();
+        $query .= $this->getOrderByClause($focus, $query);
 
         // limit+1件取得して次ページ有無を判定
         $query .= " LIMIT " . (int)$offset . ", " . (int)($limit + 1);
 
         $result = $adb->pquery($query, array());
-
-        // モジュールのIDフィールド名を取得
-        $focus = CRMEntity::getInstance($moduleName);
-        $idColumn = $focus->table_index ?? 'crmid';
 
         $count = 0;
         while ($row = $adb->fetch_array($result)) {


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1664

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. クイック作成の参照項目の虫眼鏡ボタンで開くハーフモーダル上の関連レコード一覧、ID昇順表示となっており、WebComponents版以前(jQuery版)の更新日時順表示から退行している。基本一覧は更新日時順の方が使いやすいため、ソート定義を要望。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ハーフモーダル(`RecordSearchDrawer`)が叩く `SearchRecords` API のレコード列挙クエリ (`getRecentRecords()` / `searchByFields()`) に ORDER BY 句が未定義。MySQLが主キー昇順で返却していたため、結果的にID順表示となっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `modules/Vtiger/apis/SearchRecords.php` に `getOrderByClause()` private helper を追加し、`getRecentRecords()` / `searchByFields()` のクエリへ LIMIT 句の前に ORDER BY を注入
2. basetable に `modifiedtime` カラムが存在すれば `ORDER BY {baseTable}.modifiedtime DESC, {baseTable}.{idColumn} DESC` でソート、無ければ主キー降順にフォールバック（Users 等 vtiger_crmentity 非依存モジュール対応）
3. SHOW COLUMNS の結果はリクエスト内 static cache で重複発行を回避
4. 深層防御として、basetable / idColumn 識別子のホワイトリストバリデーション (`/^[A-Za-z0-9_]+$/`)、既存クエリに ORDER BY / UNION 含む場合の注入スキップ、SHOW COLUMNS が false 返却時のフォールバックを実装

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1933" height="672" alt="image" src="https://github.com/user-attachments/assets/70a236cc-4eae-4e50-81bf-a2b6f87ef806" />
<img width="1365" height="589" alt="image" src="https://github.com/user-attachments/assets/a7dee42d-f9f2-4faf-8aa8-6f80fc425dce" />



## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- WebComponents 版クイック作成（QuickCreate）の参照フィールド検索ドロップダウンおよび虫眼鏡ハーフモーダル
- `SearchRecords` API を利用する箇所全般（参照フィールド `ReferenceField`, `RecordSearchDrawer`）
- 変更ファイル:
- `modules/Vtiger/apis/SearchRecords.php`

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った  ※該当なし（メッセージ追加・UI文言変更なし）

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
