### PR TITLE
[修正] #1707 スマホ・PC表示でのインポート画面／ユーザー管理画面のレイアウト崩れ

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -156,10 +156,15 @@ td.listViewEntryValue  .fieldValue .value {
    width: 90%;
  }
 
+.importview-content,
+.customview-content {
+  max-height: calc(100vh - 210px) !important;
+}
+
 /*
  * モバイル表示
  */
-@media (max-width: 768px) { 
+@media (max-width: 768px) {
   .settingsIcon {
     display: none;
   }
@@ -176,7 +181,7 @@ td.listViewEntryValue  .fieldValue .value {
   }
   .main-container .module-nav {
     width: 100%;
-    z-index: 1100;
+    z-index: 1050;
     background-color: #2C3B49;
     background: #2C3B49;
   }
@@ -236,9 +241,21 @@ td.listViewEntryValue  .fieldValue .value {
   .main-container.main-container-Calendar .module-nav {
     order: 2;
     width: 100%;
-    z-index: 1100;
+    z-index: 1050;
     background-color: #2C3B49;
     background: #2C3B49;
+  }
+  body.modal-open .main-container .module-nav,
+  body.modal-open .main-container.main-container-Calendar .module-nav {
+    z-index: 0;
+  }
+  .importview-content,
+  .customview-content {
+    max-height: calc(100vh - 210px) !important;
+    padding-bottom: 60px;
+  }
+  .main-container > .settingsPageDiv {
+    padding-top: 45px;
   }
   .main-container.main-container-Calendar .module-nav div.modules-menu {
     position: relative;


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1707

##  不具合の内容 / Bug
1. スマホ表示のインポート画面で注意文言（黄色の警告ブロック）末尾が固定フッターに隠れて見切れる
2. スマホ表示のカレンダー ICS インポート画面で `#modnavigator`（共有/個人/一覧切替フッター）が半モーダル上に被る
3. PC表示のインポート画面でビューポート高に余裕があるのに不要な内部スクロールが発生する
4. スマホ表示のユーザー管理画面（システム設定 → ユーザー管理 → ユーザー）で「有効なユーザー」「無効なユーザー」ボタンが上部の「ユーザーの追加」「インポート」ボタンと重なって見切れる

##  原因 / Cause
1. `.main-container .module-nav` / `.main-container.main-container-Calendar .module-nav` が `z-index: 1100` でモーダル (`.modal` z:1100) と同値。DOM 順で modnavigator が上勝ち
2. `.importview-content, .customview-content` が `max-height: 530px` 固定でビューポート高に追随せず、PC で余分なスクロール／モバイルで固定フッター配下に文言が隠れる
3. Settings 系画面は fixed nav が二段構造（127px）だが、モバイルで main-container 側に対応する余白がなく配下要素が nav 配下に潜る

##  変更内容 / Details of Change
`public/resources/styles.css` のみ変更:

1. 共通ルール追加: `.importview-content, .customview-content { max-height: calc(100vh - 210px) !important }`
2. `@media (max-width: 991px)` 内で以下を変更/追加:
   - `.main-container .module-nav` の `z-index`: `1100 → 1050`
   - `.main-container.main-container-Calendar .module-nav` の `z-index`: `1100 → 1050`
   - `body.modal-open .main-container .module-nav`, `body.modal-open .main-container.main-container-Calendar .module-nav` に `z-index: 0` を追加（モーダル open 時 modnavigator を背後へ）
   - `.importview-content, .customview-content` に `padding-bottom: 60px` を追加
   - `.main-container > .settingsPageDiv` に `padding-top: 45px` を追加

## 影響範囲  / Affected Area
- 全モジュール共通のインポート画面（`ImportBasicStep.tpl` を使う全モジュール）
- カレンダー ListView / CalendarView（`#modnavigator` を持つビュー）
- Settings 系画面全般（`.settingsPageDiv` を持つ全画面）
- スマホ表示（991px 以下）／PC表示

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った ※CSSのみで対象外

## 備考 / Remarks
CSS のみの変更。テンプレートファイル・PHP・JS の変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)