### PR TITLE
fix(#1700): スクリプト経由で項目の追加を行う際にAPI参照名の重複チェックが行われない問題を修正

### DIFF
--- a/vtlib/Vtiger/FieldBasic.php
+++ b/vtlib/Vtiger/FieldBasic.php
@@ -183,13 +183,28 @@ class Vtiger_FieldBasic {
 		if (!$this->columntype)
 			$this->columntype = 'VARCHAR(100)';
 
-		if ((int) $this->generatedtype === 2 && in_array((int) $this->uitype, array(10, 15, 16, 33))) {
-			$dupResult = $adb->pquery(
-				'SELECT 1 FROM vtiger_field WHERE columnname = ? LIMIT 1',
-				array($this->column)
-			);
-			if ($adb->num_rows($dupResult) > 0) {
-				throw new Exception("columnname '{$this->column}' already exists");
+		$dupSameModule = $adb->num_rows($adb->pquery(
+			'SELECT 1 FROM vtiger_field WHERE fieldname = ? AND tabid = ? LIMIT 1',
+			array($this->name, $this->getModuleId())
+		)) > 0;
+
+		if ($dupSameModule) {
+			$message = "同モジュール内にAPI参照名 {$this->name} が使われている為、項目の追加に失敗しました";
+			self::log("[ERROR] $message");
+			throw new Exception($message);
+		}
+
+		$isPicklist = in_array((int) $this->uitype, array(15, 16, 33));
+		if ($isPicklist) {
+			$dupCrossModule = $adb->num_rows($adb->pquery(
+				'SELECT 1 FROM vtiger_field WHERE fieldname = ? LIMIT 1',
+				array($this->name)
+			)) > 0;
+
+			if ($dupCrossModule) {
+				$message = "別モジュールの選択肢項目にAPI参照名 {$this->name} が使われている為、項目の追加に失敗しました";
+				self::log("[ERROR] $message");
+				throw new Exception($message);
 			}
 		}
 

--- a/vtlib/Vtiger/FieldBasic.php
+++ b/vtlib/Vtiger/FieldBasic.php
@@ -183,8 +183,18 @@ class Vtiger_FieldBasic {
 		if (!$this->columntype)
 			$this->columntype = 'VARCHAR(100)';
 
-        if (!$this->label && !$this->uitype === 999)
-            $this->label = $this->name;
+		if ((int) $this->generatedtype === 2 && in_array((int) $this->uitype, array(10, 15, 16, 33))) {
+			$dupResult = $adb->pquery(
+				'SELECT 1 FROM vtiger_field WHERE columnname = ? LIMIT 1',
+				array($this->column)
+			);
+			if ($adb->num_rows($dupResult) > 0) {
+				throw new Exception("columnname '{$this->column}' already exists");
+			}
+		}
+
+		if (!$this->label && !$this->uitype === 999)
+			$this->label = $this->name;
 
 		if (!empty($this->columntype)) {
 			Vtiger_Utils::AddColumn($this->table, $this->column, $this->columntype);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1700

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. スクリプト経由で項目の追加をする際、既存項目と同一のAPI参照名でも作成できてしまい、「参照・選択肢」項目を作成時に選択肢の意図しない共有が発生する

##  原因 / Cause
<!-- バグの原因を記述 -->
1. スクリプト経由での項目作成時に重複チェックが行われない

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. スクリプト経由での項目追加時に「参照, 選択肢」項目の場合、モジュール横断でAPI参照名の重複チェックを行う

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
- スクリプト経由での項目追加

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 確認内容
- uitype 15 の既存項目と同一 `columnname` でのスクリプト作成 → Exception で拒否されることを確認
- uitype 1（対象外）での作成 → チェックをスキップし従来通り作成可能
- `generatedtype = 1`（システム項目）→ チェックをスキップし従来通り作成可能