### PR TITLE
Fix/1449 リストの画面の検索窓でレコードが隠れる不具合を修正

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/List.js
+++ b/public/layouts/v7/modules/Vtiger/resources/List.js
@@ -1462,16 +1462,6 @@ Vtiger.Class("Vtiger_List_Js", {
             var element = jQuery(e.currentTarget);
             var fieldName = element.attr('name');
             var searchValue = element.val();
-			if(element.hasClass('select2')){
-				var currentElementContainer = element.closest('.select2_search_div').find('div.listSearchContributor').find('ul');
-				var desireHeight = 150;
-				if(currentElementContainer.height() > desireHeight){
-					currentElementContainer.css({'cssText':'height:'+desireHeight+'px !important;'+'padding:0'});
-				}else if(currentElementContainer.find('.mCSB_container').height() < desireHeight){
-					currentElementContainer.removeAttr('style');
-				}
-				currentElementContainer.mCustomScrollbar("update");
-			}
 			
             if(e.keyCode == 13 && thisInstance.prevSearchValues[fieldName] !== searchValue && !element.hasClass('select2')){
                 e.preventDefault();
@@ -1488,10 +1478,6 @@ Vtiger.Class("Vtiger_List_Js", {
                 }, 10);
             }
         };
-		listViewPageDiv.find('.searchRow div.listSearchContributor.select2').each(function(i,elem){
-           var currentSearchInput = jQuery(elem);
-			app.helper.showVerticalScroll(currentSearchInput.find('ul'),{'height': 150});
-        });
         listViewPageDiv.on('keyup','.listSearchContributor', listSearchContributorChangeHandler);
         listViewPageDiv.on('change','select', listSearchContributorChangeHandler);
         listViewPageDiv.on('datepicker-change', '.dateField', function(e){
@@ -2862,19 +2848,20 @@ Vtiger.Class("Vtiger_List_Js", {
 		});
 	},
 	getListViewContentHeight: function () {
-		var windowHeight = jQuery(window).height();
-		//list height should be 76% of window height
-		var listViewContentHeight = windowHeight * 0.76103500761035;
 		var listViewTable = jQuery('#listview-table');
 		if (listViewTable.length) {
-			if (!listViewTable.find('tr.emptyRecordsDiv').length) {
-				var listTableHeight = jQuery('#listview-table').height();
-				if (listTableHeight < listViewContentHeight) {
-					listViewContentHeight = listTableHeight + 3;
-				}
-			}
+			var theadHeight = listViewTable.find('thead').outerHeight() || 80;
+			var firstRow = listViewTable.find('tr.listViewEntries').first();
+			var rowHeight = firstRow.length ? firstRow.outerHeight() : 40;
+			// 担当フィールドの選択欄)ぶんの余白を常に確保
+			var choicesEl = listViewTable.find('tr.searchRow .select2_search_div .select2-choices');
+			var choicesMaxHeight = 116;
+			var choicesCurrentHeight = choicesEl.length ? (choicesEl.outerHeight() || 0) : 0;
+			theadHeight += Math.max(0, choicesMaxHeight - choicesCurrentHeight);
+			return (theadHeight + rowHeight * 20 + 3) + 'px';
 		}
-		return listViewContentHeight + 'px';
+		var windowHeight = jQuery(window).height();
+		return (windowHeight * 0.76103500761035) + 'px';
 	},
 	getListViewContentWidth: function () {
 		return '100%';

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -1851,3 +1851,8 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
     }
 }
 
+/* fix1449/検索行の担当フィールド: 2個以上選択したらスクロール（枠は広がらない） */
+.listview-table tr.searchRow .select2_search_div .select2-choices {
+    max-height: 87px;
+    overflow-y: auto;
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1449 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リスト一覧画面の検索行で「担当」フィールドにメンバーを複数選択すると、リストのレコードが隠れてしまう

##  原因 / Cause
<!-- バグの原因を記述 -->
1. public/layouts/v7/modules/Vtiger/resources/List.js
ul.select2-choices に mCustomScrollbar で固定の高さが設定されており、タグを追加しても thead の高さが変化しないため、コンテナの高さが正しく更新されなかった
2. public/resources/styles.css
select2-selecting イベントはタグが DOM に追加される前に発火するため、タグ追加後の正しい高さで reflowList が実行されなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. public/layouts/v7/modules/Vtiger/resources/List.js
・ul.select2-choices に対する mCustomScrollbar の初期化・高さ制限処理を削除
・select2-selected イベントを reflowList のトリガーに追加し、タグ追加直後にコンテナ高さを再計算するよう修正
・getListViewContentHeight を thead 実高さ＋レコード20件分(1画面最大表示件数)の固定計算に変更し、担当選択欄の最大高さ分の余白を常に確保
2. public/resources/styles.css
・CSS で担当フィールドの選択欄に max-height と overflow-y: auto を追加し、一定数以上の選択時はスクロール方式に変更

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="832" height="158" alt="image" src="https://github.com/user-attachments/assets/58b5832a-aa52-4350-95a2-4aa7bec902ae" />

変更後
<img width="828" height="383" alt="image" src="https://github.com/user-attachments/assets/766a4e61-16a9-41fd-b589-69def767bf5b" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
・リストビューの検索行全般
・担当フィールドを持つすべてのモジュールの一覧画面

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->