### PR TITLE
Fix/245-リスト機能にデフォルトのソートを設定する

### DIFF
--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1243,6 +1243,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'リストを共有',
+	'LBL_DEFAULT_SORT' => '並び順',
 	'LBL_ADD_USERS_ROLES' => 'ユーザー、役割の追加',
 	'EmailTemplates' => 'メールテンプレート',
 	'LBL_BILLING' => '請求',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1243,7 +1243,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'リストを共有',
-	'LBL_DEFAULT_SORT' => '並び順',
+	'LBL_DEFAULT_SORT' => 'デフォルトのソートを設定',
 	'LBL_ADD_USERS_ROLES' => 'ユーザー、役割の追加',
 	'EmailTemplates' => 'メールテンプレート',
 	'LBL_BILLING' => '請求',

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -113,7 +113,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
-								<input type="hidden" name="orderby" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
+								<input type="hidden" name="orderby" id="saved_orderby" value='{$CUSTOMVIEW_MODEL->get("orderby")}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -125,13 +125,29 @@
 							</div>
 						</div>
 						<div class="form-group clearfix">
-							<div class="col-sm-2 col-xs-2">
-								<label>
+							<div class="col-sm-2 col-xs-12">
+								<label style="margin-top: 5px;">
 										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
 								</label>
 							</div>
-							<div class=" row col-sm-5 col-xs-5">
-								<select id='orderby' class="select2-container select2">
+							<div class="col-sm-4 col-xs-7">
+								<select id='orderby' name='orderby' class="select2 form-control">
+									<option value="">{vtranslate('LBL_NONE',$MODULE)}</option>
+									{foreach key=BLOCK_LABEL item=BLOCK_FIELDS from=$RECORD_STRUCTURE}
+										<optgroup label='{vtranslate($BLOCK_LABEL, $SOURCE_MODULE)}'>
+											{foreach key=FIELD_NAME item=FIELD_MODEL from=$BLOCK_FIELDS}
+												<option value="{$FIELD_MODEL->get('name')}" {if $CUSTOMVIEW_MODEL->get('orderby') eq $FIELD_MODEL->get('name')}selected{/if}>
+													{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE))}
+												</option>
+											{/foreach}
+										</optgroup>
+									{/foreach}
+								</select>
+							</div>
+							<div class="col-sm-3 col-xs-5">
+								<select id='sortorder' name='sortorder' class="select2 form-control">
+									<option value="ASC" {if $CUSTOMVIEW_MODEL->get('sortorder') neq 'DESC'}selected{/if}>{vtranslate('LBL_ASCENDING', $MODULE)}</option>
+									<option value="DESC" {if $CUSTOMVIEW_MODEL->get('sortorder') eq 'DESC'}selected{/if}>{vtranslate('LBL_DESCENDING', $MODULE)}</option>
 								</select>
 							</div>
 						</div>

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -125,7 +125,7 @@
 							</div>
 						</div>
 						<div class="form-group clearfix">
-							<div class="col-sm-1 col-xs-2">
+							<div class="col-sm-2 col-xs-2">
 								<label>
 										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
 								</label>

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -113,6 +113,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
+								<input type="hidden" name="orderby" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -121,6 +122,17 @@
 							<label class="filterHeaders">{vtranslate('LBL_CHOOSE_FILTER_CONDITIONS', $MODULE)} :</label>
 							<div class="filterElements well filterConditionContainer filterConditionsDiv">
 								{include file='AdvanceFilter.tpl'|@vtemplate_path}
+							</div>
+						</div>
+						<div class="form-group clearfix">
+							<div class="col-sm-1 col-xs-2">
+								<label>
+										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
+								</label>
+							</div>
+							<div class=" row col-sm-5 col-xs-5">
+								<select id='orderby' class="select2-container select2">
+								</select>
 							</div>
 						</div>
 						<div class="checkbox">

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -90,7 +90,7 @@
 				{/if}
 				</th>
 				{foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}
-					{if $SEARCH_MODE_RESULTS || ($LISTVIEW_HEADER->getFieldDataType() eq 'multipicklist')}
+					{if $SEARCH_MODE_RESULTS || ($LISTVIEW_HEADER->getFieldDataType() eq 'multipicklist') || $IS_DEFAULT_SORT}
 						{assign var=NO_SORTING value=1}
 					{else}
 						{assign var=NO_SORTING value=0}

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -58,7 +58,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'viewname' => $request->get('viewname'),
 					'setdefault' => $request->get('setdefault'),
 					'setmetrics' => $request->get('setmetrics'),
-					'status' => $request->get('status')
+					'status' => $request->get('status'),
+					'orderby' => $request->get('orderby')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -29,7 +29,7 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
              * we should clear this from session in order to apply view
              */
             $listViewSessionKey = $sourceModuleName.'_'.$cvId;
-            Vtiger_ListView_Model::deleteParamsSession($listViewSessionKey,'list_headers');
+            Vtiger_ListView_Model::deleteParamsSession($listViewSessionKey, array('list_headers', 'orderby', 'sortorder'));
 			$response->setResult(array('id'=>$cvId, 'listviewurl'=>$moduleModel->getListViewUrl().'&viewname='.$cvId));
 		} else {
 			$response->setError(vtranslate('LBL_CUSTOM_VIEW_NAME_DUPLICATES_EXIST', $moduleName));
@@ -59,7 +59,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'setdefault' => $request->get('setdefault'),
 					'setmetrics' => $request->get('setmetrics'),
 					'status' => $request->get('status'),
-					'orderby' => $request->get('orderby')
+					'orderby' => $request->get('orderby'),
+					'sortorder' => $request->get('sortorder')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -272,6 +272,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setDefault = $this->get('setdefault');
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
+		$orderby = $this->get('orderby');
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {
@@ -283,8 +284,8 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$cvId = $db->getUniqueID("vtiger_customview");
 			$this->set('cvid', $cvId);
 
-			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid) VALUES (?,?,?,?,?,?,?)';
-			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId());
+			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby) VALUES (?,?,?,?,?,?,?,?)';
+			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(),$orderby);
 			$db->pquery($sql, $params);
 
 		} else {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -273,6 +273,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
 		$orderby = $this->get('orderby');
+		$sortorder = $this->get('sortorder');
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {
@@ -284,14 +285,14 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$cvId = $db->getUniqueID("vtiger_customview");
 			$this->set('cvid', $cvId);
 
-			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby) VALUES (?,?,?,?,?,?,?,?)';
-			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(),$orderby);
+			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby, sortorder) VALUES (?,?,?,?,?,?,?,?,?)';
+			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(), $orderby, $sortorder);
 			$db->pquery($sql, $params);
 
 		} else {
 
-			$sql = 'UPDATE vtiger_customview SET viewname=?, setdefault=?, setmetrics=?, status=? WHERE cvid=?';
-			$params = array($viewName, $setDefault, $setMetrics, $status, $cvId);
+			$sql = 'UPDATE vtiger_customview SET viewname=?, setdefault=?, setmetrics=?, status=?, orderby=?, sortorder=? WHERE cvid=?';
+			$params = array($viewName, $setDefault, $setMetrics, $status, $orderby, $sortorder, $cvId);
 			$db->pquery($sql, $params);
 
 			if(!$partial) {

--- a/modules/Migration/schema/738_to_739.php
+++ b/modules/Migration/schema/738_to_739.php
@@ -1,0 +1,14 @@
+<?php
+/*+********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+    $db->query('ALTER TABLE vtiger_customview ADD orderby varchar(250);');
+
+}

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -181,14 +181,6 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		} else {
 			$listViewModel = $this->listViewModel;
 		}
-		if($orderBy == ''){
-			global $db;
-			$db = PearDatabase::getInstance();
-			$query = "SELECT orderby from vtiger_customview WHERE cvid = ?";
-			$result = $db->pquery($query, array($cvId));//orderbyの連結完了
-			$orderBy = $db->query_result($result,'orderby');
-
-		}
 
 		if(!empty($requestViewName) && empty($tag)) {
 			unset($_SESSION[$tagSessionKey]);
@@ -262,6 +254,24 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			}
 			$listViewModel->setSortParamsSession($listViewSessionKey, $params);
 		}
+		$isDefaultSort = false;
+		global $db;
+		$db = PearDatabase::getInstance();
+		$query = "SELECT orderby, sortorder from vtiger_customview WHERE cvid = ?";
+		$result = $db->pquery($query, array($cvId));
+		$db_orderBy = '';
+		$db_sortOrder = '';
+		if ($result && $db->num_rows($result) > 0) {
+			$db_orderBy = $db->query_result($result, 0, 'orderby');
+			$db_sortOrder = $db->query_result($result, 0, 'sortorder');
+		}
+
+		if (!empty($db_orderBy)) {
+			// If a default sort is set, it locks the sorting for this custom view.
+			$orderBy = $db_orderBy;
+			$sortOrder = $db_sortOrder;
+			$isDefaultSort = true;
+		}
 		if($sortOrder == "ASC"){
 			$nextSortOrder = "DESC";
 			$sortImage = "icon-chevron-down";
@@ -300,6 +310,19 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$viewer->assign('OPERATOR',$operator);
 			$viewer->assign('ALPHABET_VALUE',$searchValue);
 		}
+		$viewer->assign('ORDER_BY',$orderBy);
+		$viewer->assign('SORT_ORDER',$sortOrder);
+		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
+		$viewer->assign('SORT_IMAGE',$sortImage);
+		$viewer->assign('FASORT_IMAGE',$faSortImage);
+		if(!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME',$orderBy);
+			$viewer->assign('IS_DEFAULT_SORT', false);
+		} else {
+			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('IS_DEFAULT_SORT', true);
+		}
+		
 		if(!empty($searchKey) && !empty($searchValue)) {
 			$listViewModel->set('search_key', $searchKey);
 			$listViewModel->set('search_value', $searchValue);
@@ -392,7 +415,13 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
 		$viewer->assign('SORT_IMAGE',$sortImage);
 		$viewer->assign('FASORT_IMAGE',$faSortImage);
-		$viewer->assign('COLUMN_NAME',$orderBy);
+		if(!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME',$orderBy);
+			$viewer->assign('IS_DEFAULT_SORT', false);
+		} else {
+			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('IS_DEFAULT_SORT', true);
+		}
 		$viewer->assign('VIEWNAME',$this->viewName);
 
 		$viewer->assign('LISTVIEW_ENTRIES_COUNT',$noOfEntries);

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -181,6 +181,14 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		} else {
 			$listViewModel = $this->listViewModel;
 		}
+		if($orderBy == ''){
+			global $db;
+			$db = PearDatabase::getInstance();
+			$query = "SELECT orderby from vtiger_customview WHERE cvid = ?";
+			$result = $db->pquery($query, array($cvId));//orderbyの連結完了
+			$orderBy = $db->query_result($result,'orderby');
+
+		}
 
 		if(!empty($requestViewName) && empty($tag)) {
 			unset($_SESSION[$tagSessionKey]);

--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -239,6 +239,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		this.makeColumnListSortable();
 		this.registerToogleShareList();
 		this.registerOnlyAllUsersInSharedList();
+		this.addColumnsOrderbyList();
 		var customViewForm = jQuery('#CustomView');
 
 		if(customViewForm.length > 0) {
@@ -247,7 +248,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					var form = jQuery(form); 
 						  var selectElement = form.find('#viewColumnsSelect'); 
 						  var mandatoryFieldsList = JSON.parse(jQuery('#mandatoryFieldsList').val()); 
-						  var selectedOptions = selectElement.val(); 
+						  var selectedOptions = selectElement.val();
 						  var mandatoryFieldsMissing = true; 
 						  for(var i=0; i<selectedOptions.length; i++) { 
 						if(jQuery.inArray(selectedOptions[i], mandatoryFieldsList) >= 0) { 
@@ -270,6 +271,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					}
 					var selectValues = JSON.stringify(selectedValues);
 					jQuery('input[name="columnslist"]', self.getContainer()).val(selectValues);
+					jQuery('input[name="orderby"]').val(jQuery('#orderby').val());
 					var allUsersStatusEle = jQuery('#allUsersStatusValue');
 					if(self.isAllUsersSelected() && (jQuery('[data-toogle-members]').is(":checked"))){
 						allUsersStatusEle.val(allUsersStatusEle.data('public'));
@@ -346,5 +348,40 @@ jQuery.Class("Vtiger_CustomView_Js",{
 				target.trigger('post.ToggleDefault.saved',data);
 			})
 		});
+	},
+
+	addElementsforOrderbyList :function(){
+		selectElement = this.getColumnSelectElement();
+		selectedOptions = selectElement.select2('data');
+		
+		for (var i= 0;i<selectedOptions.length;i++){
+			selectedOptionid = selectedOptions[i].id.split(':');
+			const newOption = document.createElement("option");
+			newOption.value = selectedOptionid[1];
+			newOption.textContent = selectedOptions[i].text;
+			jQuery("#orderby").append(newOption);
+		}
+	},
+
+	addColumnsOrderbyList :function(){
+		selectfield = document.getElementById('s2id_viewColumnsSelect');
+		this.addElementsforOrderbyList();
+
+		var observer = new MutationObserver(function(){
+			customview = new Vtiger_CustomView_Js();
+			var parent = document.getElementById("orderby");
+			
+			while(parent.lastChild){
+				parent.removeChild(parent.lastChild);
+			}
+			customview.addElementsforOrderbyList();
+		});
+		const config = { 
+			attributes: false, 
+			childList: true, 
+			characterData: false,
+			subtree:true
+		};
+		observer.observe(selectfield, config);
 	}
 });

--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -224,6 +224,26 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		});
 	},
 
+	registerOrderbyChangeEvent : function() {
+		var form = jQuery('#CustomView');
+		var orderBySelect = form.find('#orderby');
+		var sortOrderSelect = form.find('#sortorder');
+		// The container is the parent div of the sortorder select
+		var sortOrderContainer = sortOrderSelect.closest('div.col-sm-3, div.col-xs-4');
+
+		if(orderBySelect.length > 0) {
+			orderBySelect.on('change', function() {
+				if(jQuery(this).val() == '') {
+					sortOrderContainer.hide();
+				} else {
+					sortOrderContainer.show();
+				}
+			});
+			// Trigger on load to set initial state
+			orderBySelect.trigger('change');
+		}
+	},
+
 	/**
 	 * Function which will register the select2 elements for columns selection
 	 */
@@ -239,7 +259,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		this.makeColumnListSortable();
 		this.registerToogleShareList();
 		this.registerOnlyAllUsersInSharedList();
-		this.addColumnsOrderbyList();
+		this.registerOrderbyChangeEvent();
 		var customViewForm = jQuery('#CustomView');
 
 		if(customViewForm.length > 0) {
@@ -271,7 +291,6 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					}
 					var selectValues = JSON.stringify(selectedValues);
 					jQuery('input[name="columnslist"]', self.getContainer()).val(selectValues);
-					jQuery('input[name="orderby"]').val(jQuery('#orderby').val());
 					var allUsersStatusEle = jQuery('#allUsersStatusValue');
 					if(self.isAllUsersSelected() && (jQuery('[data-toogle-members]').is(":checked"))){
 						allUsersStatusEle.val(allUsersStatusEle.data('public'));
@@ -350,38 +369,4 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		});
 	},
 
-	addElementsforOrderbyList :function(){
-		selectElement = this.getColumnSelectElement();
-		selectedOptions = selectElement.select2('data');
-		
-		for (var i= 0;i<selectedOptions.length;i++){
-			selectedOptionid = selectedOptions[i].id.split(':');
-			const newOption = document.createElement("option");
-			newOption.value = selectedOptionid[1];
-			newOption.textContent = selectedOptions[i].text;
-			jQuery("#orderby").append(newOption);
-		}
-	},
-
-	addColumnsOrderbyList :function(){
-		selectfield = document.getElementById('s2id_viewColumnsSelect');
-		this.addElementsforOrderbyList();
-
-		var observer = new MutationObserver(function(){
-			customview = new Vtiger_CustomView_Js();
-			var parent = document.getElementById("orderby");
-			
-			while(parent.lastChild){
-				parent.removeChild(parent.lastChild);
-			}
-			customview.addElementsforOrderbyList();
-		});
-		const config = { 
-			attributes: false, 
-			childList: true, 
-			characterData: false,
-			subtree:true
-		};
-		observer.observe(selectfield, config);
-	}
 });

--- a/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
+++ b/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * マイグレーション: add_orderby_to_customview
+ * 生成日時: 20260625044739
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260625044739_AddOrderbyToCustomview extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     * ここにマイグレーション処理を記述してください
+     */
+    public function process() {
+        $sql = "ALTER TABLE vtiger_customview ADD orderby varchar(250)";
+        $this->db->pquery($sql, array());
+        
+        $this->log("マイグレーション add_orderby_to_customview が正常に完了しました");
+    }
+}

--- a/setup/migration/scripts/20260625054700_add_sortorder_to_customview.php
+++ b/setup/migration/scripts/20260625054700_add_sortorder_to_customview.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * マイグレーション: add_sortorder_to_customview
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260625054700_AddSortorderToCustomview extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     */
+    public function process() {
+        $db = PearDatabase::getInstance();
+        $result = $db->pquery("SHOW COLUMNS FROM vtiger_customview LIKE 'sortorder'", array());
+        if ($db->num_rows($result) == 0) {
+            $db->pquery("ALTER TABLE vtiger_customview ADD sortorder varchar(250) DEFAULT 'ASC'", array());
+            $this->log("sortorderカラムをvtiger_customviewに追加しました。");
+        }
+        $this->log("マイグレーション add_sortorder_to_customview が正常に完了しました");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #245
- fix #869 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 作成済みのリストはデフォルトソート項目を変更できない 
2. リスト上でソートに利用する項目を変更しても画面遷移後にはデフォルトソートに設定した項目でのソートに戻ってしまう
3. リストの編集画面にてデフォルトソート項目を選択する選択肢項目の幅が狭い
4. リストの編集画面にて現在設定されているデフォルトソート項目の値が表示されない
5. デフォルトソート項目の設定と併せて昇順・降順を選べるようにしたい
6. デフォルトソート項目を利用して表示した場合はソートUIが表示にならない方が良い
7. デフォルトソート項目に設定できる項目の拡大


##  原因 / Cause
<!-- バグの原因を記述 -->
1. 新規作成時（INSERT文）にはソート項目を保存する処理が存在したが、既存リストの更新時（UPDATE文）のSQLに処理がなかった
2. 手動ソートが保持されていなかった
3. 横幅の比率指定が狭かった
4. プルダウンの選択肢を生成する際に、データベースの保存値と一致したら選択状態にするチェックロジックが組み込まれていなかった
5. 昇順、降順が入ってなかった
6. 「デフォルトソート適用中」であることを画面側に伝え、手動ソート用UIを動的に非表示にする仕組みがない
7. 選択中の表示カラム一覧の情報だけを使ってプルダウンを動的に生成する作りだった


##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 既存リストの更新時（UPDATE文）にも、新しく追加したorderbyとsortorderの値をデータベースに書き込む処理を追加
2. 変更6によりデフォルトソートが設定されているリストでは手動ソート操作をロックすることで解決
3. レイアウトを調整
4. 保存済みの設定値と各選択肢の値が一致するかを判定する  if 文を追加し、一致する場合には画面を開いた直後に現在の設定内容が正しく表示されるように修正
5. データベースにカラム、編集画面にプルダウンを追加
6. デフォルトソート設定中には手動ソートをロックする処理を追加
7. すべてのフィールド情報を含んだ変数をループさせてプルダウンの選択肢を描画

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="1529" height="605" alt="image" src="https://github.com/user-attachments/assets/e0df4229-1c8e-465a-aa9d-4de09d4dc18f" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->