### PR TITLE
Fix/967-[不具合] レポートの編集画面でFaqの関連モジュールに選択肢が表示されない

### DIFF
--- a/modules/Reports/views/ChartEdit.php
+++ b/modules/Reports/views/ChartEdit.php
@@ -91,7 +91,8 @@ Class Reports_ChartEdit_View extends Vtiger_Edit_View {
 		if (!empty($record)) {
 			$viewer->assign('MODE', 'edit');
 		} else {
-			$firstModuleName = reset($modulesList);
+			reset($modulesList);
+			$firstModuleName = key($modulesList);
 			if($firstModuleName)
 				$reportModel->setPrimaryModule($firstModuleName);
 			$viewer->assign('MODE', '');

--- a/modules/Reports/views/Edit.php
+++ b/modules/Reports/views/Edit.php
@@ -92,7 +92,8 @@ Class Reports_Edit_View extends Vtiger_Edit_View {
 		if (!empty($record)) {
 			$viewer->assign('MODE', 'edit');
 		} else {
-			$firstModuleName = reset($modulesList);
+			reset($modulesList);
+			$firstModuleName = key($modulesList);
 			if($firstModuleName)
 				$reportModel->setPrimaryModule($firstModuleName);
 			$viewer->assign('MODE', '');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #967 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
レポートの追加からレポートやグラフを追加しようとしたときに主モジュールにはFAQが選択されているが、関連モジュールの選択欄をクリックすると該当なしと表示される。主モジュールをほかのモジュールに一度変更して、再度元のFAQモジュールに戻すと正常に関連モジュールの選択肢が表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
新規作成画面を開いた際、サーバーは自動的にリスト先頭のモジュールを初期設定しようとするが、この時に誤ってキーの  Faq  ではなく、値である表示名のFAQを取り出して関連モジュールを探しに行っていたため、関連モジュールが該当なしになっていた。ユーザが手動で切り替えると文字ではなくHTML内に隠されたキーのFaqを読み取って再検索したため正常に選択肢を表示できていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
modules/Reports/views/Edit.php、modules/Reports/views/ChartEdit.php：
配列の先頭を取得する際、値を返す関数（ reset ）から、キーを返す関数（ key ）を使用するように変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前
<img width="1042" height="329" alt="image" src="https://github.com/user-attachments/assets/71fb6fdf-00cb-420d-8c7d-31aa7e4e6319" />

変更後
<img width="1033" height="314" alt="image" src="https://github.com/user-attachments/assets/a0b24dfb-f610-4178-a808-e02e8026f335" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->