### PR TITLE
fix(#1686): uitype16項目のプログラム削除で選択肢テーブルが残留する不具合を修正

### DIFF
--- a/modules/Vtiger/handlers/FieldEventHandler.php
+++ b/modules/Vtiger/handlers/FieldEventHandler.php
@@ -58,7 +58,7 @@ class FieldEventHandler extends VTEventHandler {
 			$db->pquery($query, array($fieldId));
 		}
 
-		if (in_array($fieldEntity->uitype, array(15, 33))) {
+		if (in_array($fieldEntity->uitype, array(15, 16, 33))) {
 			$db->pquery('DROP TABLE IF EXISTS vtiger_' . $db->sql_escape_string($columnName), array());
 			$db->pquery('DROP TABLE IF EXISTS vtiger_' . $db->sql_escape_string($columnName) . '_seq', array()); //To Delete Sequence Table  
 			$db->pquery('DELETE FROM vtiger_picklist_dependency WHERE sourcefield=? OR targetfield=?', array($columnName, $columnName));


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1686

##  不具合の内容 / Bug
1. uitype16（役割に基づかない定義リスト）の選択肢項目を、プログラム/スクリプト経由（vtlib の `Vtiger_Field::delete()` → `vtiger.field.afterdelete` イベント）で削除すると、選択肢の値テーブル `vtiger_<columnname>` と採番テーブル `vtiger_<columnname>_seq` が削除されず残留する。
2. 画面（レイアウトエディタ）からの削除では発現しない。移行スクリプトやモジュールのアンインストール等、プログラム削除経路で孤立した選択肢テーブルが残る。

##  原因 / Cause
1. `modules/Vtiger/handlers/FieldEventHandler.php` の `triggerPostDeleteEvents()` における選択肢テーブル削除判定が `in_array($fieldEntity->uitype, array(15, 33))` となっており、**uitype16 が判定配列に含まれていなかった**。このためイベント削除経路では uitype16 のテーブル DROP 処理に入らなかった。
2. 一方、画面削除経路（`modules/Settings/LayoutEditor/models/Field.php::delete()` の `getFieldDataType() == 'picklist'` 判定）は uitype16 を含むため正常に削除されており、**2経路で削除挙動が不整合**だった。

##  変更内容 / Details of Change
1. `modules/Vtiger/handlers/FieldEventHandler.php`：判定配列 `array(15, 33)` に `16` を追加し `array(15, 16, 33)` とした（1行）。これによりイベント削除経路でも uitype16 の値テーブル・採番テーブルが DROP され、画面削除経路と挙動が揃う。

## スクリーンショット / Screenshot
DB 処理のため画面なし。検証ログは「備考」を参照。

## 影響範囲  / Affected Area
- プログラム削除（`vtiger.field.afterdelete` イベント発火経路：移行スクリプト・モジュールアンインストール等）における **uitype16 選択肢項目の後処理のみ**。
- uitype15 / 33 は従来どおり（配列に既存のため挙動変化なし）。画面削除経路（LayoutEditor）は変更なし。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [-] 言語対応（日・英）：該当なし（言語ファイルの変更を伴わないコード修正）

## 備考 / Remarks
- localhost で再現・修正を検証。uitype16 と uitype15 の選択肢項目を作成し vtlib 経由で削除して比較した：
  - **修正前** `array(15, 33)`：uitype16 のみ値テーブル `vtiger_<col>` と `_seq` が残留、uitype15 は正常削除。
  - **修正後** `array(15, 16, 33)`：uitype16 も正常に削除されることを確認。
- git 履歴上、本判定配列は導入当初から `array(15, 33)` であり、uitype16 除外に意図的な根拠は見当たらない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
