### PR TITLE
Fix/1547-[不具合] レポートで同一レコード内の２つの値（金額）を含むデータを一覧表示した場合に、項目名などでグループ化した場合にデータが表示されない場合がある

### DIFF
--- a/layouts/v7/modules/Reports/ReportContents.tpl
+++ b/layouts/v7/modules/Reports/ReportContents.tpl
@@ -79,13 +79,19 @@
 
                         {if $GROUPBYFIELDSCOUNT eq 1}
                             {assign var=FIRST_FIELD value=vtranslate(trim($FIELDNAMES[0]),$GROUPING_MODULES[0])}
+                            {assign var=FULL_FIRST_FIELD value=vtranslate($GROUPING_MODULES[0], $GROUPING_MODULES[0])|cat:" "|cat:$FIRST_FIELD}
                         {else if $GROUPBYFIELDSCOUNT eq 2}    
                             {assign var=FIRST_FIELD value=vtranslate(trim($FIELDNAMES[0]),$GROUPING_MODULES[0])}
+                            {assign var=FULL_FIRST_FIELD value=vtranslate($GROUPING_MODULES[0], $GROUPING_MODULES[0])|cat:" "|cat:$FIRST_FIELD}
                             {assign var=SECOND_FIELD value=vtranslate(trim($FIELDNAMES[1]),$GROUPING_MODULES[1])}
+                            {assign var=FULL_SECOND_FIELD value=vtranslate($GROUPING_MODULES[1], $GROUPING_MODULES[1])|cat:" "|cat:$SECOND_FIELD}
                         {else if $GROUPBYFIELDSCOUNT eq 3}    
                             {assign var=FIRST_FIELD value=vtranslate(trim($FIELDNAMES[0]),$GROUPING_MODULES[0])}
+                            {assign var=FULL_FIRST_FIELD value=vtranslate($GROUPING_MODULES[0], $GROUPING_MODULES[0])|cat:" "|cat:$FIRST_FIELD}
                             {assign var=SECOND_FIELD value=vtranslate(trim($FIELDNAMES[1]),$GROUPING_MODULES[1])}
+                            {assign var=FULL_SECOND_FIELD value=vtranslate($GROUPING_MODULES[1], $GROUPING_MODULES[1])|cat:" "|cat:$SECOND_FIELD}
                             {assign var=THIRD_FIELD value=vtranslate(trim($FIELDNAMES[2]),$GROUPING_MODULES[2])}
+                            {assign var=FULL_THIRD_FIELD value=vtranslate($GROUPING_MODULES[2], $GROUPING_MODULES[2])|cat:" "|cat:$THIRD_FIELD}
                         {/if}    
 
                         {assign var=FIRST_VALUE value=" "}
@@ -96,7 +102,7 @@
                             {assign var=SECOND_IS_HEAD value=0}
                             <tr>
                                 {foreach from=$VALUES item=VALUE key=NAME}
-                                    {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || strpos($NAME, $FIRST_FIELD) === 0) && ($FIRST_VALUE eq $VALUE || $FIRST_VALUE eq " ")}
+                                    {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || $NAME eq $FULL_FIRST_FIELD) && ($FIRST_VALUE eq $VALUE || $FIRST_VALUE eq " ")}
                                         {if $FIRST_VALUE eq " " || $VALUE eq "-"}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$FIRST_IS_HEAD = 1}
@@ -108,7 +114,7 @@
                                         {if $VALUE neq " " }
                                             {$FIRST_VALUE = $VALUE}
                                         {/if}   
-                                    {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || strpos($NAME, $SECOND_FIELD) === 0) && ($SECOND_VALUE eq $VALUE || $SECOND_VALUE eq " ")}
+                                    {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || $NAME eq $FULL_SECOND_FIELD) && ($SECOND_VALUE eq $VALUE || $SECOND_VALUE eq " ")}
                                         {if $SECOND_VALUE eq " " || $VALUE eq "-" || $FIRST_IS_HEAD eq 1}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$SECOND_IS_HEAD = 1}
@@ -120,7 +126,7 @@
                                         {if $VALUE neq " " }
                                             {$SECOND_VALUE = $VALUE}
                                         {/if}   
-                                    {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || strpos($NAME, $THIRD_FIELD) === 0) && ($THIRD_VALUE eq $VALUE || $THIRD_VALUE eq " ")}
+                                    {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || $NAME eq $FULL_THIRD_FIELD) && ($THIRD_VALUE eq $VALUE || $THIRD_VALUE eq " ")}
                                         {if $THIRD_VALUE eq " " || $VALUE eq "-" || $SECOND_IS_HEAD eq 1}
                                             <td class="summaryHead">{$VALUE}</td>
                                         {else if $VALUE eq ""}
@@ -132,15 +138,15 @@
                                             {$THIRD_VALUE = $VALUE}
                                         {/if}
                                     {else}
-                                        {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || strpos($NAME, $FIRST_FIELD) === 0)}
+                                        {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || $NAME eq $FULL_FIRST_FIELD)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$FIRST_IS_HEAD = 1}
                                             {$FIRST_VALUE = $VALUE}
-                                        {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || strpos($NAME, $SECOND_FIELD) === 0)}
+                                        {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || $NAME eq $FULL_SECOND_FIELD)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$SECOND_IS_HEAD = 1}
                                             {$SECOND_VALUE = $VALUE}
-                                        {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || strpos($NAME, $THIRD_FIELD) === 0)}
+                                        {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || $NAME eq $FULL_THIRD_FIELD)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$THIRD_VALUE = $VALUE}
                                         {else}

--- a/layouts/v7/modules/Reports/ReportContents.tpl
+++ b/layouts/v7/modules/Reports/ReportContents.tpl
@@ -96,7 +96,7 @@
                             {assign var=SECOND_IS_HEAD value=0}
                             <tr>
                                 {foreach from=$VALUES item=VALUE key=NAME}
-                                    {if ($NAME eq $FIRST_FIELD || $NAME|strstr:{$FIRST_FIELD}) && ($FIRST_VALUE eq $VALUE || $FIRST_VALUE eq " ")}
+                                    {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || strpos($NAME, $FIRST_FIELD) === 0) && ($FIRST_VALUE eq $VALUE || $FIRST_VALUE eq " ")}
                                         {if $FIRST_VALUE eq " " || $VALUE eq "-"}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$FIRST_IS_HEAD = 1}
@@ -108,7 +108,7 @@
                                         {if $VALUE neq " " }
                                             {$FIRST_VALUE = $VALUE}
                                         {/if}   
-                                    {else if ( $NAME eq $SECOND_FIELD || $NAME|strstr:$SECOND_FIELD) && ($SECOND_VALUE eq $VALUE || $SECOND_VALUE eq " ")}
+                                    {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || strpos($NAME, $SECOND_FIELD) === 0) && ($SECOND_VALUE eq $VALUE || $SECOND_VALUE eq " ")}
                                         {if $SECOND_VALUE eq " " || $VALUE eq "-" || $FIRST_IS_HEAD eq 1}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$SECOND_IS_HEAD = 1}
@@ -120,7 +120,7 @@
                                         {if $VALUE neq " " }
                                             {$SECOND_VALUE = $VALUE}
                                         {/if}   
-                                    {else if ($NAME eq $THIRD_FIELD || $NAME|strstr:$THIRD_FIELD) && ($THIRD_VALUE eq $VALUE || $THIRD_VALUE eq " ")}
+                                    {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || strpos($NAME, $THIRD_FIELD) === 0) && ($THIRD_VALUE eq $VALUE || $THIRD_VALUE eq " ")}
                                         {if $THIRD_VALUE eq " " || $VALUE eq "-" || $SECOND_IS_HEAD eq 1}
                                             <td class="summaryHead">{$VALUE}</td>
                                         {else if $VALUE eq ""}
@@ -132,15 +132,15 @@
                                             {$THIRD_VALUE = $VALUE}
                                         {/if}
                                     {else}
-                                        {if $NAME eq $FIRST_FIELD || $NAME|strstr:$FIRST_FIELD}
+                                        {if !empty($FIRST_FIELD) && ($NAME eq $FIRST_FIELD || strpos($NAME, $FIRST_FIELD) === 0)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$FIRST_IS_HEAD = 1}
                                             {$FIRST_VALUE = $VALUE}
-                                        {else if $NAME eq $SECOND_FIELD || $NAME|strstr:$SECOND_FIELD}
+                                        {else if !empty($SECOND_FIELD) && ($NAME eq $SECOND_FIELD || strpos($NAME, $SECOND_FIELD) === 0)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$SECOND_IS_HEAD = 1}
                                             {$SECOND_VALUE = $VALUE}
-                                        {else if $NAME eq $THIRD_FIELD || $NAME|strstr:$THIRD_FIELD}
+                                        {else if !empty($THIRD_FIELD) && ($NAME eq $THIRD_FIELD || strpos($NAME, $THIRD_FIELD) === 0)}
                                             <td class="summaryHead">{$VALUE}</td>
                                             {$THIRD_VALUE = $VALUE}
                                         {else}

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -3754,9 +3754,11 @@ class ReportRun extends CRMEntity {
 				}
 
 				$groupslist = $this->getGroupingList($this->reportid);
+				$groupByModules = array();
 				foreach ($groupslist as $reportFieldName => $reportFieldValue) {
 					$nameParts = explode(":", $reportFieldName);
 					list($groupFieldModuleName, $groupFieldName) = split("_", $nameParts[2], 2);
+					$groupByModules[] = $groupFieldModuleName;
 					if(in_array($groupFieldName, $includedUnderbarLabels)){
 						$groupByFieldNames[] = vtranslate($groupFieldName, $groupFieldModuleName);
 					} else {
@@ -3766,13 +3768,19 @@ class ReportRun extends CRMEntity {
 				if (php7_count($groupByFieldNames) > 0) {
 					if (php7_count($groupByFieldNames) == 1) {
 						$firstField = $groupByFieldNames[0];
+						$fullFirstField = vtranslate($groupByModules[0], $groupByModules[0]) . " " . $firstField;
 					} else if (php7_count($groupByFieldNames) == 2) {
 						$firstField = $groupByFieldNames[0];
+						$fullFirstField = vtranslate($groupByModules[0], $groupByModules[0]) . " " . $firstField;
 						$secondField = $groupByFieldNames[1];
+						$fullSecondField = vtranslate($groupByModules[1], $groupByModules[1]) . " " . $secondField;
 					} else if (php7_count($groupByFieldNames) == 3) {
 						$firstField = $groupByFieldNames[0];
+						$fullFirstField = vtranslate($groupByModules[0], $groupByModules[0]) . " " . $firstField;
 						$secondField = $groupByFieldNames[1];
+						$fullSecondField = vtranslate($groupByModules[1], $groupByModules[1]) . " " . $secondField;
 						$thirdField = $groupByFieldNames[2];
+						$fullThirdField = vtranslate($groupByModules[2], $groupByModules[2]) . " " . $thirdField;
 					}
 					$firstValue = ' ';
 					$secondValue = ' ';
@@ -3785,7 +3793,7 @@ class ReportRun extends CRMEntity {
 							if ($fieldName == 'ACTION' || $fieldName == vtranslate('LBL_ACTION', $this->primarymodule) || $fieldName == vtranslate($this->primarymodule, $this->primarymodule) . " " . vtranslate('LBL_ACTION', $this->primarymodule) || $fieldName == vtranslate('LBL ACTION', $this->primarymodule) || $fieldName == vtranslate($this->primarymodule, $this->primarymodule) . " " . vtranslate('LBL ACTION', $this->primarymodule)) {
 								continue;
 							}
-							if (!empty($firstField) && ($fieldName == $firstField || strpos($fieldName, $firstField) === 0) && ($firstValue == $fieldValue || $firstValue == " ")) {
+							if (!empty($firstField) && ($fieldName == $firstField || $fieldName == $fullFirstField) && ($firstValue == $fieldValue || $firstValue == " ")) {
 								if ($firstValue == ' ' || $fieldValue == '-') {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 									$firstIsHead = 1;
@@ -3797,7 +3805,7 @@ class ReportRun extends CRMEntity {
 								if ($fieldValue != ' ') {
 									$firstValue = $fieldValue;
 								}
-							} else if (!empty($secondField) && ($fieldName == $secondField || strpos($fieldName, $secondField) === 0) && ($secondValue == $fieldValue || $secondValue == " ")) {
+							} else if (!empty($secondField) && ($fieldName == $secondField || $fieldName == $fullSecondField) && ($secondValue == $fieldValue || $secondValue == " ")) {
 								if ($secondValue == ' ' || $secondValue == '-' || $firstIsHead == 1) {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 									$secondIsHead = 1;
@@ -3809,7 +3817,7 @@ class ReportRun extends CRMEntity {
 								if ($fieldValue != ' ') {
 									$secondValue = $fieldValue;
 								}
-							} else if (!empty($thirdField) && ($fieldName == $thirdField || strpos($fieldName, $thirdField) === 0) && ($thirdValue == $fieldValue || $thirdValue == " ")) {
+							} else if (!empty($thirdField) && ($fieldName == $thirdField || $fieldName == $fullThirdField) && ($thirdValue == $fieldValue || $thirdValue == " ")) {
 								if ($thirdValue == ' ' || $thirdValue == '-' || $secondIsHead == 1) {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 								} else if($thirdValue == '') {
@@ -3822,13 +3830,13 @@ class ReportRun extends CRMEntity {
 								}
 							} else {
 								$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
-								if (!empty($firstField) && ($fieldName == $firstField || strpos($fieldName, $firstField) === 0)) {
+								if (!empty($firstField) && ($fieldName == $firstField || $fieldName == $fullFirstField)) {
 									$firstIsHead = 1;
 									$firstValue = $fieldValue;
-								} else if (!empty($secondField) && ($fieldName == $secondField || strpos($fieldName, $secondField) === 0)) {
+								} else if (!empty($secondField) && ($fieldName == $secondField || $fieldName == $fullSecondField)) {
 									$secondIsHead = 1;
 									$secondValue = $fieldValue;
-								} else if (!empty($thirdField) && ($fieldName == $thirdField || strpos($fieldName, $thirdField) === 0)) {
+								} else if (!empty($thirdField) && ($fieldName == $thirdField || $fieldName == $fullThirdField)) {
 									$thirdValue = $fieldValue;
 								}
 							}

--- a/modules/Reports/ReportRun.php
+++ b/modules/Reports/ReportRun.php
@@ -3785,7 +3785,7 @@ class ReportRun extends CRMEntity {
 							if ($fieldName == 'ACTION' || $fieldName == vtranslate('LBL_ACTION', $this->primarymodule) || $fieldName == vtranslate($this->primarymodule, $this->primarymodule) . " " . vtranslate('LBL_ACTION', $this->primarymodule) || $fieldName == vtranslate('LBL ACTION', $this->primarymodule) || $fieldName == vtranslate($this->primarymodule, $this->primarymodule) . " " . vtranslate('LBL ACTION', $this->primarymodule)) {
 								continue;
 							}
-							if (($fieldName == $firstField || strstr($fieldName, $firstField)) && ($firstValue == $fieldValue || $firstValue == " ")) {
+							if (!empty($firstField) && ($fieldName == $firstField || strpos($fieldName, $firstField) === 0) && ($firstValue == $fieldValue || $firstValue == " ")) {
 								if ($firstValue == ' ' || $fieldValue == '-') {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 									$firstIsHead = 1;
@@ -3797,7 +3797,7 @@ class ReportRun extends CRMEntity {
 								if ($fieldValue != ' ') {
 									$firstValue = $fieldValue;
 								}
-							} else if (($fieldName == $secondField || strstr($fieldName, $secondField)) && ($secondValue == $fieldValue || $secondValue == " ")) {
+							} else if (!empty($secondField) && ($fieldName == $secondField || strpos($fieldName, $secondField) === 0) && ($secondValue == $fieldValue || $secondValue == " ")) {
 								if ($secondValue == ' ' || $secondValue == '-' || $firstIsHead == 1) {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 									$secondIsHead = 1;
@@ -3809,7 +3809,7 @@ class ReportRun extends CRMEntity {
 								if ($fieldValue != ' ') {
 									$secondValue = $fieldValue;
 								}
-							} else if (($fieldName == $thirdField || strstr($fieldName, $thirdField)) && ($thirdValue == $fieldValue || $thirdValue == " ")) {
+							} else if (!empty($thirdField) && ($fieldName == $thirdField || strpos($fieldName, $thirdField) === 0) && ($thirdValue == $fieldValue || $thirdValue == " ")) {
 								if ($thirdValue == ' ' || $thirdValue == '-' || $secondIsHead == 1) {
 									$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
 								} else if($thirdValue == '') {
@@ -3822,13 +3822,13 @@ class ReportRun extends CRMEntity {
 								}
 							} else {
 								$valtemplate .= "<td style='border-bottom: 0;'>" . $fieldValue . "</td>";
-								if ($fieldName == $firstField || strstr($fieldName, $firstField)) {
+								if (!empty($firstField) && ($fieldName == $firstField || strpos($fieldName, $firstField) === 0)) {
 									$firstIsHead = 1;
 									$firstValue = $fieldValue;
-								} else if ($fieldName == $secondField || strstr($fieldName, $secondField)) {
+								} else if (!empty($secondField) && ($fieldName == $secondField || strpos($fieldName, $secondField) === 0)) {
 									$secondIsHead = 1;
 									$secondValue = $fieldValue;
-								} else if ($fieldName == $thirdField || strstr($fieldName, $thirdField)) {
+								} else if (!empty($thirdField) && ($fieldName == $thirdField || strpos($fieldName, $thirdField) === 0)) {
 									$thirdValue = $fieldValue;
 								}
 							}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1547

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. レポートのグループ化設定で、グループ化項目を1つのみ指定した状態でレポートを表示すると、グループ化の対象として指定していない列（特に「金額」、「予想金額」など）に、左隣の列と同じ値が入っている場合などにおいて、そのセルの値がマージされて空白（非表示）になる。
2. レポートのグループ化項目に「担当」を指定してレポートを表示すると、「担当」列で連続する同一人物名が非表示になるべきところ、すべての行に重複して名前が表示されたままになる。


##  原因 / Cause
<!-- バグの原因を記述 -->
1. 不具合1：グループ化項目が1つしか設定されていない場合、2番目・3番目のグループ化項目用の変数は空文字となり、SmartyおよびPHPの仕様上、`strstr($NAME, "")` はどのような文字列に対しても常に `true` (合致) を返すため、テーブル内のすべての列が「2番目のグループ化項目」であると誤認され、重複チェック（`$SECOND_VALUE == $VALUE`）の対象となっていた。
2. 不具合2：カラム名にグループ化対象（例：「担当」）の部分文字列が含まれている場合、無関係な列であっても `strstr` でヒットしてしまう。例えば、「顧客担当者名」が、グループ化キー「担当」に対して部分一致でヒットしてしまっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. layouts/v7/modules/Reports/ReportContents.tpl：`strstr` による曖昧な部分一致を廃止し、各グループ化カラム判定（`FIRST_FIELD`、`SECOND_FIELD`、`THIRD_FIELD`）を厳密化。
2. modules/Reports/ReportRun.php：レポート描画処理についても、テンプレート側と同様に厳密な前方一致判定に修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
不具合1 修正前（「タイプ」でグループ化）
<img width="1292" height="395" alt="image" src="https://github.com/user-attachments/assets/f34fdf08-eff0-4884-9246-98dfedbf8b02" />


不具合1 修正後（「タイプ」でグループ化）
<img width="1300" height="402" alt="image" src="https://github.com/user-attachments/assets/62ea58db-6be5-45fd-be81-c5017a65615c" />

不具合2 修正前（「担当」でグループ化）
<img width="1291" height="399" alt="image" src="https://github.com/user-attachments/assets/478c47d7-e317-4540-8a7c-12f4da947888" />


不具合2 修正後（「担当」でグループ化）
<img width="1285" height="400" alt="image" src="https://github.com/user-attachments/assets/91a88efb-535e-4d2a-b5f8-f1179c570d18" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->