### PR TITLE
[修正] #1709 スマホ表示でメールマネージャー画面のレイアウト崩れ

### DIFF
--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -257,6 +257,15 @@ td.listViewEntryValue  .fieldValue .value {
   .main-container > .settingsPageDiv {
     padding-top: 45px;
   }
+  .main-container-MailManager .listViewPageDiv {
+    padding-left: 0 !important;
+  }
+  .main-container-MailManager .mmDescription {
+    width: auto !important;
+    height: auto !important;
+    margin-left: 15px !important;
+    margin-right: 15px !important;
+  }
   .main-container.main-container-Calendar .module-nav div.modules-menu {
     position: relative;
     left: auto;


### PR DESCRIPTION
## 関連Issue / Related Issue
- fix #1709

## 不具合の内容 / Bug
1. スマートフォン幅（991px 以下）でメールマネージャー画面（`index.php?module=MailManager&view=List`）を表示した際、本文領域が左に約 230px 分の余白を持ったまま表示され、コンテンツが画面右側に押し込まれる。
2. メールボックス未設定時に表示される説明ブロック（`.mmDescription`）が画面外にはみ出し、かつ高さ 300px 固定のため「メールボックスの設定」ボタンがブロック外にあふれる。

## 原因 / Cause
1. skin CSS（`public/layouts/v7/skins/*/style.css`）の `.main-container-MailManager .listViewPageDiv { padding-left: 230px; }` が `@media` 未指定でスマホでも常時適用され、PC 時のサイドバー用オフセットがスマホに残っていた。
2. 同じく skin CSS の `.mmDescription { width: 80%; margin-left: -4%; height: 300px; }` が幅・負マージン・固定高さを持ち、スマホ幅ではブロックが画面外にはみ出し／内容が高さ内に収まらずボタンが枠外にあふれていた。

## 変更内容 / Details of Change
1. `public/resources/styles.css` の `@media (max-width: 991px)` 内に以下を追加。
    - `.main-container-MailManager .listViewPageDiv { padding-left: 0 !important; }` … スマホ時の余分な左余白を解除
    - `.main-container-MailManager .mmDescription { width: auto !important; height: auto !important; margin-left: 15px !important; margin-right: 15px !important; }` … 幅を全幅化、高さ自動、左右マージンで枠内配置

## 影響範囲  / Affected Area
- MailManager モジュール一覧画面（`module=MailManager&view=List`）のスマホ表示
- 変更は `@media (max-width: 991px)` 内かつ `.main-container-MailManager` 配下スコープに限定。PC 表示（≥992px）および他モジュールへの影響なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイル変更なし（CSS のみ）のため「言語対応（日・英）」該当なし
- 動作確認: Chrome DevTools でビューポート 375×812（スマホ）／1400×900（PC）を切替、修正前後のスクリーンショットで崩れ解消と PC 表示無変化を確認済み