### PR TITLE
[改善] Docker構成のMySQLを8.0から8.4に更新

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.4
 RUN mkdir /var/log/mysql
 RUN chown mysql:mysql /var/log/mysql
 ADD ./docker/mysql/my.cnf /etc/mysql/conf.d/my.cnf


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1166 への追加対応（Docker構成のMySQL 8.4対応）

##  不具合の内容 / Bug
1. #1166 にてF-RevoCRM本体のMySQL 8.4対応が完了しているが、Docker構成（`docker/mysql/Dockerfile`）が`mysql:8.0`のままで、Dockerで立ち上げた環境では引き続きMySQL 8.0が起動する。

##  原因 / Cause
1. F-RevoCRM本体のMySQL 8.4対応時、Docker構成ファイルのMySQLイメージタグ更新が漏れていた。

##  変更内容 / Details of Change
1. `docker/mysql/Dockerfile` の `FROM mysql:8.0` → `FROM mysql:8.4` に変更。
2. `docker/mysql/my.cnf` の設定値は MySQL 8.4 でも有効なオプションのみで構成されているため変更不要。

## スクリーンショット / Screenshot
（必要に応じて追加）

## 影響範囲  / Affected Area
- Docker構成で起動するF-RevoCRM環境（`compose.yaml` 経由起動分）
- 既存の `db-store` ボリュームに MySQL 8.0 のデータが残存している場合、起動不可。初回適用時のみ `docker compose down -v` でボリューム削除が必要。
- ホスト直接起動環境・本番環境には影響なし。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [-] 言語対応（日・英）を行った（言語ファイル変更なし、対象外）

## 備考 / Remarks
- 動作確認: MySQL 8.4.10 で Docker 起動 → インストーラ完了 → 取引先1件登録成功。
- 既存環境への適用手順は本PR内に記載（`docker compose down -v` 後 `up -d --build`）。