### PR TITLE
[修正] #1714 ラベル項目の「関連一覧に表示」ロックを解除し設定値どおりに表示する

### DIFF
--- a/languages/en_us/Settings/LayoutEditor.php
+++ b/languages/en_us/Settings/LayoutEditor.php
@@ -157,6 +157,7 @@ $languageStrings = array(
     'LBL_HEADER' => 'Header',
     'LBL_DETAIL_HEADER' => 'Record header',
     'LBL_HEADER_FIELD' => 'Header View',
+    'LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN' => 'At least one label field must be enabled as Header View or Key Field View, so this field cannot be disabled',
 
 	'LBL_DUPLICATE_HANDLING' => 'Duplicate Prevention',
 	'LBL_DUPLICATE_CHECK' => 'Enable duplicate check',

--- a/languages/ja_jp/Settings/LayoutEditor.php
+++ b/languages/ja_jp/Settings/LayoutEditor.php
@@ -157,6 +157,7 @@ $languageStrings = array(
     'LBL_HEADER' => '関連一覧',
     'LBL_DETAIL_HEADER' => '関連一覧',
     'LBL_HEADER_FIELD' => '関連一覧に表示',
+    'LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN' => 'ラベル項目のうち最低1つは「関連一覧に表示」または「主要項目」を有効にする必要があるため、この項目は無効にできません',
 
 	'LBL_DUPLICATE_HANDLING' => '重複登録の防止',
 	'LBL_DUPLICATE_CHECK' => '重複チェックを有効にする',

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -214,7 +214,7 @@
 										<input type="hidden" name="headerfield" value="0"/>
 										<label class="checkbox" style="margin-left: 9%;">
 											<input type="checkbox" class="{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'} cursorPointerNotAllowed {else} cursorPointer{/if}" name="headerfield" value="1" {if $FIELD_MODEL->get('headerfield') eq '1'}checked="checked"{/if}
-												{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $IS_NAME_FIELD || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
+												{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
 										</label>
 									</div>
 								</div>

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl
@@ -200,9 +200,14 @@
 									</label>
 									<div class="controls col-sm-2">
 										<input type="hidden" name="summaryfield" value="0"/>
+										{* ラベル(entityname)項目のうち、表示が有効な最後の1項目は無効にできないようにする *}
+										{assign var=IS_LAST_VISIBLE_NAME_FIELD value=$FIELD_MODEL->isLastVisibleNameField()}
+										{assign var=SUMMARY_FIELD_LOCKED value=$IS_LAST_VISIBLE_NAME_FIELD && $FIELD_MODEL->get('summaryfield') eq '1'}
+										{assign var=HEADER_FIELD_LOCKED value=$IS_LAST_VISIBLE_NAME_FIELD && $FIELD_MODEL->get('headerfield') eq '1'}
 										<label class="checkbox" style="margin-left: 6%;">
-											<input type="checkbox" class="{if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'} cursorPointerNotAllowed {else} cursorPointer{/if}" name="summaryfield" value="1" {if $FIELD_MODEL->get('summaryfield') eq '1'}checked="checked"{/if}
-												{if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
+											<input type="checkbox" class="{if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SUMMARY_FIELD_LOCKED || $SELECTED_MODULE_NAME eq 'Users'} cursorPointerNotAllowed {else} cursorPointer{/if}" name="summaryfield" value="1" {if $FIELD_MODEL->get('summaryfield') eq '1'}checked="checked"{/if}
+												{if $SUMMARY_FIELD_LOCKED}title="{vtranslate('LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN',$QUALIFIED_MODULE)}"{/if}
+												{if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SUMMARY_FIELD_LOCKED || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
 										</label>
 									</div>
 								</div>
@@ -213,8 +218,9 @@
 									<div class="controls col-sm-5">
 										<input type="hidden" name="headerfield" value="0"/>
 										<label class="checkbox" style="margin-left: 9%;">
-											<input type="checkbox" class="{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'} cursorPointerNotAllowed {else} cursorPointer{/if}" name="headerfield" value="1" {if $FIELD_MODEL->get('headerfield') eq '1'}checked="checked"{/if}
-												{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
+											<input type="checkbox" class="{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $HEADER_FIELD_LOCKED || $SELECTED_MODULE_NAME eq 'Users'} cursorPointerNotAllowed {else} cursorPointer{/if}" name="headerfield" value="1" {if $FIELD_MODEL->get('headerfield') eq '1'}checked="checked"{/if}
+												{if $HEADER_FIELD_LOCKED}title="{vtranslate('LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN',$QUALIFIED_MODULE)}"{/if}
+												{if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $HEADER_FIELD_LOCKED || $SELECTED_MODULE_NAME eq 'Users'}readonly="readonly"{/if} />
 										</label>
 									</div>
 								</div>

--- a/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl
@@ -146,21 +146,25 @@
                                   />&nbsp;{vtranslate('LBL_MASS_EDIT',$QUALIFIED_MODULE)}
                             </span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                             {assign var=IS_HEADER_FIELD value=$FIELD_MODEL->isHeaderField()}
+                            {* ラベル(entityname)項目のうち、表示が有効な最後の1項目は無効にできないようにする *}
+                            {assign var=IS_LAST_VISIBLE_NAME_FIELD value=$FIELD_MODEL->isLastVisibleNameField()}
+                            {assign var=HEADER_FIELD_LOCKED value=$IS_LAST_VISIBLE_NAME_FIELD && $IS_HEADER_FIELD}
+                            {assign var=SUMMARY_FIELD_LOCKED value=$IS_LAST_VISIBLE_NAME_FIELD && $FIELD_MODEL->isSummaryField()}
                             <span class="header switch {if (!$IS_HEADER_FIELD)} disabled {/if} 
-                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-                                data-toggle="tooltip" {if $IS_HEADER_FIELD} title="{$NOT_H_FIELD_TITLE}" {else} title="{$H_FIELD_TITLE}" {/if}>
+                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $HEADER_FIELD_LOCKED} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $HEADER_FIELD_LOCKED} title="{vtranslate('LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN',$QUALIFIED_MODULE)}" {elseif $IS_HEADER_FIELD} title="{$NOT_H_FIELD_TITLE}" {else} title="{$H_FIELD_TITLE}" {/if}>
                               <i class="fa fa-flag-o" data-name="headerfield" 
                                 data-enable-value="1" data-disable-value="0"
-                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled()}readonly="readonly"{/if}
+                                {if $FIELD_MODEL->isHeaderFieldOptionDisabled() || $HEADER_FIELD_LOCKED}readonly="readonly"{/if}
                                 title="{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_HEADER',$QUALIFIED_MODULE)}
                             </span><br><br>
                             {assign var=IS_SUMMARY_VIEW_ENABLED value=$FIELD_MODEL->isSummaryField()}
                             <span class="summary switch {if (!$IS_SUMMARY_VIEW_ENABLED)} disabled {/if} 
-                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled()} cursorPointerNotAllowed {else} cursorPointer {/if}"
-                                data-toggle="tooltip" {if $IS_SUMMARY_VIEW_ENABLED} title="{$NOT_S_FIELD_TITLE}" {else} title="{$S_FIELD_TITLE}" {/if}>
+                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SUMMARY_FIELD_LOCKED} cursorPointerNotAllowed {else} cursorPointer {/if}"
+                                data-toggle="tooltip" {if $SUMMARY_FIELD_LOCKED} title="{vtranslate('LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN',$QUALIFIED_MODULE)}" {elseif $IS_SUMMARY_VIEW_ENABLED} title="{$NOT_S_FIELD_TITLE}" {else} title="{$S_FIELD_TITLE}" {/if}>
                               <i class="fa fa-key" data-name="summaryfield" 
                                 data-enable-value="1" data-disable-value="0"
-                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled()}readonly="readonly"{/if}
+                                {if $FIELD_MODEL->isSummaryFieldOptionDisabled() || $SUMMARY_FIELD_LOCKED}readonly="readonly"{/if}
                                 title="{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}"></i>&nbsp;{vtranslate('LBL_KEY_FIELD',$QUALIFIED_MODULE)}
                             </span><br><br>
                             <div class="defaultValue col-sm-12 {if !$FIELD_MODEL->hasDefaultValue()}disabled{/if} 

--- a/modules/Settings/LayoutEditor/actions/Field.php
+++ b/modules/Settings/LayoutEditor/actions/Field.php
@@ -84,6 +84,10 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
         $headerField = $request->get('headerfield',null);
         $fieldDefaultValue = $request->get('fieldDefaultValue', null);
 
+        // ラベル(entityname)項目のうち、表示が有効な最後の1項目かどうかは
+        // set() で値を上書きする前に、現在の設定値で判定しておく必要がある
+        $isLastVisibleNameField = $fieldInstance->isLastVisibleNameField();
+
 		if (!$fieldLabel) {
 			$fieldInstance->set('label', $fieldLabel);
 		}
@@ -123,6 +127,11 @@ class Settings_LayoutEditor_Field_Action extends Settings_Vtiger_Index_Action {
 
 		$response = new Vtiger_Response();
         try{
+            // ラベル項目を全て非表示にすると、関連一覧・検索ポップアップから
+            // レコードを識別する列が無くなってしまうため、最後の1項目は無効にできない
+            if($isLastVisibleNameField && !$fieldInstance->isHeaderField() && !$fieldInstance->isSummaryField()) {
+                throw new Exception(vtranslate('LBL_LAST_NAME_FIELD_CANNOT_BE_HIDDEN', $request->getModule(false)));
+            }
             $fieldInstance->save();
 			$fieldInstance = Settings_LayoutEditor_Field_Model::getInstance($fieldId);
 			$fieldLabel = decode_html($request->get('fieldLabel'));

--- a/modules/Settings/LayoutEditor/models/Field.php
+++ b/modules/Settings/LayoutEditor/models/Field.php
@@ -283,6 +283,45 @@ class Settings_LayoutEditor_Field_Model extends Vtiger_Field_Model {
 	}
 
 	/**
+	 * ラベル(entityname)項目のうち、表示が有効な最後の1項目かどうかを返す。
+	 * ラベル項目を全て無効にすると関連一覧・検索ポップアップからレコードを
+	 * 識別する列が無くなってしまうため、最後の1項目は無効にできないようにする。
+	 * @return <Boolean> true/false
+	 */
+	public function isLastVisibleNameField() {
+		$visibleNameFields = self::getVisibleNameFields($this->block->module->name);
+		return php7_count($visibleNameFields) === 1 && in_array($this->getName(), $visibleNameFields);
+	}
+
+	/**
+	 * ラベル(entityname)項目のうち、「関連一覧に表示」または「主要項目」が有効なものを返す。
+	 * 項目設定画面は全項目からこの判定を呼ぶため、モジュール単位でキャッシュする。
+	 * @param <String> $moduleName
+	 * @return <Array> 有効なラベル項目名の配列
+	 */
+	protected static function getVisibleNameFields($moduleName) {
+		static $visibleNameFieldsCache = array();
+		if(isset($visibleNameFieldsCache[$moduleName])) {
+			return $visibleNameFieldsCache[$moduleName];
+		}
+		$visibleNameFields = array();
+		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+		if($moduleModel) {
+			$fieldModels = $moduleModel->getFields();
+			foreach($moduleModel->getNameFields() as $nameField) {
+				if(!isset($fieldModels[$nameField])) {
+					continue;
+				}
+				if($fieldModels[$nameField]->isHeaderField() || $fieldModels[$nameField]->isSummaryField()) {
+					$visibleNameFields[] = $nameField;
+				}
+			}
+		}
+		$visibleNameFieldsCache[$moduleName] = $visibleNameFields;
+		return $visibleNameFields;
+	}
+
+	/**
 	 * Function to check field is editable or not
 	 * @return <Boolean> true/false
 	 */

--- a/modules/Settings/LayoutEditor/views/Index.php
+++ b/modules/Settings/LayoutEditor/views/Index.php
@@ -196,7 +196,6 @@ class Settings_LayoutEditor_Index_View extends Settings_Vtiger_Index_View {
 		$viewer->assign('QUALIFIED_MODULE', $qualifiedModule);
 		$viewer->assign('USER_MODEL', Users_Record_Model::getCurrentUserModel());
 		$viewer->assign('HEADER_FIELDS_COUNT', $headerFieldsCount);
-		$viewer->assign('IS_NAME_FIELD', in_array($fieldInstance->getName(), $moduleModel->getNameFields()));
 
 		$cleanFieldModel = Settings_LayoutEditor_Field_Model::getCleanInstance();
 		$cleanFieldModel->setModule($moduleModel);

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -1790,6 +1790,17 @@ class Vtiger_Module_Model extends Vtiger_Module {
 		}else{
 			$popupFields = array_values($this->getRelatedListFields());
 		}
+
+		// ラベル(entityname)項目を entityname の順で先頭にまとめる。
+		// 概要/ヘッダー項目でないラベル項目も列として表示する。
+		$nameFields = array();
+		foreach($this->getNameFields() as $nameField){
+			if($this->getField($nameField)){
+				$nameFields[] = $nameField;
+			}
+		}
+		$popupFields = array_merge($nameFields, array_diff($popupFields, $nameFields));
+
 		return $popupFields;
 	}
 

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -628,16 +628,8 @@ class Vtiger_Module_Model extends Vtiger_Module {
 			}
 		}
 
-		if(php7_count($relatedListFields)>0) {
-			$nameFields = $this->getNameFields();
-			foreach($nameFields as $fieldName){
-				if(!isset($relatedListFields[$fieldName]) || !$relatedListFields[$fieldName]) {
-					$fieldModel = $this->getField($fieldName);
-					$relatedListFields[$fieldModel->get('column')] = $fieldModel->get('name');
-				}
-			}
-		}
-
+		// ラベル(entityname)項目の無条件追加は行わない。
+		// 項目設定の「関連一覧に表示」「主要項目」の設定値をそのまま反映する。
 		return $relatedListFields;
 	}
 
@@ -1488,9 +1480,13 @@ class Vtiger_Module_Model extends Vtiger_Module {
 			$allRelationListViewFields = array_merge($headerViewFields,$summaryViewFields);
 			$relationListViewFields = array();
 			$nameFields = $this->getNameFields();
+			// ラベル(entityname)項目は entityname に登録された順で先頭にまとめる。
+			// 「主要項目」「関連一覧に表示」のどちらで有効化されていても列に含める
+			// （旧実装は「主要項目」のみを見ていたため、「関連一覧に表示」だけが
+			//  有効なラベル項目が後続のループでも除外され、列から欠落していた）。
 			foreach($nameFields as $nameField) {
-				if(array_key_exists($nameField, $summaryViewFields)) {
-					$relationListViewFields[$nameField] = $summaryViewFields[$nameField];
+				if(array_key_exists($nameField, $allRelationListViewFields)) {
+					$relationListViewFields[$nameField] = $allRelationListViewFields[$nameField];
 				}
 			}
 			foreach($allRelationListViewFields as $fieldName => $fieldModel) {
@@ -1845,17 +1841,6 @@ class Vtiger_Module_Model extends Vtiger_Module {
 		}else{
 			$popupFields = array_values($this->getRelatedListFields());
 		}
-
-		// ラベル(entityname)項目を entityname の順で先頭にまとめる。
-		// 概要/ヘッダー項目でないラベル項目も列として表示する。
-		$nameFields = array();
-		foreach($this->getNameFields() as $nameField){
-			if($this->getField($nameField)){
-				$nameFields[] = $nameField;
-			}
-		}
-		$popupFields = array_merge($nameFields, array_diff($popupFields, $nameFields));
-
 		return $popupFields;
 	}
 

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -1489,6 +1489,16 @@ class Vtiger_Module_Model extends Vtiger_Module {
 					$relationListViewFields[$nameField] = $allRelationListViewFields[$nameField];
 				}
 			}
+			// ラベル項目が1つも有効でない場合、関連一覧・検索ポップアップから
+			// レコードを識別する列が無くなってしまうため、entityname 先頭の項目を必ず残す。
+			// 項目設定側でも最後の1項目は無効にできないようにしているが、
+			// DB・API 経由の変更でもこの状態にならないようにするための保証。
+			if(empty($relationListViewFields) && !empty($nameFields)) {
+				$fallbackFieldModel = $this->getField($nameFields[0]);
+				if($fallbackFieldModel && $fallbackFieldModel->isViewable()) {
+					$relationListViewFields[$nameFields[0]] = $fallbackFieldModel;
+				}
+			}
 			foreach($allRelationListViewFields as $fieldName => $fieldModel) {
 				if(!in_array($fieldName, $nameFields)) {
 					$relationListViewFields[$fieldName] = $fieldModel;

--- a/modules/Vtiger/models/RelationListView.php
+++ b/modules/Vtiger/models/RelationListView.php
@@ -424,13 +424,11 @@ class Vtiger_RelationListView_Model extends Vtiger_Base_Model {
 			}
 		}
 
-		$nameFields = $relatedModuleModel->getNameFields();
-		foreach($nameFields as $fieldName){
-			if(!$headerFields[$fieldName]) {
-				$headerFields[$fieldName] = $relatedModuleModel->getField($fieldName);
-			}
-		}
-
+		// ラベル(entityname)項目の無条件追加は行わない。
+		// getHeaderAndSummaryViewFieldsList() が設定値どおりの項目を返し、
+		// かつラベル項目が全て無効な場合は先頭の1項目を保証するため、
+		// ここで追加すると「見出しだけあって値が空の列」ができてしまう
+		// （値は getConfigureRelatedListFields() 側で決まる）。
 		return $headerFields;
 	}
 

--- a/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -668,11 +668,11 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 							}
 							thisInstance.reArrangeBlockFields(block);
 						}
-					}, function () {
+					}, function (err) {
 						app.helper.hideProgress();
 						saveButton.removeAttr('disabled');
 						app.helper.showAlertNotification({
-							'message': app.vtranslate('JS_MAXIMUM_HEADER_FIELDS_ALLOWED', thisInstance.maxNumberOfHeaderFields)
+							'message': (err && err.message) ? err.message : app.vtranslate('JS_MAXIMUM_HEADER_FIELDS_ALLOWED', thisInstance.maxNumberOfHeaderFields)
 						});
 					});
 				} else {
@@ -1786,7 +1786,8 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 						app.helper.showSuccessNotification(params);
 						aDeferred.resolve(data);
 					} else {
-						aDeferred.reject();
+						//サーバ側のエラーメッセージを呼び出し側で表示できるように渡す
+						aDeferred.reject(err);
 					}
 				});
 		}
@@ -2151,10 +2152,10 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					app.helper.hideProgress();
 					thisInstance.setFieldDetails(data, fieldContatiner);
 				},
-				function () {
+				function (err) {
 					app.helper.hideProgress();
 					app.helper.showAlertNotification({
-						'message': app.vtranslate('JS_MAXIMUM_HEADER_FIELDS_ALLOWED', thisInstance.maxNumberOfHeaderFields)
+						'message': (err && err.message) ? err.message : app.vtranslate('JS_MAXIMUM_HEADER_FIELDS_ALLOWED', thisInstance.maxNumberOfHeaderFields)
 					});
 				});
 		});

--- a/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -434,7 +434,6 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 			if (typeof currentElement.attr('readonly') != "undefined") {
 				return;
 			}
-			var fieldName = container.find('[name="fieldname"]').val();
 			var currentFlagName = currentElement.attr('name');
 			var dependentFlagName = 'headerfield';
 			if (currentFlagName === dependentFlagName) {
@@ -445,17 +444,9 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 						.prop('checked', false).attr('readonly', 'readonly')
 						.removeClass('cursorPointer').addClass('cursorPointerNotAllowed');
 			} else {
-				if (dependentFlagName === 'headerfield') {
-					if (thisInstance.nameFields.indexOf(fieldName) === -1) {
-						container.find('input[type="checkbox"][name="'+dependentFlagName+'"]')
-								.removeAttr('readonly', 'readonly').removeClass('cursorPointerNotAllowed')
-								.addClass('cursorPointer');
-					}
-				} else {
-					container.find('input[type="checkbox"][name="'+dependentFlagName+'"]')
-							.removeAttr('readonly', 'readonly').removeClass('cursorPointerNotAllowed')
-							.addClass('cursorPointer');
-				}
+				container.find('input[type="checkbox"][name="'+dependentFlagName+'"]')
+						.removeAttr('readonly', 'readonly').removeClass('cursorPointerNotAllowed')
+						.addClass('cursorPointer');
 			}
 		}).filter(':checked').trigger('change');
 	},
@@ -2131,16 +2122,6 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 				valueToUpdate = element.find('i').data('enableValue');
 				if (typeof valueToUpdate == 'undefined')
 					valueToUpdate = element.find('img').data('enable-value');
-			}
-
-			if (fieldPropertyName === 'headerfield') {
-				//name fields are header enabled by default
-				if (thisInstance.nameFields.indexOf(fieldName) !== -1) {
-					app.helper.showAlertNotification({
-						'message': app.vtranslate('JS_NAME_FIELDS_APPEAR_IN_HEADER_BY_DEFAULT')
-					});
-					return;
-				}
 			}
 
 			if (fieldPropertyName === 'summaryfield' || fieldPropertyName === 'headerfield') {

--- a/setup/migration/scripts/20260814180218_enable_headerfield_for_entityname_fields.php
+++ b/setup/migration/scripts/20260814180218_enable_headerfield_for_entityname_fields.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * マイグレーション: enable_headerfield_for_entityname_fields
+ * 生成日時: 20260814180218
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260814180218_EnableHeaderfieldForEntitynameFields extends FRMigrationClass {
+
+    /**
+     * ラベル(vtiger_entityname.fieldname)に指定された項目のうち、
+     * 「関連一覧に表示」(vtiger_field.headerfield) も「主要項目」(summaryfield) も
+     * 無効なものを「関連一覧に表示」有効にする。
+     *
+     * これまでラベル項目は Vtiger_Module_Model::getConfigureRelatedListFields() で
+     * 関連一覧へ無条件に追加されており、項目設定側では「関連一覧に表示」を
+     * 操作できないようロックされていた（強制表示だが設定値としては OFF）。
+     * ロックを外して設定値どおりに表示する実装へ変更するため、
+     * 従来の強制表示相当の状態を設定値として DB へ反映する。
+     *
+     * すでに「主要項目」が有効なラベル項目（既定の accountname 等）は対象外。
+     * headerfield と summaryfield は排他のため、ここで headerfield を立てると
+     * 主要項目ブロックから消えてしまうことを避ける。
+     */
+    public function process() {
+        global $adb;
+
+        $result = $adb->pquery(
+            'SELECT tabid, modulename, fieldname FROM vtiger_entityname ORDER BY modulename',
+            array()
+        );
+
+        if (!$result) {
+            $this->log('vtiger_entityname を読み込めませんでした');
+            return;
+        }
+
+        $updatedCount = 0;
+
+        while ($row = $adb->fetch_array($result)) {
+            $tabid      = $row['tabid'];
+            $moduleName = $row['modulename'];
+
+            // vtiger_entityname.fieldname は項目名(vtiger_field.fieldname)を
+            // カンマ区切りで保持する
+            foreach (explode(',', $row['fieldname']) as $labelField) {
+                $labelField = trim($labelField);
+                if ($labelField === '') {
+                    continue;
+                }
+
+                $fieldResult = $adb->pquery(
+                    'SELECT fieldid, headerfield, summaryfield FROM vtiger_field WHERE tabid = ? AND fieldname = ?',
+                    array($tabid, $labelField)
+                );
+
+                if (!$fieldResult || $adb->num_rows($fieldResult) === 0) {
+                    // ユーザー等、vtiger_field に対応する項目を持たないラベルは対象外
+                    $this->log("{$moduleName}.{$labelField}: vtiger_field に該当項目が無いためスキップ");
+                    continue;
+                }
+
+                $fieldId      = $adb->query_result($fieldResult, 0, 'fieldid');
+                $headerField  = (int) $adb->query_result($fieldResult, 0, 'headerfield');
+                $summaryField = (int) $adb->query_result($fieldResult, 0, 'summaryfield');
+
+                if ($headerField === 1 || $summaryField === 1) {
+                    continue;
+                }
+
+                $adb->pquery(
+                    'UPDATE vtiger_field SET headerfield = 1 WHERE fieldid = ?',
+                    array($fieldId)
+                );
+
+                $this->log("{$moduleName}.{$labelField}: 「関連一覧に表示」を有効化");
+                $updatedCount++;
+            }
+        }
+
+        $this->log("ラベル項目の「関連一覧に表示」を {$updatedCount} 件更新しました");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1714

##  不具合の内容 / Bug
1. 参照型項目の虫眼鏡ポップアップで、参照先のラベル（`vtiger_entityname.fieldname`）に複数項目を指定しても全項目が列に表示されない。例）取引先ラベルに `accountname,phone` → 「顧客企業名」のみ表示。
2. 項目設定でラベル項目の「関連一覧に表示」がロックされていて操作できない（強制表示だが設定値は OFF という食い違い）。

##  原因 / Cause
1. `Vtiger_Module_Model::getHeaderAndSummaryViewFieldsList()` がラベル項目を「主要項目に該当する場合のみ」採用し、続くループでも `$nameFields` を除外していたため、**「関連一覧に表示」だけが有効なラベル項目が列から完全に欠落**していた。
2. `getConfigureRelatedListFields()` がラベル項目を無条件に追加していたため強制表示になっており、項目設定側はそれに合わせてロックしていた。

※ F-RevoCRM の日本語UIでは `headerfield` =「関連一覧に表示」、`summaryfield` =「主要項目」で、関連一覧の列は両者の合併で決まる。

##  変更内容 / Details of Change
1. `getHeaderAndSummaryViewFieldsList()`：ラベル項目の採用条件を「主要項目のみ」→「**主要項目 または 関連一覧に表示**」に変更。並び順は従来どおり entityname の登録順で先頭にまとめる。
2. `getConfigureRelatedListFields()`：ラベル項目の無条件追加を削除し、設定値をそのまま反映する。
3. 項目設定でラベル項目の「関連一覧に表示」のロックを解除（`FieldCreate.tpl` の `$IS_NAME_FIELD` による `readonly`、`LayoutEditor.js` の名称項目だけ readonly を解除しない分岐と `JS_NAME_FIELDS_APPEAR_IN_HEADER_BY_DEFAULT` のアラート中断を除去）。
4. ラベル項目を**全て**無効にはできないようガードを追加（外せるようにした結果、レコードを識別する列が消える／空列になるのを防ぐ）。
    - `getHeaderAndSummaryViewFieldsList()`：ラベル項目が1つも有効でない場合は entityname 先頭の項目を必ず含める。関連一覧の見出し・値とポップアップ列の共通の供給元なので、ここ1箇所で3面が揃う
    - `RelationListView::getHeaders()`：ラベル項目の無条件追加を削除。残すと値を決める `getConfigureRelatedListFields()` と食い違い、**見出しだけあって値が常に空の列**ができる
    - 項目設定：有効なラベル項目が1つだけのとき、その項目を無効にできないようにする（一覧のインラインアイコン・項目編集モーダルの両方をロック＋ツールチップ、DB・API 経由に備えてサーバ側ガードも追加）
    - 保存失敗時にサーバのエラーメッセージを表示（従来は失敗を全て「ヘッダー項目の上限」と表示していた）
5. Migration を追加：`vtiger_entityname.fieldname` をカンマ分割し、**`headerfield=0` かつ `summaryfield=0` の項目だけ** `headerfield=1` にする。既定のラベル項目（`accountname` 等）は `summaryfield=1` のため対象外。

## スクリーンショット / Screenshot
実画面で確認した結果（案件のラベル = `potentialname,sales_stage`）。

| ラベル項目の状態 | 検索ポップアップの列 | 関連一覧（見出し / 値） |
|---|---|---|
| `potentialname`=主要項目, `sales_stage`=関連一覧に表示 | 案件名 + 営業ステージ | 両方表示 / 値あり |
| `sales_stage` を両方 OFF | 営業ステージの列自体が出ない | 見出しも出ない（空列なし） |
| ラベル項目を全て OFF（DB 直編集） | 案件名がフォールバックで表示 | 案件名を表示 / 値あり |

| 項目設定 | 結果 |
|---|---|
| 有効なラベル項目が1つだけ | 該当項目がロック（ツールチップに理由）。クリックしても設定は変わらない |
| ラベル項目が2つ以上有効 | どちらもロックされず、片方を外せる |
| UI をバイパスした直 POST | エラーメッセージで拒否、DB 不変 |

## 影響範囲  / Affected Area
- 参照型項目の虫眼鏡検索ポップアップの表示列
- 詳細画面の関連一覧の表示列
- 項目設定（レイアウトエディタ）のラベル項目の「関連一覧に表示」「主要項目」の操作可否

変更ファイル:
- `modules/Vtiger/models/Module.php`
- `modules/Vtiger/models/RelationListView.php`
- `modules/Settings/LayoutEditor/models/Field.php`
- `modules/Settings/LayoutEditor/actions/Field.php`
- `modules/Settings/LayoutEditor/views/Index.php`
- `layouts/v7/modules/Settings/LayoutEditor/FieldCreate.tpl`
- `layouts/v7/modules/Settings/LayoutEditor/FieldsList.tpl`
- `public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js`
- `languages/{ja_jp,en_us}/Settings/LayoutEditor.php`
- `setup/migration/scripts/20260814180218_enable_headerfield_for_entityname_fields.php`（新規）

### 挙動が変わる点（レビュー観点）
- ラベル項目の関連一覧への表示が**設定値に従う**ようになる。既存環境は 5. の Migration で従来相当に揃う。
- Migration 適用後に entityname へ追加した項目は既定値が `0/0` のため、必要に応じて項目設定から有効化する運用になる。
- ヘッダー項目の上限（`maxNumberOfHeaderFields = 5`）にラベル項目も数えられる。
- ラベル項目のうち最低1つは常に表示される（最後の1項目は無効にできない）。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 検証環境は Docker（PHP 8.5）。上記の表は Playwright で実画面を操作して確認したもの。他モジュールでは `HelpDesk`（ラベル項目が `ticket_title` のみ）が新ロックの対象になり、`Contacts` / `Leads`（`lastname,firstname` の両方が主要項目）は従来どおり操作可であることも確認済み。
- ロックの判定は描画時にサーバ側で行うため、同一画面で2つ目のラベル項目を有効化しても1つ目のロック表示はリロードまで残る。その状態で外そうとした場合はサーバ側ガードがメッセージ付きで止める。
- コア基底クラス（`modules/Vtiger/`）への修正が `Module.php` と `RelationListView.php` の2件。不具合・強制追加が全モジュール共有の基底に存在するため、基底クラスで対応している。
- `getConfigureRelatedListFields()` を `parent::` を呼ばず override している `Documents` には本修正が及ばない。必要であれば別Issueで対応したい。
- **要相談**：Migration の対象に `Users` が含まれるが、`Users` は項目設定側で「関連一覧に表示」「主要項目」とも操作不可のため、除外すべきかどうか判断したい。
- 使用箇所が無くなった `JS_NAME_FIELDS_APPEAR_IN_HEADER_BY_DEFAULT` は各言語ファイルに残している（別の掃除として分離）。
