### PR TITLE
fix #1648 インポートのバルクセーブをデフォルトでfalseにする

### DIFF
--- a/cron/modules/Import/ScheduledImport.service
+++ b/cron/modules/Import/ScheduledImport.service
@@ -10,7 +10,8 @@
 
 
 $previousBulkSaveMode = $VTIGER_BULK_SAVE_MODE;
-$VTIGER_BULK_SAVE_MODE = true;
+// バルクセーブではイベントがスキップされ不具合が発生するため、デフォルトでfalseにする
+$VTIGER_BULK_SAVE_MODE = false;
 
 require_once  'includes/Loader.php';
 require_once 'includes/runtime/Controller.php';

--- a/modules/Vtiger/views/Import.php
+++ b/modules/Vtiger/views/Import.php
@@ -36,7 +36,8 @@ class Vtiger_Import_View extends Vtiger_Index_View {
 	function process(Vtiger_Request $request) {
 		global $VTIGER_BULK_SAVE_MODE;
 		$previousBulkSaveMode = $VTIGER_BULK_SAVE_MODE;
-		$VTIGER_BULK_SAVE_MODE = true;
+		// バルクセーブではイベントがスキップされ不具合が発生するため、デフォルトでfalseにする
+		$VTIGER_BULK_SAVE_MODE = false;
 
 		$mode = $request->getMode();
 		if(!empty($mode)) {
@@ -260,7 +261,8 @@ class Vtiger_Import_View extends Vtiger_Index_View {
 			exit;
 		}
 		$previousBulkSaveMode = $VTIGER_BULK_SAVE_MODE;
-		$VTIGER_BULK_SAVE_MODE = true;
+		// バルクセーブではイベントがスキップされ不具合が発生するため、デフォルトでfalseにする
+		$VTIGER_BULK_SAVE_MODE = false;
 		$query = "SELECT recordid FROM $dbTableName WHERE status = ? AND recordid IS NOT NULL";
 		//For inventory modules
 		$inventoryModules = getInventoryModules();


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1648

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インポート時、バルクセーブモード（`$VTIGER_BULK_SAVE_MODE`）がデフォルトで `true` になっている。
2. バルクセーブモードではイベント（ワークフロー等）がスキップされるため、スキップを想定していない処理で不具合が発生する。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポート処理（インタラクティブ実行・スケジュール実行）およびインポートのアンドゥ処理で、`$VTIGER_BULK_SAVE_MODE` を一律 `true` に設定していたため、イベントがスキップされていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `modules/Vtiger/views/Import.php` の `process()`（インポート実行）で `$VTIGER_BULK_SAVE_MODE` を `false` に変更。
2. `modules/Vtiger/views/Import.php` のアンドゥ処理で `$VTIGER_BULK_SAVE_MODE` を `false` に変更。
3. `cron/modules/Import/ScheduledImport.service`（スケジュールインポート）で `$VTIGER_BULK_SAVE_MODE` を `false` に変更。

※ 速度面で指摘があった場合に `true` へ戻せるよう、設定箇所はそのまま残しています。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
なし（内部処理の変更のため）

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- 全モジュールのインポート（手動実行・スケジュール実行）およびインポートのアンドゥ処理。
- これまでスキップされていたイベント（ワークフロー等）がインポート時にも実行されるようになる。インポートの処理速度は低下する可能性がある。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
バルクセーブを有効にすると速度は向上するがイベントがスキップされるトレードオフがあるため、Issueの要望に従い、デフォルトを `false`（イベントを実行する安全側）に変更しています。
