### PR TITLE
Fix/1389-[不具合]関連タブから活動を表示した際にステータスが表示されない

### DIFF
--- a/modules/Vtiger/models/RelationListView.php
+++ b/modules/Vtiger/models/RelationListView.php
@@ -375,6 +375,9 @@ class Vtiger_RelationListView_Model extends Vtiger_Base_Model {
 					}
 					$newRow['subject'] = vtranslate('Busy','Events').'*';
 				}
+				if (empty($newRow['taskstatus']) && !empty($row['eventstatus'])) {
+					$newRow['taskstatus'] = $row['eventstatus'];
+				}
 			}
 
 			$record = Vtiger_Record_Model::getCleanInstance($relationModule->get('name'));


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1389

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
システム設定のモジュール管理の項目設定において、「活動」モジュールに対象モジュール（標準で活動が関連タブに存在しないモジュール）を追加すると、活動にステータスが設定されているのにもかかわらず、空白になる。

##  原因 / Cause
<!-- バグの原因を記述 -->
カレンダーの中で、タスクのステータスとイベントのステータスが違うカラムに保存されいている。最初から用意している関連リストでは、正しく合流処理がされていたため表示されるが、新しく追加した関連リストでは合流処理がなくタスク用のカラムを読んでいたため何も表示されなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
modules/Vtiger/models/RelationListView.php：イベントのステータスを画面表示用の配列に代入する処理を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1848" height="519" alt="image" src="https://github.com/user-attachments/assets/2c17811c-3cb3-45c5-a780-fc3e8520c4b9" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->