### PR TITLE
[修正] #1711 リマインダーメールの文字化け・翻訳不備

### DIFF
--- a/cron/SendReminder.service
+++ b/cron/SendReminder.service
@@ -193,7 +193,7 @@ if($adb->num_rows($result) >= 1)
 
 			$recordModel = Vtiger_Record_Model::getInstanceById($activity_id, 'Calendar');
 			$recordDetailViewLink = $recordModel->getDetailViewUrl();
-			$contents = $contents."<br/> ".vtranslate('LBL_CLICK_HERE_TO_VIEW', 'Calendar')."&nbsp;<a href=$site_URL/$recordDetailViewLink>".vtranslate('LBL_RECORD', 'Calendar')."</a>";
+			$contents = $contents."<br/> <a href=$site_URL/$recordDetailViewLink>".vtranslate('LBL_CLICK_HERE_TO_VIEW', 'Calendar')."</a>";
 			if(php7_count($to_addr) >=1)
 			{
 				send_email($to_addr,$from,$subject,$contents,$mail_server,$mail_server_username,$mail_server_password);

--- a/include/utils/EmailTemplate.php
+++ b/include/utils/EmailTemplate.php
@@ -282,7 +282,7 @@ s								 */
 						$needle = '$' . strtolower($this->module) . "-$column$";
 						$replaceValue = $values[array_search($column, $fieldColumnMapping)];
 						if($this->removeTags){
-							$encodedValue = json_encode($replaceValue);
+							$encodedValue = json_encode($replaceValue, JSON_UNESCAPED_UNICODE);
 							$replaceValue = substr($encodedValue, 1, -1);
 						}
 
@@ -304,10 +304,10 @@ s								 */
 							$replacer = $values[array_search($column, $fieldColumnMapping)];
 						}
 						if($this->removeTags){
-							$encodedValue = json_encode($replacer);
+							$encodedValue = json_encode($replacer, JSON_UNESCAPED_UNICODE);
 							$replacer = substr($encodedValue, 1, -1);
 						}
-						
+
 						$this->processedDescription = str_replace($needle, $replacer, $this->processedDescription);
 					}
 					if (!$params['owner'])

--- a/languages/ar_ae/Calendar.php
+++ b/languages/ar_ae/Calendar.php
@@ -174,7 +174,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'تشرين الأول / أكتوبر',
   'LBL_NOVEMBER' => 'تشرين الثاني / نوفمبر',
   'LBL_DECEMBER' => 'كانون الأول / ديسمبر',
-	'LBL_CLICK_HERE_TO_VIEW' => 'انقر هنا لعرض',
+	'LBL_CLICK_HERE_TO_VIEW' => 'انقر هنا لعرض السجل',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'عدد الأحداث المكررة تخطي',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'عدد المهام المكررة تخطي',

--- a/languages/de_de/Calendar.php
+++ b/languages/de_de/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Oktober',
   'LBL_NOVEMBER' => 'November',
   'LBL_DECEMBER' => 'Dezember',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Klicke hier, um anzusehen',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Klicken Sie hier, um den Datensatz anzusehen',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Anzahl der doppelten Ereignisse übersprungen',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Anzahl der doppelten Aufgaben übersprungen',

--- a/languages/en_gb/Calendar.php
+++ b/languages/en_gb/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'October',
   'LBL_NOVEMBER' => 'November',
   'LBL_DECEMBER' => 'December',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Click here to view',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Click here to view record',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'No. of duplicate Events skipped',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'No. of duplicate Tasks skipped',

--- a/languages/en_us/Calendar.php
+++ b/languages/en_us/Calendar.php
@@ -183,7 +183,7 @@ false : Persists checkbox states only for My Group. Other organization or role v
 	'LBL_OCTOBER' => 'October',
 	'LBL_NOVEMBER' => 'November',
 	'LBL_DECEMBER' => 'December',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Click here to view',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Click here to view record',
 
 	//F-RevoCRM
 	'Send Reminder' => 'Send Reminder',

--- a/languages/es_es/Calendar.php
+++ b/languages/es_es/Calendar.php
@@ -154,7 +154,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Octubre',
   'LBL_NOVEMBER' => 'Noviembre',
   'LBL_DECEMBER' => 'De diciembre de',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Haga clic aquí para ver',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Haga clic aquí para ver el registro',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Número de eventos duplicados saltado',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Número de tareas duplicadas saltado',

--- a/languages/es_mx/Calendar.php
+++ b/languages/es_mx/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'octubre',
   'LBL_NOVEMBER' => 'noviembre',
   'LBL_DECEMBER' => 'diciembre',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Haga clic aquí para ver',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Haga clic aquí para ver el registro',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Número de eventos duplicados saltados',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Número de tareas duplicadas saltadas',

--- a/languages/fr_fr/Calendar.php
+++ b/languages/fr_fr/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
 	'LBL_OCTOBER' => 'Octobre',
 	'LBL_NOVEMBER' => 'Novembre',
 	'LBL_DECEMBER' => 'Décembre',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Cliquez ici pour afficher',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Cliquez ici pour afficher l\'enregistrement',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Nombre de dupliquer des événements ignorés',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Nombre de tâches en double sautée',

--- a/languages/hu_hu/Calendar.php
+++ b/languages/hu_hu/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Október',
   'LBL_NOVEMBER' => 'November',
   'LBL_DECEMBER' => 'December',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Ide kattintva megtekintheti',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Ide kattintva megtekintheti a rekordot',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Nem ismétlődő események kimarad',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Nem ismétlődő feladatok kimarad',

--- a/languages/it_it/Calendar.php
+++ b/languages/it_it/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Ottobre',
   'LBL_NOVEMBER' => 'Novembre',
   'LBL_DECEMBER' => 'Dicembre',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Clicca qui per vedere',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Clicca qui per vedere il record',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Numero di eventi duplicati saltato',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Numero di Task duplicati saltato',

--- a/languages/ja_jp/Calendar.php
+++ b/languages/ja_jp/Calendar.php
@@ -182,9 +182,11 @@ false : マイグループのみチェック状態を記憶し、他の組織・
 	'LBL_OCTOBER' => '10月',
 	'LBL_NOVEMBER' => '11月',
 	'LBL_DECEMBER' => '12月',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Click here to view',
+	'LBL_CLICK_HERE_TO_VIEW' => '詳細はこちら',
 
 	//F-RevoCRM
+	'Reminder' => 'リマインダー',
+	'Activity Reminder' => 'リマインダー',
 	'Send Reminder' => '事前にメールを送信',
 	'Start Date & Time,Due Date' => '開始日時,終了日',
 	'My Group' => 'マイグループ',

--- a/languages/nl_nl/Calendar.php
+++ b/languages/nl_nl/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Oktober',
   'LBL_NOVEMBER' => 'November',
   'LBL_DECEMBER' => 'December',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Klik hier om te bekijken',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Klik hier om het record te bekijken',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Aantal dubbele Events overgeslagen',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Aantal dubbele Taken overgeslagen',

--- a/languages/pl_pl/Calendar.php
+++ b/languages/pl_pl/Calendar.php
@@ -167,7 +167,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Październik',
   'LBL_NOVEMBER' => 'Listopad',
   'LBL_DECEMBER' => 'Grudzień',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Kliknij tutaj, aby wyświetlić',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Kliknij tutaj, aby wyświetlić wpis',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Ilość duplikatów Wydarzenia pomijane',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Ilość Duplikaty pomijane',

--- a/languages/pt_br/Calendar.php
+++ b/languages/pt_br/Calendar.php
@@ -177,7 +177,7 @@ $languageStrings = array(
 	'LBL_OCTOBER' => 'Outubro',
 	'LBL_NOVEMBER' => 'Novembro',
 	'LBL_DECEMBER' => 'Dezembro',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Clique aqui para visualizar',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Clique aqui para visualizar o registro',
 );
 
 $jsLanguageStrings = array(

--- a/languages/ro_ro/Calendar.php
+++ b/languages/ro_ro/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Octombrie',
   'LBL_NOVEMBER' => 'Noiembrie',
   'LBL_DECEMBER' => 'Decembrie',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Apasa aici pentru a vizualiza',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Apasă aici pentru a vizualiza înregistrarea',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Nr de evenimente duplicate omit',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Nr Sarcini duplicate omit',

--- a/languages/ru_ru/Calendar.php
+++ b/languages/ru_ru/Calendar.php
@@ -145,7 +145,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Октябрь',
   'LBL_NOVEMBER' => 'Ноябрь',
   'LBL_DECEMBER' => 'Декабрь',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Нажмите сюда, чтобы посмотреть',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Нажмите сюда, чтобы посмотреть запись',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Количество повторяющихся событий пропускаются',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Количество повторяющихся задач пропускаются',

--- a/languages/sv_se/Calendar.php
+++ b/languages/sv_se/Calendar.php
@@ -174,7 +174,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Oktober',
   'LBL_NOVEMBER' => 'November',
   'LBL_DECEMBER' => 'December',
-	'LBL_CLICK_HERE_TO_VIEW' => 'Klicka här för att se',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Klicka här för att se posten',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'Antal dubbla händelser hoppas över',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'Antal dubbla uppgifter hoppas över',

--- a/languages/tr_tr/Calendar.php
+++ b/languages/tr_tr/Calendar.php
@@ -146,7 +146,7 @@ $languageStrings = array(
   'LBL_OCTOBER' => 'Ekim',
   'LBL_NOVEMBER' => 'Kasım',
   'LBL_DECEMBER' => 'Aralık',
-	'LBL_CLICK_HERE_TO_VIEW' => 'görmek için buraya tıklayın',
+	'LBL_CLICK_HERE_TO_VIEW' => 'Kaydı görmek için buraya tıklayın',
 
 	'LBL_TOTAL_EVENTS_DUPLICATED' => 'yinelenen Olayların sayılı atlanır',
 	'LBL_TOTAL_TASKS_DUPLICATED' => 'yinelenen Görevlerin sayılı atlanır',


### PR DESCRIPTION
## Summary

Closes #1711

リマインダーメール（活動・TODO）の以下の不具合を修正しました。

### 修正内容

1. **ステータス・場所の文字化け修正** (`include/utils/EmailTemplate.php`)
   - `json_encode()` に `JSON_UNESCAPED_UNICODE` を追加（285行目・307行目）
   - 日本語が `\uXXXX` 形式にエスケープされる問題を解消

2. **メール件名の日本語翻訳追加** (`languages/ja_jp/Calendar.php`)
   - `'Reminder' => 'リマインダー'` — 活動のメール件名用
   - `'Activity Reminder' => 'リマインダー'` — TODOのメール件名用
   - `'LBL_CLICK_HERE_TO_VIEW' => '詳細はこちら'`

3. **リンクテキストの改善** (`cron/SendReminder.service`)
   - `LBL_CLICK_HERE_TO_VIEW` + `LBL_RECORD` の2つの `vtranslate` を `LBL_CLICK_HERE_TO_VIEW` 1つに統合
   - リンクテキスト全体が `<a>` タグで囲まれるように変更
   - `LBL_RECORD` の上書きによる他画面への影響を回避

4. **全16言語の `LBL_CLICK_HERE_TO_VIEW` 更新** (`languages/*/Calendar.php`)
   - リンクテキストに各言語のrecord相当の目的語を追加し、文として完結させた

## Test plan

- [x] 活動（Events）のリマインダーメールで件名が「リマインダー: ...」と表示される
- [x] TODOのリマインダーメールで件名が「リマインダー: ...」と表示される
- [x] ステータスが日本語（例: 計画済み、未着手）で正しく表示される
- [x] 場所が日本語（例: 東京オフィス 3F会議室）で正しく表示される
- [x] メール末尾のリンクが「詳細はこちら」として自然に表示される
- [ ] レコードのマージ画面（MergeRecords）で `LBL_RECORD` が「レコード」のまま表示される（影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)