### PR TITLE
[要望] Import画面に、Workflow等の自動処理が動かない旨の説明を追加 #1672

### DIFF
--- a/languages/en_us/Import.php
+++ b/languages/en_us/Import.php
@@ -140,4 +140,12 @@ $languageStrings = array(
 
 	'LBL_SETUP_PARAMETER_MESSAGE_IMPORT_MAX_HISTORY_COUNT' => 'The maximum number of import history records that can be retained per user and per module.',
 
+	// Notice that some automatic processing does not run during import
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_TITLE' => 'Note: Some automatic processing does not run during import',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_BODY' => 'When you register records in bulk from a file such as CSV (import), some of the processing that normally runs automatically when you create or edit records one at a time on screen will not run. Specifically, the following will not run:',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW' => 'Processing that runs automatically when records are created or updated (Workflows)',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES' => 'e.g., sending automated emails / auto-filling and auto-updating fields / automatically creating related records / automatically generating tasks, etc.',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL' => 'Linking and updating processing that runs automatically behind the scenes when records are saved',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND' => 'If you need these to run, after importing please open the target records and save them again, or register them manually on screen.',
+
 );

--- a/languages/ja_jp/Import.php
+++ b/languages/ja_jp/Import.php
@@ -140,4 +140,12 @@ $languageStrings = array(
 
 	'LBL_SETUP_PARAMETER_MESSAGE_IMPORT_MAX_HISTORY_COUNT' => 'ユーザーかつモジュール単位で保持できるインポート履歴の最大件数です。',
 
+	// インポート時に一部の自動処理が動かない旨の注意書き
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_TITLE' => '【ご注意】インポートでは一部の自動処理が実行されません',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_BODY' => 'CSVなどのファイルからまとめて登録（インポート）する場合、レコードを1件ずつ画面から登録・編集したときに自動で動く処理の一部が実行されません。具体的には、次のような処理は動きません。',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW' => 'レコードの登録・更新をきっかけに自動実行される処理（ワークフロー）',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES' => '例：自動メールの送信／項目の自動入力・自動更新／関連レコードの自動作成／タスクの自動生成 など',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL' => '保存時に裏側で自動的に行われる連携・反映処理',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND' => 'これらの処理が必要な場合は、インポート後に対象レコードを開いて保存し直すか、画面から手動で登録してください。',
+
 );

--- a/layouts/v7/modules/Import/ImportStepOne.tpl
+++ b/layouts/v7/modules/Import/ImportStepOne.tpl
@@ -86,4 +86,16 @@
             {/if}
         {/if}
     </table>
+    <div class="alert alert-warning" role="alert">
+        <strong><i class="fa fa-exclamation-triangle"></i>&nbsp;{'LBL_IMPORT_AUTO_PROCESS_NOTICE_TITLE'|@vtranslate:$MODULE}</strong>
+        <p>{'LBL_IMPORT_AUTO_PROCESS_NOTICE_BODY'|@vtranslate:$MODULE}</p>
+        <ul>
+            <li>
+                {'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW'|@vtranslate:$MODULE}<br>
+                <small class="text-muted">{'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES'|@vtranslate:$MODULE}</small>
+            </li>
+            <li>{'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL'|@vtranslate:$MODULE}</li>
+        </ul>
+        <p>{'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND'|@vtranslate:$MODULE}</p>
+    </div>
 </div>


### PR DESCRIPTION
## 概要

close #1672

インポート画面の Step1（ファイル選択）下部に、**インポートでは一部の自動処理が実行されない**旨の注意書きを表示します。エンドユーザーがシステム内部を理解していない前提で、平易・具体例ベースの文言にしています。

## 背景・Issueの問題点

Issue #1672 では「Workflow・自動採番・重複制御・内部埋め込みの自動処理が発火しない旨を記載したい」という要望でした。
実装にあたり Bulk Save Mode の挙動をコードで調査したところ、**4項目のうち「実際に発火しないもの」と「インポートでも機能するもの」が混在している**ことが分かりました。誤った案内を載せないため、**確実に発火しないものだけ**を文言に採用しています。

| 項目 | 実際の挙動 | 文言への掲載 |
|---|---|---|
| ワークフロー | **発火しない** | ◯ 掲載 |
| 保存時の内部自動処理（イベントハンドラ） | **発火しない** | ◯ 掲載 |
| 自動採番 | インポート完了時に一括付与され**機能する** | ✗ 非掲載 |
| 重複制御 | インポートウィザードの設定に従い**機能する** | ✗ 非掲載 |

## Bulk Save Mode の挙動（調査結果・コード根拠）

インポートは全行程が Bulk Save Mode で実行されます。
`modules/Vtiger/views/Import.php:36-57` で `$VTIGER_BULK_SAVE_MODE = true` を設定した状態でレコード作成（`import()` → `Import_Main_View::import()` → `Import_Data_Action::createRecords()`）が走ります。

### 1. ワークフローは発火しない（要望の主目的）
- ワークフローエンジン `VTWorkflowEventHandler` は `vtiger.entity.aftersave` イベントに登録されている（`modules/Install/models/InitSchema.php:931`）。
- しかし Bulk Save Mode のときは保存イベント自体をトリガーしない（`data/CRMEntity.php:1040-1050` … `//In Bulk mode stop triggering events`）。
- インポート後に `vtiger.batchevent.save`（`modules/Import/actions/Data.php:498`）は発火するが、これを購読しているのは PBXManager / EmailLookupHandler のみで、ワークフローエンジンは購読していない。

→ 「レコード作成時／編集時／保存時」に動くワークフロー（メール送信・項目の自動更新・関連レコードの自動作成・タスク自動生成など）はインポートでは実行されません。
（補足：時間ベース/スケジュール実行のワークフローは cron 側で別途評価されるため、後から拾われ得ます。）

### 2. 保存時の内部自動処理も発火しない
同じ理由（保存イベント抑止）で、保存イベントに登録された内部処理（`VTEntityDelta` の項目変更差分記録、各モジュール連携ハンドラ等）も動きません。これが Issue の「内部埋め込みの自動処理」に該当します。

### 3. 自動採番は機能する（＝文言から除外）
- 保存時は採番をスキップして空のまま登録（`data/CRMEntity.php:540-545` … `// Bulk Save Mode: Avoid generation of module sequence number, take care later.`）。
- インポート完了時に `updateMissingSeqNumber()` が呼ばれ（`modules/Import/actions/Data.php:478-479`）、空の採番項目（`WHERE $fld_column = '' OR ... is NULL`）に接頭辞＋連番を `UPDATE` で付与し、採番カウンタ `vtiger_modentity_num` も進めます（`data/CRMEntity.php:1700-1727`）。
- なお本実装は initial commit（`cbbc077f`, 2020-11-10）から存在しており、上流 vtiger から引き継いだ挙動です。

→ 最終的に採番されるため「自動採番が動かない」は不正確。文言には含めていません。

### 4. 重複制御も機能する（＝文言から除外）
- インポートウィザード Step3 の「重複レコードの処理方法」（無視／上書き／結合）は正常に動作します（`modules/Import/actions/Data.php:285-400`）。

→ 「効かない」ではなく「インポート独自の設定に従う」が正確。文言には含めていません。

## 変更内容

- `layouts/v7/modules/Import/ImportStepOne.tpl`
  - Step1（ファイル選択）テーブル下部に注意書きブロック（`alert alert-warning`）を追加。inline style は使わずクラスのみで構成。
- `languages/ja_jp/Import.php` / `languages/en_us/Import.php`
  - 注意書き用の翻訳キーを日本語・英語で追加。

## 表示文言（日本語）

> ⚠ **【ご注意】インポートでは一部の自動処理が実行されません**
> CSVなどのファイルからまとめて登録（インポート）する場合、レコードを1件ずつ画面から登録・編集したときに自動で動く処理の一部が実行されません。具体的には、次のような処理は動きません。
> - レコードの登録・更新をきっかけに自動実行される処理（ワークフロー）
>   例：自動メールの送信／項目の自動入力・自動更新／関連レコードの自動作成／タスクの自動生成 など
> - 保存時に裏側で自動的に行われる連携・反映処理
>
> これらの処理が必要な場合は、インポート後に対象レコードを開いて保存し直すか、画面から手動で登録してください。

## 動作確認

- `php -l` で両言語ファイルの構文チェック通過（`main-php-1` コンテナ）。
- Step1 表示時に注意書きが表示されること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
