### PR TITLE
[修正] 個人設定「ユーザー情報」「カレンダー設定」画面でヘッダーのアプリメニューが表示されない不具合を修正 (#1694)

### DIFF
--- a/modules/Users/views/Calendar.php
+++ b/modules/Users/views/Calendar.php
@@ -100,6 +100,14 @@ class Users_Calendar_View extends Vtiger_Detail_View {
 			$viewer->assign('HOME_MODULE_MODEL', $homeModuleModel);
 			$viewer->assign('HEADER_LINKS',$this->getHeaderLinks());
 			$viewer->assign('ANNOUNCEMENT', $this->getAnnouncement());
+
+			// WebComponents用アプリメニューデータの構築（基底ビューと同様にヘッダーの<app-menu>へ渡す）
+			$menuGroupedByParent = Settings_MenuEditor_Module_Model::getAllVisibleModules();
+			$supportGroup = $menuGroupedByParent['SUPPORT'];
+			unset($menuGroupedByParent['SUPPORT']);
+			$menuGroupedByParent['SUPPORT'] = $supportGroup;
+			$viewer->assign('HEADER_MENU_APP_MENUS_JSON', $this->buildAppMenuData($menuGroupedByParent));
+
 			$viewer->assign('CURRENT_VIEW', $request->get('view'));
 			$viewer->assign('SKIN_PATH', Vtiger_Theme::getCurrentUserThemePath());
 			$viewer->assign('LANGUAGE', $currentUser->get('language'));

--- a/modules/Users/views/PreferenceDetail.php
+++ b/modules/Users/views/PreferenceDetail.php
@@ -100,6 +100,14 @@ class Users_PreferenceDetail_View extends Vtiger_Detail_View {
 			$viewer->assign('HOME_MODULE_MODEL', $homeModuleModel);
 			$viewer->assign('HEADER_LINKS',$this->getHeaderLinks());
 			$viewer->assign('ANNOUNCEMENT', $this->getAnnouncement());
+
+			// WebComponents用アプリメニューデータの構築（基底ビューと同様にヘッダーの<app-menu>へ渡す）
+			$menuGroupedByParent = Settings_MenuEditor_Module_Model::getAllVisibleModules();
+			$supportGroup = $menuGroupedByParent['SUPPORT'];
+			unset($menuGroupedByParent['SUPPORT']);
+			$menuGroupedByParent['SUPPORT'] = $supportGroup;
+			$viewer->assign('HEADER_MENU_APP_MENUS_JSON', $this->buildAppMenuData($menuGroupedByParent));
+
 			$viewer->assign('CURRENT_VIEW', $request->get('view'));
 			$viewer->assign('SKIN_PATH', Vtiger_Theme::getCurrentUserThemePath());
 			$viewer->assign('CURRENT_USER_MODEL', $currentUser);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1694

##  不具合の内容 / Bug
1. 個人設定の「ユーザー情報」画面（`view=PreferenceDetail`）と「カレンダー設定」画面（`view=Calendar`）でのみ、ヘッダー上部の Web Components 製アプリメニュー（`<app-menu>`）が表示されない。

##  原因 / Cause
1. アプリメニューへ渡すメニュー情報 `HEADER_MENU_APP_MENUS_JSON` は、基底ビュー `Vtiger_Basic_View::preProcess()`（`modules/Vtiger/views/Basic.php`）内で `buildAppMenuData()` の結果として Viewer に assign されている。
1. しかし `Users_PreferenceDetail_View::preProcess()` と `Users_Calendar_View::preProcess()` は `preProcess()` を全面オーバーライドしており、`parent::preProcess()` を呼ばず `HEADER_MENU_APP_MENUS_JSON` の assign も行っていなかった。
1. その結果、`Topbar.tpl` の `<app-menu app-menus="{$HEADER_MENU_APP_MENUS_JSON|escape:'html'}">` に渡る値が空文字となり、Web Components 側で描画するメニュー情報が存在せずメニューが非表示になっていた。

##  変更内容 / Details of Change
1. `modules/Users/views/PreferenceDetail.php` / `modules/Users/views/Calendar.php` の `preProcess()` に、基底ビューと同じ手順でメニュー情報を構築し `HEADER_MENU_APP_MENUS_JSON` を assign する処理を追加。
   - `Settings_MenuEditor_Module_Model::getAllVisibleModules()` でメニューを取得し、SUPPORT カテゴリを末尾へ並べ替え
   - 継承済みの `buildAppMenuData()` の結果を `HEADER_MENU_APP_MENUS_JSON` として assign
1. コア（`modules/Vtiger/`）は改変していない。

## スクリーンショット / Screenshot
localhost で実際にログインし、両画面の `<app-menu>` の `app-menus` 属性を確認した結果：

| 画面 | 修正前 | 修正後 |
|---|---|---|
| ユーザー情報（PreferenceDetail） | `app-menus=""`（空 / 23 bytes） | メニュー JSON（12,597 bytes） |
| カレンダー設定（Calendar） | `app-menus=""`（空 / 23 bytes） | メニュー JSON（12,597 bytes） |

## 影響範囲  / Affected Area
- 個人設定「ユーザー情報」画面 / 「カレンダー設定」画面のヘッダー表示のみ。
- 追加処理は基底ビューと同一ロジックであり、他画面のメニュー表示には影響しない。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（表示ラベルは既存の翻訳キーを利用。新規文言なし）

## 備考 / Remarks
- 動作確認は Docker 開発環境（localhost / PHP 8.3.30 / MySQL 8.0.46）で実施。
- `php -l` で対象 2 ファイルの構文エラーが無いことを確認済み。
- 本来は各ビューが `preProcess()` を全面オーバーライドせず基底の処理へ委譲するのが理想だが、これらのビューは独自の preProcess を前提に組まれており、基底処理へ寄せると設定画面全体の描画に広く影響しうる。今回はリスクと影響範囲を抑えるため、基底と同じロジックを最小差分で追加する方針とした（メニュー構築の数行のみ重複）。将来的な重複解消は別途リファクタで検討したい。
