### PR TITLE
[修正] #1720 項目設定 必須日付項目のデフォルト値を削除できない

### DIFF
--- a/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
+++ b/public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js
@@ -1077,7 +1077,21 @@ Vtiger.Class('Settings_LayoutEditor_Js', {
 					});	
 				}
 
-				defaultValueUiContainer.find('[data-rule-required]').removeAttr('data-rule-required');
+				// mandatory項目でも項目設定のデフォルト値入力は必須にしない。
+				// removeAttrだけではjQuery内部dataキャッシュに残ってvalidatorがrequired=trueを返すため、
+				// data-rule-required属性・data-fieldinfo(mandatory)・関連dataキャッシュを合わせて削除する。
+				defaultValueUiContainer.find('[data-rule-required]')
+					.removeAttr('data-rule-required')
+					.removeData('ruleRequired')
+					.removeData('rule-required');
+				defaultValueUiContainer.find('[data-fieldinfo]').each(function () {
+					var el = jQuery(this);
+					var info = el.data('fieldinfo');
+					if (info && info.mandatory) {
+						info.mandatory = false;
+						el.attr('data-fieldinfo', JSON.stringify(info)).data('fieldinfo', info);
+					}
+				});
 				if (defaultValueUi.is('select')) {
 					//generating random id since validation engine needs it 
 					defaultValueUi.attr('id', Math.floor((Math.random() * 10)+1));


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1720

##  不具合の内容 / Bug
1. 項目設定で必須（`typeofdata=D~M~…`）の日付項目のデフォルト値を「本日 (TODAY)」または固定日付に設定後、削除・空保存できない
2. 案件/キャンペーン/カレンダー/日報/活動/資産・レンタル管理 の各 mandatory 日付項目で発生

##  原因 / Cause
1. `public/layouts/v7/modules/Settings/LayoutEditor/resources/LayoutEditor.js` の setDefaultValueUi で、`Vtiger_Field_Js.addValidationToElement()` が mandatory 項目に付与する `data-rule-required='true'` を `removeAttr` で削除していた
2. しかし jQuery 内部の `.data()` キャッシュには `true` が残留し、jQuery Validate の `dataRules()` が `.data('ruleRequired')` 経由でキャッシュを読み取り `required: true` を返していた
3. 結果、空値保存時に必須入力エラーとなり保存できなかった

##  変更内容 / Details of Change
1. `removeAttr('data-rule-required')` に加え、`removeData('ruleRequired')` / `removeData('rule-required')` で jQuery 内部 dataキャッシュも削除
2. `data-fieldinfo` 内の `mandatory` フラグを `false` に書き換えて二重ガード

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- 項目設定（Settings > LayoutEditor）でのデフォルト値保存挙動
- mandatory=M の全日付型項目（uitype 5 / 23）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
