### PR TITLE
#1571 活動のクイック作成時、未来の予定を完了に設定出来ないよう修正

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { transformCalendarDateTime } from '../../utils/datetime';
 import { validateFieldByUIType } from '../../utils/validation';
 import { syncJoditEditorFormData } from '../../utils/joditEditor';
+import { isFutureEventHeldInvalid } from './utils/calendarValidation';
 
 /**
  * Activity type for Calendar variant
@@ -703,6 +704,10 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
         if (new Date(dateStart) > new Date(dueDate)) {
           errors['due_date'] = t('LBL_END_DATE_AFTER_START');
         }
+      }
+      // 未来日付の活動はステータス「完了」(Held) で登録不可
+      if (isFutureEventHeldInvalid(currentCalendarFormData['eventstatus'], dateStart)) {
+        errors['eventstatus'] = t('JS_FUTURE_EVENT_CANNOT_BE_HELD');
       }
     }
 

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { isFutureEventHeldInvalid } from './calendarValidation';
+
+describe('isFutureEventHeldInvalid', () => {
+  const now = new Date('2026-06-24T12:00:00');
+
+  it('未来日付 + Held で NG (true)', () => {
+    expect(isFutureEventHeldInvalid('Held', '2026-07-15T10:00', now)).toBe(true);
+  });
+
+  it('未来日付 + Held (date のみ、時刻なし) で NG (true)', () => {
+    expect(isFutureEventHeldInvalid('Held', '2026-07-15', now)).toBe(true);
+  });
+
+  it('過去日付 + Held は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Held', '2026-06-01T10:00', now)).toBe(false);
+  });
+
+  it('現在以前 + Held は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Held', '2026-06-24T11:00:00', now)).toBe(false);
+  });
+
+  it('未来日付 + Planned は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Planned', '2026-07-15T10:00', now)).toBe(false);
+  });
+
+  it('未来日付 + Not Held は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Not Held', '2026-07-15T10:00', now)).toBe(false);
+  });
+
+  it('eventstatus が undefined は OK (false)', () => {
+    expect(isFutureEventHeldInvalid(undefined, '2026-07-15T10:00', now)).toBe(false);
+  });
+
+  it('date_start が undefined は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Held', undefined, now)).toBe(false);
+  });
+
+  it('date_start が空文字は OK (false)', () => {
+    expect(isFutureEventHeldInvalid('Held', '', now)).toBe(false);
+  });
+
+  it('date_start が不正な文字列は OK (false) — 必須チェック側で弾く', () => {
+    expect(isFutureEventHeldInvalid('Held', 'not-a-date', now)).toBe(false);
+  });
+});

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
@@ -43,4 +43,31 @@ describe('isFutureEventHeldInvalid', () => {
   it('date_start が不正な文字列は OK (false) — 必須チェック側で弾く', () => {
     expect(isFutureEventHeldInvalid('Held', 'not-a-date', now)).toBe(false);
   });
+
+  describe('ローカル時刻境界 (YYYY-MM-DD のみ入力時の UTC 誤解釈防止)', () => {
+    it('当日同一日付 (時刻なし) + 現在 12:00 は OK (false) — 今日0:00は過去', () => {
+      // 旧実装では new Date("2026-06-24") = UTC 0:00 = JST 9:00 となり、
+      // JST 8:00 時点では「未来」と誤判定された。ローカル時刻として解釈する必要がある。
+      const noonNow = new Date('2026-06-24T12:00:00');
+      expect(isFutureEventHeldInvalid('Held', '2026-06-24', noonNow)).toBe(false);
+    });
+
+    it('当日同一日付 (時刻なし) + 現在 0:00 ちょうど は OK (false) — 同時刻は未来ではない', () => {
+      const midnight = new Date('2026-06-24T00:00:00');
+      expect(isFutureEventHeldInvalid('Held', '2026-06-24', midnight)).toBe(false);
+    });
+
+    it('翌日 (時刻なし) + 現在 23:59 は NG (true)', () => {
+      const lateToday = new Date('2026-06-24T23:59:59');
+      expect(isFutureEventHeldInvalid('Held', '2026-06-25', lateToday)).toBe(true);
+    });
+  });
+
+  it('eventstatus が小文字 held はマッチしない (false)', () => {
+    expect(isFutureEventHeldInvalid('held', '2026-07-15T10:00', now)).toBe(false);
+  });
+
+  it('eventstatus が null は OK (false)', () => {
+    expect(isFutureEventHeldInvalid(null, '2026-07-15T10:00', now)).toBe(false);
+  });
 });

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
@@ -1,6 +1,20 @@
 /**
+ * date_start 文字列を Date に変換する。
+ * `YYYY-MM-DD` のみの場合は ISO 仕様で UTC 解釈されローカル時刻とズレるため、
+ * ローカル時刻 0:00 として再構築する。
+ * `YYYY-MM-DDTHH:MM` 形式（タイムゾーン指定なし）はネイティブのローカル時刻解釈に委ねる。
+ */
+function parseDateStartLocal(dateStart: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStart)) {
+    const [y, m, d] = dateStart.split('-').map(Number);
+    return new Date(y, m - 1, d);
+  }
+  return new Date(dateStart);
+}
+
+/**
  * 未来日付の活動はステータス「完了」(Held) で登録できないかを判定する
- * @returns true: バリデーションOK / false: 未来×Held で NG
+ * @returns true: 未来×Held で NG（invalid）/ false: それ以外（OK）
  */
 export function isFutureEventHeldInvalid(
   eventstatus: unknown,
@@ -9,7 +23,7 @@ export function isFutureEventHeldInvalid(
 ): boolean {
   if (eventstatus !== 'Held') return false;
   if (typeof dateStart !== 'string' || !dateStart) return false;
-  const start = new Date(dateStart);
+  const start = parseDateStartLocal(dateStart);
   if (isNaN(start.getTime())) return false;
   return start.getTime() > now.getTime();
 }

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
@@ -1,0 +1,15 @@
+/**
+ * 未来日付の活動はステータス「完了」(Held) で登録できないかを判定する
+ * @returns true: バリデーションOK / false: 未来×Held で NG
+ */
+export function isFutureEventHeldInvalid(
+  eventstatus: unknown,
+  dateStart: unknown,
+  now: Date = new Date()
+): boolean {
+  if (eventstatus !== 'Held') return false;
+  if (typeof dateStart !== 'string' || !dateStart) return false;
+  const start = new Date(dateStart);
+  if (isNaN(start.getTime())) return false;
+  return start.getTime() > now.getTime();
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1571

##  不具合の内容 / Bug
カレンダーのクイック作成画面で、未来の日付＋ステータス「完了」(Held)のまま活動を登録できてしまう。
従来仕様では未来活動を完了で登録不可だった。

##  原因 / Cause
1. 旧版 (jQuery + `validation.js` の `futureEventCannotBeHeld` validator) が WebComponents 化された際、新しい
React `QuickCreate.tsx` の `validateForm` に「未来×Held
不可」チェックが移植されておらず、保存が通過してしまっていた。

##  変更内容 / Details of Change
1. 純粋関数 `isFutureEventHeldInvalid(eventstatus, dateStart, now?)` を
`assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts` に新規追加。`eventstatus ===
'Held'` かつ `date_start` が現在より未来の場合に `true` を返す。
3. `QuickCreate.tsx` の `validateForm` 内 `isCalendarVariant` ブロックで上記を呼び、エラー時は既存翻訳キー
`JS_FUTURE_EVENT_CANNOT_BE_HELD` を `errors['eventstatus']` に詰める。
4. `YYYY-MM-DD` のみの入力は ISO 仕様で UTC
解釈されてローカル時刻と最大9時間ズレるため、ローカル0時として再構築する正規化処理を追加（終日活動・ToDo
完了日対策）。
5. ユニットテスト 15 ケース (`calendarValidation.test.ts`):
真陽性／真陰性／null・undefined・空文字／不正文字列／他ステータス／ローカル時刻境界／小文字・null の
eventstatus。

## スクリーンショット / Screenshot
<img width="889" height="313" alt="image" src="https://github.com/user-attachments/assets/f0bea3b2-af59-4469-b5af-b9349c2c587e" />


## 影響範囲  / Affected Area
- カレンダー / 活動 / イベント のクイック作成フォーム (`calendar-quick-create` Web Component)
- 既存の他バリデーション（必須／日付範囲）には影響なし


## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った  ※既存翻訳キー `JS_FUTURE_EVENT_CANNOT_BE_HELD` を再利用、追加・修正なし
