### PR TITLE
[要望] Import画面の注意書きに重複制御の挙動（項目設定の重複制御は動かずインポート設定が優先）を追記 #1672

### DIFF
--- a/languages/en_us/Import.php
+++ b/languages/en_us/Import.php
@@ -146,6 +146,8 @@ $languageStrings = array(
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW' => 'Processing that runs automatically when records are created or updated (Workflows)',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES' => 'e.g., sending automated emails / auto-filling and auto-updating fields / automatically creating related records / automatically generating tasks, etc.',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL' => 'Linking and updating processing that runs automatically behind the scenes when records are saved',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE' => 'Duplicate checking based on field settings (the module\'s "Do not allow duplicates" setting)',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE_NOTE' => 'During import, this field-based duplicate control does not run. Instead, the "Handling of duplicate records (Ignore / Overwrite / Merge)" you specify in the import wizard takes precedence.',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND' => 'If you need these to run, after importing please open the target records and save them again, or register them manually on screen.',
 
 );

--- a/languages/ja_jp/Import.php
+++ b/languages/ja_jp/Import.php
@@ -146,6 +146,8 @@ $languageStrings = array(
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW' => 'レコードの登録・更新をきっかけに自動実行される処理（ワークフロー）',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES' => '例：自動メールの送信／項目の自動入力・自動更新／関連レコードの自動作成／タスクの自動生成 など',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL' => '保存時に裏側で自動的に行われる連携・反映処理',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE' => '項目設定（モジュールの「重複を許可しない」設定）による重複チェック',
+	'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE_NOTE' => 'インポートでは、この項目設定の重複制御は動作しません。代わりに、インポートウィザードで指定した「重複レコードの処理方法（無視／上書き／結合）」が優先されます。',
 	'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND' => 'これらの処理が必要な場合は、インポート後に対象レコードを開いて保存し直すか、画面から手動で登録してください。',
 
 );

--- a/layouts/v7/modules/Import/ImportStepOne.tpl
+++ b/layouts/v7/modules/Import/ImportStepOne.tpl
@@ -95,6 +95,10 @@
                 <small class="text-muted">{'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKFLOW_EXAMPLES'|@vtranslate:$MODULE}</small>
             </li>
             <li>{'LBL_IMPORT_AUTO_PROCESS_NOTICE_INTERNAL'|@vtranslate:$MODULE}</li>
+            <li>
+                {'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE'|@vtranslate:$MODULE}<br>
+                <small class="text-muted">{'LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE_NOTE'|@vtranslate:$MODULE}</small>
+            </li>
         </ul>
         <p>{'LBL_IMPORT_AUTO_PROCESS_NOTICE_WORKAROUND'|@vtranslate:$MODULE}</p>
     </div>


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1672

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. PR #1675 でインポート画面に「一部の自動処理が実行されない」旨の注意書きを追加した際、重複制御は「インポートウィザードの設定に従って機能する」と判断し文言から除外していた。
2. しかし正確には、**項目設定（モジュールの「重複を許可しない」設定）による重複制御はインポート時には発火しない**。ユーザーが項目設定の重複制御を期待してインポートすると、意図せず重複レコードが登録され得るため、その旨を明記したい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. インポートは全行程が Bulk Save Mode（`$VTIGER_BULK_SAVE_MODE = true`）で実行される（`modules/Vtiger/views/Import.php`）。
2. 項目設定の重複制御は `CheckDuplicateHandler` が担っており、`vtiger.entity.beforesave` イベントに登録されている（`setup/sql/dump_firstinstall.sql` の `vtiger_eventhandlers` #30、`modules/Vtiger/handlers/CheckDuplicateHandler.php`）。
3. Bulk Save Mode では保存イベント（`beforesave` 含む）自体がトリガーされない（`data/CRMEntity.php:1040-1050` … `//In Bulk mode stop triggering events`）。このため `CheckDuplicateHandler` は呼ばれず、項目設定の重複制御は機能しない。
4. 一方、インポートウィザード Step3 の「重複レコードの処理方法（無視／上書き／結合）」はインポート独自のロジックで正常に動作し（`modules/Import/actions/Data.php:285-400`）、こちらが実質的に優先される。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. `layouts/v7/modules/Import/ImportStepOne.tpl`
   - PR #1675 で追加した注意書きブロックに、重複制御に関するリスト項目を1件追加。
   - 「項目設定による重複チェックは動かず、インポートウィザードで指定した重複時処理が優先される」旨を補足表示。
2. `languages/ja_jp/Import.php` / `languages/en_us/Import.php`
   - 上記用の翻訳キー（`LBL_IMPORT_AUTO_PROCESS_NOTICE_DUPLICATE` / `..._DUPLICATE_NOTE`）を日本語・英語で追加。

### 表示文言（日本語・追記分）
> - 項目設定（モジュールの「重複を許可しない」設定）による重複チェック
>   インポートでは、この項目設定の重複制御は動作しません。代わりに、インポートウィザードで指定した「重複レコードの処理方法（無視／上書き／結合）」が優先されます。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
（インポート Step1 の注意書きブロックに重複制御の項目が1件追加されます。）

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- インポート画面 Step1（ファイル選択）の表示のみ。表示文言（翻訳キー）と Smarty テンプレートの追記であり、インポート処理・重複判定ロジック自体には変更なし。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
- PR #1675（同 Issue #1672 対応）のフォローアップです。#1675 では「重複制御は機能する」としていましたが、これは**インポートウィザード Step3 の重複時処理**を指したものでした。本PRでは、混同しやすい**項目設定側の重複制御は発火しない**点を明示し、どちらが優先されるかをエンドユーザー向けに案内します。
- `php -l` で両言語ファイルの構文チェック通過を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
