### PR TITLE
[修正] #1717 チケット概要画面で幅768–1199pxのとき主要項目・ドキュメントペインが表示されない

### DIFF
--- a/layouts/v7/modules/HelpDesk/SummaryViewWidgets.tpl
+++ b/layouts/v7/modules/HelpDesk/SummaryViewWidgets.tpl
@@ -76,7 +76,7 @@
     
 </div>
 
-<div class="middle-block col-lg-7">
+<div class="middle-block col-lg-7 col-md-7 col-sm-7">
     
     {include file=vtemplate_path('RelatedActivitiesWidget.tpl','Vtiger')}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1717

##  不具合の内容 / Bug
1. HelpDesk（チケット）の概要画面で、ブラウザ幅が 768–1199px の範囲のとき、主要項目・ドキュメントペイン（left-block）が表示されない。活動・コメント（middle-block）のみ表示される。

##  原因 / Cause
1. `layouts/v7/modules/HelpDesk/SummaryViewWidgets.tpl` の `middle-block` に `col-lg-7` のみ指定・`col-md-*` `col-sm-*` 未指定。一方 `left-block` は `col-lg-5 col-md-5 col-sm-5` 指定あり。
2. この不均衡により 768–1199px 帯で `left-block` が float:left（幅42%）、`middle-block` が非float の block（幅100%）となり、両者が同じ y 座標で重なり、middle-block が left-block を覆い隠す。

##  変更内容 / Details of Change
1. `middle-block` に `col-md-7 col-sm-7` を追加し、`left-block` (`col-md-5 col-sm-5`) との整合を取った（5+7=12）。sm/md 帯でも左右並列で表示される。

## 影響範囲  / Affected Area
- HelpDesk（チケット）モジュールの概要画面（Detail View / Summary）のみ。
- 他モジュール（Accounts / Quotes / Contacts / Leads / Invoice / SalesOrder / PurchaseOrder / Dailyreports）は `left-block` `middle-block` ともに `col-lg-*` のみで対称のため、md/sm 帯では両方 float:none 100%幅で縦積みされ本問題は発生しない（実機確認済）。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（言語ファイル変更なし）

## 備考 / Remarks
- 動作確認: 500px（xs, 縦積み） / 1000px（sm/md, 5:7並列） / 1300px（lg, 従来通り）で表示確認済。