### PR TITLE
[修正] 品目名インライン検索が動作しない不具合を修正

### DIFF
--- a/modules/Products/models/Record.php
+++ b/modules/Products/models/Record.php
@@ -450,12 +450,12 @@ class Products_Record_Model extends Vtiger_Record_Model {
 		if($module !== false) {
 			$query .= ' AND setype = ?';
 			if($module == 'Products'){
-				$query = 'SELECT label, crmid, setype, createdtime FROM vtiger_crmentity INNER JOIN vtiger_products ON 
-							vtiger_products.productid = vtiger_crmentity.crmid WHERE label LIKE ? AND vtiger_crmentity.deleted = 0 
+				$query = 'SELECT vtiger_products.label, vtiger_crmentity.crmid, vtiger_crmentity.setype, vtiger_crmentity.createdtime FROM vtiger_crmentity INNER JOIN vtiger_products ON
+							vtiger_products.productid = vtiger_crmentity.crmid WHERE vtiger_products.label LIKE ? AND vtiger_crmentity.deleted = 0
 							AND vtiger_products.discontinued = 1 AND setype = ?';
 			}else if($module == 'Services'){
-				$query = 'SELECT label, crmid, setype, createdtime FROM vtiger_crmentity INNER JOIN vtiger_service ON 
-							vtiger_service.serviceid = vtiger_crmentity.crmid WHERE label LIKE ? AND vtiger_crmentity.deleted = 0 
+				$query = 'SELECT vtiger_service.label, vtiger_crmentity.crmid, vtiger_crmentity.setype, vtiger_crmentity.createdtime FROM vtiger_crmentity INNER JOIN vtiger_service ON
+							vtiger_service.serviceid = vtiger_crmentity.crmid WHERE vtiger_service.label LIKE ? AND vtiger_crmentity.deleted = 0
 							AND vtiger_service.discontinued = 1 AND setype = ?';
 			}
 			$params[] = $module;


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1704

##  不具合の内容 / Bug
1. 受注/見積/請求/発注の「項目の詳細」で品目名インライン検索（オートコンプリート）が常に「結果がありません」となる

##  原因 / Cause
1. `modules/Products/models/Record.php` `getSearchResult()` の Products/Services 用 SQL で `label` / `createdtime` を無修飾で参照
1. `vtiger_products` / `vtiger_service` 両テーブルに `label` カラムが存在するため、`vtiger_crmentity` との JOIN 時に「Column 'label' is ambiguous」で SQL 実行失敗
1. 結果が空配列で返却され、フロントには「結果がありません」と表示

##  変更内容 / Details of Change
1. Products/Services クエリの `SELECT` / `WHERE` 内 `label` / `createdtime` を `vtiger_products.` / `vtiger_service.` に明示修飾

## スクリーンショット / Screenshot
（before/after 添付予定）

## 影響範囲  / Affected Area
- インベントリ系モジュール（受注・見積・請求・発注）の項目詳細インライン検索
- Products/Services モジュールの `Products_Record_Model::getSearchResult()` 呼び出し全体

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った（対象外：SQL修正のみ）

## 備考 / Remarks
- 保存経路（`CRMEntity::save` → `updateBasicInformation`）で `vtiger_products.label` は `productname` と同期される設計。新規Product作成時に同期を実測確認済み
- DB直INSERT等 通常保存経路外で作成された旧データは `vtiger_products.label` が NULL のため検索対象外となる点は既知の制約