### PR TITLE
[修正] サービス一覧が表示されない不具合を修正

### DIFF
--- a/modules/Products/models/ListView.php
+++ b/modules/Products/models/ListView.php
@@ -79,7 +79,7 @@ class Products_ListView_Model extends Vtiger_ListView_Model {
 			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
 		} else if(empty($orderBy) && empty($sortOrder)){
 			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_products.modifiedtime DESC';
+			$listQuery .= ' ORDER BY '.$moduleFocus->table_name.'.modifiedtime DESC';
 		}
 
 		$viewid = ListViewSession::getCurrentView($moduleName);


### PR DESCRIPTION
## 関連Issue / Related Issue
- fix #1512

## 不具合の内容 / Bug
1. サービスモジュールの一覧画面 (`module=Services&view=List`) でレコードが1件も表示されない（0件表示）。レコード追加・詳細画面は正常動作。

## 原因 / Cause
1. `Services_ListView_Model` は `Products_ListView_Model` を継承している。
2. PR #1513（issue #1512）で `modules/Products/models/ListView.php` の並び順SQLを `vtiger_crmentity.modifiedtime` → `vtiger_products.modifiedtime` へ置換した。
3. Services 側の一覧クエリは `vtiger_service` テーブルのみを JOIN し `vtiger_products` は JOIN しないため、`ORDER BY vtiger_products.modifiedtime` で SQLエラーが発生。
4. 発生エラー: `ERROR 1054 (42S22): Unknown column 'vtiger_products.modifiedtime' in 'order clause'`
5. 結果、一覧クエリが空を返し、レコードが表示されない。

## 変更内容 / Details of Change
1. `modules/Products/models/ListView.php` の `ORDER BY` に指定するテーブル名を、ハードコードの `vtiger_products` からモジュールのエンティティテーブルを動的に参照する `$moduleFocus->table_name` に変更。
2. Products モジュール → `vtiger_products.modifiedtime`、Services モジュール → `vtiger_service.modifiedtime` として展開されるため、両モジュールで正常動作する。

## スクリーンショット / Screenshot
- 修正前: サービス一覧が空表示（SQLエラーで結果0件）
- 修正後: サービス一覧に既存レコード（test）が「1 to 1」で表示されることを Chrome DevTools MCP にて確認

## 影響範囲 / Affected Area
- サービス一覧画面（Services List View）: 修正対象
- 製品一覧画面（Products List View）: 動作変わらず（`$moduleFocus->table_name` = `vtiger_products`）
- `Products_ListView_Model` を継承する他モジュールが存在する場合、同様に恩恵を受ける

## チェックリスト / Check List
- [x] 自らテストを行った（Chrome DevTools MCP でサービス一覧のレコード表示を確認）
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（言語ファイルの修正は無し）

## 備考 / Remarks
- 埋め込み元PR: #1513 「vtiger_crmentityへの参照をbasetableに置換」
- 関連Issue: #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)