### PR TITLE
[修正] #1722 iPhoneでメール送信TO検索結果タップ時に同一メールアドレスが2件設定される

### DIFF
--- a/public/layouts/v7/modules/Emails/resources/MassEdit.js
+++ b/public/layouts/v7/modules/Emails/resources/MassEdit.js
@@ -291,6 +291,25 @@ jQuery.Class("Emails_MassEdit_Js",{},{
 		}).on("change", function (selectedData) {
 			var addedElement = selectedData.added;
 			if (typeof addedElement != 'undefined') {
+				var emailField = container.find('#emailField');
+				if (!thisInstance.__dedupPending) {
+					thisInstance.__dedupPending = true;
+					setTimeout(function(){
+						thisInstance.__dedupPending = false;
+						var pd = thisInstance.getPreloadData() || [];
+						var seen = {}, uniqPd = [];
+						for (var i = 0; i < pd.length; i++) {
+							var idv = pd[i].id;
+							if (seen[idv]) continue;
+							seen[idv] = true;
+							uniqPd.push(pd[i]);
+						}
+						if (uniqPd.length !== pd.length) {
+							thisInstance.setPreloadData(uniqPd);
+							emailField.select2('data', uniqPd, false);
+						}
+					}, 100);
+				}
 				var data = {
 					'id' : addedElement.recordId,
 					'name' : addedElement.text,
@@ -476,7 +495,9 @@ jQuery.Class("Emails_MassEdit_Js",{},{
 		if(value == ""){
 			value = new Array();
 		}
-		value.push(mailInfo.emailid);
+		if(jQuery.inArray(mailInfo.emailid, value) === -1){
+			value.push(mailInfo.emailid);
+		}
 		toEmails.val(JSON.stringify(value));
 	},
 
@@ -490,8 +511,10 @@ jQuery.Class("Emails_MassEdit_Js",{},{
 		//existing email id
 		 if(existingToMailInfo.hasOwnProperty(mailInfo.id) === true){
 			var existingValues = existingToMailInfo[mailInfo.id];
-			var newValue = new Array(mailInfo.emailid);
-			existingToMailInfo[mailInfo.id] = jQuery.merge(existingValues,newValue);
+			if(jQuery.inArray(mailInfo.emailid, existingValues) === -1){
+				existingValues.push(mailInfo.emailid);
+			}
+			existingToMailInfo[mailInfo.id] = existingValues;
 		} else {
 			existingToMailInfo[mailInfo.id] = new Array(mailInfo.emailid);
 		}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1722

##  不具合の内容 / Bug
1. iPhone (Safari) で顧客担当者(Contacts)レコード詳細画面から「メールを送る」を実行し、TO欄で連絡先を検索して検索候補をタップすると、同一のメールアドレスが TO欄に2件設定されてしまう。

##  原因 / Cause
1. iPhone Safari では検索候補タップ時に `touchend` → `click` の順で二重にイベントが発火する。select2 (v3) 側の内部処理でも `triggerChange()` 内から change イベントと click が連鎖するため、`change` ハンドラが同一 added 要素で複数回呼ばれる。
2. `Emails_MassEdit_Js.registerAutoCompleteFields()` の `change` ハンドラおよび `addToEmails()` / `addToEmailAddressData()` に重複チェックが無く、hidden `to` 配列・`toemailinfo` 双方に同一メールアドレスが蓄積する。
3. さらに select2 の可視ピル（`.select2-search-choice`）自体も内部データと不整合のまま2件描画される。

##  変更内容 / Details of Change
1. `public/layouts/v7/modules/Emails/resources/MassEdit.js` の change ハンドラで、added 検出時に 100ms 後 `preloadData` を id で dedup し `select2('data', uniq, false)` で再構築するよう修正。可視ピルの重複を解消。`__dedupPending` フラグで多重予約を防止。
2. `addToEmails()` で hidden `to` 配列 push 前に `jQuery.inArray` チェックを追加。
3. `addToEmailAddressData()` で同一レコード内 emailid の重複チェックを追加（`jQuery.merge` を条件付き push に変更）。

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- メール送信画面 (Emails / ComposeEmail) の TO / CC / BCC 検索候補選択挙動
- 対象ファイル: `public/layouts/v7/modules/Emails/resources/MassEdit.js`
- PC / スマホ双方で同一ファイル使用のため両環境の挙動を確認する必要がある

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイル修正なし（言語対応該当なし）。
- iPhone Safari 実機で TO 検索結果タップ後、可視ピル 2件→1件収束を確認。