### PR TITLE
Fix/1532 親の製品の関連付けが削除できない不具合を修正

### DIFF
--- a/modules/Products/models/Relation.php
+++ b/modules/Products/models/Relation.php
@@ -90,7 +90,10 @@ class Products_Relation_Model extends Vtiger_Relation_Model {
 	public function deleteProductToProductRelation($sourceRecordId, $relatedRecordId) {
 		$db = PearDatabase::getInstance();
 		if(!empty($sourceRecordId) && !empty($relatedRecordId)){
-			$db->pquery('DELETE FROM vtiger_seproductsrel WHERE crmid = ? AND productid = ?', array($relatedRecordId, $sourceRecordId));
+			$db->pquery('DELETE FROM vtiger_seproductsrel 
+						 WHERE (crmid = ? AND productid = ?) 
+							OR (crmid = ? AND productid = ?)', 
+						 array($relatedRecordId, $sourceRecordId, $sourceRecordId, $relatedRecordId));
 			return true;
 		}
 	}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1532 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. [製品]-[親の製品]タブを選択し、1つを選んで「関連を外す」を選択しても、リストから削除されない

##  原因 / Cause
<!-- バグの原因を記述 -->
1. /modules/Products/models/Relation.php内の関数deleteProductToProductRelation()で、親→子の関連付けの削除のみ定義されていた。（ 製品は親にも子にもなることができるため。）

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. OR 条件を追加し、$sourceRecordId と $relatedRecordId がどちらの列に入っていても、双方向の関連レコードがまとめて削除されるようにした。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
製品（Products）モジュール間の関連付け解除機能。
画面上で、製品の関連リストから別の製品との「関連を外す（削除する）」操作を行った際の挙動すべて。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
uitype10で関連付けされているものも確認した限り同様の挙動はなかった。