### PR TITLE
Fix/1592 グループに役割を追加した際にラベル名が表示される不具合を修正

### DIFF
--- a/layouts/v7/modules/Settings/Groups/DetailView.tpl
+++ b/layouts/v7/modules/Settings/Groups/DetailView.tpl
@@ -54,10 +54,17 @@
 												{vtranslate($GROUP_LABEL,$QUALIFIED_MODULE)}
 											</li>
 											{foreach item=GROUP_MEMBER_INFO from=$GROUP_MEMBERS}
-												<li>
-													<a href="{$GROUP_MEMBER_INFO->getDetailViewUrl()}">{$GROUP_MEMBER_INFO->get('name')}</a>
-												</li>
-											{/foreach}
+	<li>
+		<a href="{$GROUP_MEMBER_INFO->getDetailViewUrl()}">
+			{assign var="MEMBER_NAME" value=$GROUP_MEMBER_INFO->get('name')}
+			{if ($GROUP_LABEL eq 'Roles' or $GROUP_LABEL eq 'RoleAndSubordinates')}
+				{vtranslate($MEMBER_NAME, 'Settings:Roles')}
+			{else}
+				{$MEMBER_NAME}
+			{/if}
+		</a>
+	</li>
+{/foreach}
 										{/if}
 									{/foreach}
 								</ul>

--- a/layouts/v7/modules/Settings/Groups/EditView.tpl
+++ b/layouts/v7/modules/Settings/Groups/EditView.tpl
@@ -65,7 +65,13 @@
 												<optgroup label="{vtranslate({$GROUP_LABEL}, $QUALIFIED_MODULE)}" class="{$GROUP_LABEL}">
 													{foreach from=$ALL_GROUP_MEMBERS item=MEMBER}
 														{if $MEMBER->getName() neq $RECORD_MODEL->getName()}
-															<option value="{$MEMBER->getId()}" data-member-type="{$GROUP_LABEL}" {if isset($GROUP_MEMBERS[$GROUP_LABEL][$MEMBER->getId()])} selected="true"{/if}>{vtranslate(trim($MEMBER->getName()), $QUALIFIED_MODULE)}</option>
+															<option value="{$MEMBER->getId()}" data-member-type="{$GROUP_LABEL}" {if isset($GROUP_MEMBERS[$GROUP_LABEL][$MEMBER->getId()])} selected="true"{/if}>
+																{if ($GROUP_LABEL eq 'Roles' or $GROUP_LABEL eq 'RoleAndSubordinates')}
+																	{vtranslate(trim($MEMBER->getName()), $QUALIFIED_MODULE)}
+																{else}
+																	{$MEMBER->getName()}
+																{/if}
+															</option>
 														{/if}
 													{/foreach}
 												</optgroup>

--- a/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
@@ -81,7 +81,11 @@
 											{assign var=LISTVIEW_HEADERNAME value=$LISTVIEW_HEADER->get('name')}
 											{assign var=LAST_COLUMN value=$LISTVIEW_HEADER@last}
 											<td class="listViewEntryValue textOverflowEllipsis {$WIDTHTYPE}" width="{$WIDTH}%" nowrap>
-												{vtranslate($LISTVIEW_ENTRY->getDisplayValue($LISTVIEW_HEADERNAME), $QUALIFIED_MODULE)}
+												{if $MODULE eq 'Groups' and $LISTVIEW_HEADERNAME eq 'groupname'}
+													{$LISTVIEW_ENTRY->getDisplayValue($LISTVIEW_HEADERNAME)}
+												{else}
+													{vtranslate($LISTVIEW_ENTRY->getDisplayValue($LISTVIEW_HEADERNAME), $QUALIFIED_MODULE)}
+												{/if}
 												{if $LAST_COLUMN && $LISTVIEW_ENTRY->getRecordLinks()}
 													</td>
 												{/if}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1592 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. グループに役割を追加した際にラベル名が表示される

##  原因 / Cause
<!-- バグの原因を記述 -->
1. グループの詳細画面の制御にはvtranslteでラベルの翻訳がされていなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. layouts/v7/modules/Settings/Groups/DetailView.tpl
グループ詳細画面のメンバー一覧において、種別が「ロール（Roles/RoleAndSubordinates）」の場合に、メンバー名が正しく翻訳されて表示されるよう修正。
2. layouts/v7/modules/Settings/Groups/EditView.tpl
グループ編集画面のメンバー選択において、詳細画面と同様に「ロール」名の翻訳が適用されるよう修正。
3. layouts/v7/modules/Settings/Vtiger/ListViewContents.tpl
グループ一覧画面において、グループ名（groupname）自体が誤って翻訳（置換）されてしまうのを防ぐため、グループ名表示時は翻訳処理を通さないよう条件分岐を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="322" height="210" alt="image" src="https://github.com/user-attachments/assets/c5f3809e-7a1d-488c-a964-4756efc0dff4" />

変更後
<img width="320" height="209" alt="image" src="https://github.com/user-attachments/assets/f8c463d3-3db9-481e-adf1-d52d07d5e4eb" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
グループの一覧、詳細、編集画面
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
グループ名として「LBL_GENERAL」のような役割のラベルｔ偶然一致した際に、間違えて翻訳されて「一般」にならないように条件をつけた。