### PR TITLE
[修正] アクセスキーの変更が成功しても失敗と表示される不具合を修正 (#1696)

### DIFF
--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -738,8 +738,10 @@ class Users extends CRMEntity {
 
 	function createAccessKey() {
 		global $adb;
+		$accessKey = vtws_generateRandomAccessKey(16);
 		$updateQuery = "update vtiger_users set accesskey=? where id=?";
-		$adb->pquery($updateQuery,array(vtws_generateRandomAccessKey(16),$this->id));
+		$adb->pquery($updateQuery,array($accessKey,$this->id));
+		return $accessKey;
 	}
 
 	/** Function to insert values in the specifed table for the specified module

--- a/modules/Users/actions/SaveAjax.php
+++ b/modules/Users/actions/SaveAjax.php
@@ -271,16 +271,16 @@ class Users_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 			$oldAccessKey = $recordModel->get('accesskey');
 
 			$entity = $recordModel->getEntity();
-			$entity->createAccessKey();
+			// createAccessKey() で生成した新しいアクセスキーをそのまま受け取る。
+			// 直後に再生成する user_privileges ファイルから読み戻すと、同一リクエスト内では
+			// opcache が書き換え前のバイトコードを返し、古い値のまま比較され誤って失敗判定になる。
+			$newAccessKey = $entity->createAccessKey();
 
 			require_once('modules/Users/CreateUserPrivilegeFile.php');
 			createUserPrivilegesfile($recordId);
 			Vtiger_AccessControl::clearUserPrivileges($recordId);
 
-			$recordModel = Users_Record_Model::getInstanceFromPreferenceFile($recordId);
-			$newAccessKey = $recordModel->get('accesskey');
-
-			if ($newAccessKey != $oldAccessKey) {
+			if ($newAccessKey && $newAccessKey != $oldAccessKey) {
 				$response->setResult(array('success' => true, 'message' => vtranslate('LBL_ACCESS_KEY_UPDATED_SUCCESSFULLY', $moduleName), 'accessKey' => $newAccessKey));
 			} else {
 				$response->setError(vtranslate('LBL_FAILED_TO_UPDATE_ACCESS_KEY', $moduleName));


### PR DESCRIPTION
## 概要
ユーザー詳細画面から「アクセスキーの変更」を実行すると、アクセスキー自体は正しく更新されているにもかかわらず、画面上に「アクセスキーの更新に失敗しました」というエラーが表示される不具合を修正します。

Fixes thinkingreed-inc/F-RevoCRM#1696

## 原因
`modules/Users/actions/SaveAjax.php` の `changeAccessKey()` が、更新成否の判定を「再生成直後の `user_privileges/user_privileges_<id>.php` から読み戻した値」と旧アクセスキーの比較で行っていました。

- `Users::createAccessKey()` は `vtiger_users.accesskey` を新しいランダム値で正しく UPDATE している。
- しかし判定に使う値は、直後に `createUserPrivilegesfile()` で書き換えた権限ファイルから読み戻している。この権限ファイルはリクエスト冒頭で既に読み込まれており、opcache により**同一リクエスト内では書き換え前の古いバイトコードが返る**ため、読み戻し値が旧アクセスキーのままになる。
- 結果、`$newAccessKey != $oldAccessKey` が常に false となり、DB は更新されているのに「失敗」と判定されていた（リロードすると新しいキーが表示される）。

ログでの確認例:
```
oldAccessKey       = aKSIa7jrVAcyRLF4   ← 更新前のDB値
dbKey(afterUpdate) = bNKNS61IYehaljf3   ← createAccessKey() 後のDB値（更新は成功）
newAccessKey(file) = aKSIa7jrVAcyRLF4   ← 権限ファイルから読み戻した値（古いまま）
```

## 修正内容
同一リクエスト内で書き込み直後の PHP ファイルを読み戻す設計をやめ、権威あるデータベースの値（＝`createAccessKey()` が生成・書き込んだ値そのもの）で判定・レスポンスするよう変更しました。

- `modules/Users/Users.php` … `createAccessKey()` が生成したアクセスキーを返すよう変更
- `modules/Users/actions/SaveAjax.php` … ファイル読み戻しをやめ、`createAccessKey()` の戻り値で成否判定・レスポンス

## 動作確認
Docker 環境（F-RevoCRM 8.0.2 / PHP 8.3.30・opcache 有効 / MySQL 8.0.46）で確認。

- 修正前: `index.php?module=Users&action=SaveAjax&mode=changeAccessKey&record=1` が `{"success":false,...,"アクセスキーの更新に失敗しました"}` を返す（不具合再現）。
- 修正後: `{"success":true,...,"accessKey":"XrnlgV4DNs0kLp90"}` を返し、DB の `accesskey` と一致。
- 連続実行でも毎回 `success:true` かつ毎回異なる新しいアクセスキーが発行されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
