### PR TITLE
[修正] #1725 項目設定・日付項目のデフォルト値まわり複数不具合

### DIFF
--- a/layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl
+++ b/layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl
@@ -64,8 +64,8 @@
 							</div>
 							<div class="input-group date {if $DEFAULT_VALUE eq 'TODAY'}hide{/if}">
 								{assign var=FIELD_NAME value=$FIELD_MODEL->get('name')}
-								<input type="text" class="inputElement dateField" {if $DEFAULT_VALUE neq 'TODAY'}name="{$NAME_ATTR}"{/if} data-toregister="date" data-date-format="{$USER_MODEL->get('date_format')}" 
-									value="{if $DEFAULT_VALUE eq 'TODAY'}{else}{$FIELD_MODEL->getEditViewDisplayValue($DEFAULT_VALUE)}{/if}" style='width: 75%' {if $DEFAULT_VALUE eq 'TODAY'}disabled{/if}/>
+								<input type="text" class="inputElement dateField" {if $DEFAULT_VALUE neq 'TODAY'}name="{$NAME_ATTR}"{/if} data-toregister="date" data-date-format="{$USER_MODEL->get('date_format')}"
+									value="{if $DEFAULT_VALUE eq 'TODAY' or $DEFAULT_VALUE eq ''}{else}{$FIELD_MODEL->getEditViewDisplayValue($DEFAULT_VALUE)}{/if}" style='width: 75%' {if $DEFAULT_VALUE eq 'TODAY'}disabled{/if}/>
 								<span class="input-group-addon">
 									<i class="fa fa-calendar"></i>
 								</span>

--- a/modules/Calendar/models/EditRecordStructure.php
+++ b/modules/Calendar/models/EditRecordStructure.php
@@ -67,13 +67,7 @@ class Calendar_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mode
 							if ($fieldValue == '') {
 								$defaultValue = $fieldModel->getDefaultFieldValue();
 								if ($defaultValue != "" && !$recordId) {
-									$defaultValue = $fieldModel->getDefaultFieldValue();
-									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
-										$fieldValue = date('Y-m-d');
-									}
-									else{
-										$fieldValue = $defaultValue;
-									}
+									$fieldValue = $defaultValue;
 								}
 							}
 							$fieldModel->set('fieldvalue', $fieldValue);

--- a/modules/Calendar/models/QuickCreateRecordStructure.php
+++ b/modules/Calendar/models/QuickCreateRecordStructure.php
@@ -57,12 +57,7 @@ class Calendar_QuickCreateRecordStructure_Model extends Vtiger_QuickCreateRecord
 				$fieldModel->set('fieldvalue', $fieldValue);
 			} else {
 				$defaultValue = $fieldModel->getDefaultFieldValue();
-				if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
-					$fieldModel->set('fieldvalue', date('Y-m-d'));
-				}
-				else{
-					$fieldModel->set('fieldvalue', $defaultValue);
-				}
+				$fieldModel->set('fieldvalue', $defaultValue);
 			}
 			$values[$fieldName] = $fieldModel;
 		}

--- a/modules/Inventory/models/EditRecordStructure.php
+++ b/modules/Inventory/models/EditRecordStructure.php
@@ -41,12 +41,7 @@ class Inventory_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mod
 							} else if($fieldValue == '') {
                                 $defaultValue = $fieldModel->getDefaultFieldValue();
                                 if($defaultValue != "" && !$recordId){
-									if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
-										$fieldValue = date('Y-m-d');
-									}
-									else{
-										$fieldValue = $defaultValue;
-									}
+									$fieldValue = $defaultValue;
 								}
 							}
 							$fieldModel->set('fieldvalue', $fieldValue);

--- a/modules/Settings/LayoutEditor/models/Field.php
+++ b/modules/Settings/LayoutEditor/models/Field.php
@@ -11,6 +11,10 @@
 
 class Settings_LayoutEditor_Field_Model extends Vtiger_Field_Model {
 
+	public function getDefaultFieldValue() {
+		return $this->defaultvalue;
+	}
+
 	public function delete() {
 		$adb = PearDatabase::getInstance();
 		parent::delete();

--- a/modules/Vtiger/models/EditRecordStructure.php
+++ b/modules/Vtiger/models/EditRecordStructure.php
@@ -38,13 +38,8 @@ class Vtiger_EditRecordStructure_Model extends Vtiger_RecordStructure_Model {
 						}else{
 							$defaultValue = $fieldModel->getDefaultFieldValue();
 							if($defaultValue != "" && !$recordId)
-								if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
-									$fieldModel->set('fieldvalue', date('Y-m-d'));
-								}
-								else{
-									$fieldModel->set('fieldvalue', $defaultValue);
-								}
-								
+								$fieldModel->set('fieldvalue', $defaultValue);
+
 						}
 						$values[$blockLabel][$fieldName] = $fieldModel;
                         if ($fieldName == 'taxclass' && php7_count($recordModel->getTaxClassDetails()) < 1) {

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -1329,6 +1329,9 @@ class Vtiger_Field_Model extends Vtiger_Field {
 	 * @return <String> defaultvalue
 	 */
 	public function getDefaultFieldValue(){
+		if ($this->getFieldDataType() == 'date' && $this->defaultvalue == 'TODAY') {
+			return date('Y-m-d');
+		}
 		return $this->defaultvalue;
 	}
 

--- a/modules/Vtiger/models/QuickCreateRecordStructure.php
+++ b/modules/Vtiger/models/QuickCreateRecordStructure.php
@@ -50,12 +50,7 @@ class Vtiger_QuickCreateRecordStructure_Model extends Vtiger_RecordStructure_Mod
             } else{
                 $defaultValue = $fieldModel->getDefaultFieldValue();
                 if($defaultValue) {
-                    if($fieldModel->getFieldDataType() == "date" && $defaultValue == 'TODAY'){
-                        $fieldModel->set('fieldvalue', date('Y-m-d'));
-                    }
-                    else{
-                        $fieldModel->set('fieldvalue', $defaultValue);
-                    }
+                    $fieldModel->set('fieldvalue', $defaultValue);
                 }
             }
 			$values[$fieldName] = $fieldModel;


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1725

##  不具合の内容 / Bug
1. 日報モジュール「提出日」等でデフォルト値に `TODAY` を設定した場合、新規レコード作成画面で本日日付に変換されず `TODAY` 文字列がそのまま入力欄に入る。ユーザーモジュールに追加した日付項目でも同様。
2. 顧客担当者モジュール `support_start_date` / `support_end_date` について、項目一覧上は「デフォルト値はありません」と表示されるが、項目編集ダイアログを開くとデフォルト値欄に本日日付（終了日は +1 年後）が入力された状態となり、未変更で保存すると固定日付でデフォルト値が DB に保存される。

##  原因 / Cause
1. 各モジュールの `EditRecordStructure` / `QuickCreateRecordStructure` のうち、Vtiger コアを override しているものが TODAY→本日日付の変換ロジックを個別に持っており、抜けているモジュールで未変換となっていた。
2. `modules/Vtiger/uitypes/Date.php::getEditViewDisplayValue()` に顧客担当者 `support_start_date` / `support_end_date` の特殊分岐（本来はレコード新規作成画面用に本日・+1 年をセットするもの）があり、`layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl` が空のデフォルト値でも同関数を呼んでいたため、LayoutEditor 項目編集ダイアログ側にもこの特殊分岐が漏れ出していた。

##  変更内容 / Details of Change
1. `modules/Vtiger/models/Field.php::getDefaultFieldValue()` に date 型 + `TODAY` → 本日日付の変換ロジックを追加（共通化）。
2. `modules/Settings/LayoutEditor/models/Field.php` に `getDefaultFieldValue()` を override し、常に生値（`TODAY` 等）を返却するように変更。これにより LayoutEditor 項目編集画面でデフォルト値が本日日付として固定保存される事象を防止。
3. 上記共通化に伴い、各 override 側（`modules/Vtiger/models/EditRecordStructure.php` / `QuickCreateRecordStructure.php`、`modules/Calendar/models/EditRecordStructure.php` / `QuickCreateRecordStructure.php`、`modules/Inventory/models/EditRecordStructure.php`）に散在していた冗長な TODAY 変換分岐を削除。
4. `layouts/v7/modules/Settings/LayoutEditor/DefaultValueUi.tpl` の date 入力 value 生成箇所を修正し、デフォルト値が空の場合は `getEditViewDisplayValue()` を呼ばないようにした（顧客担当者専用の特殊分岐が発火しないようにするため）。

## スクリーンショット / Screenshot
別途添付予定。

## 影響範囲  / Affected Area
- 全モジュールの新規レコード作成画面・クイック作成画面における日付項目のデフォルト値（`TODAY` 設定時）
- 「設定 > 項目設定」（LayoutEditor）配下の項目編集ダイアログ／項目一覧のデフォルト値表示
- 特に顧客担当者モジュール `support_start_date` / `support_end_date`

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイル（`languages/`）変更なし。ラベル追加なしのため言語対応 不要。
- `Vtiger_Field_Model::getDefaultFieldValue()` の変更はコア相当（`modules/Vtiger/`）への手入れとなるため、アップグレード時の再適用が必要な可能性あり。
- 動作確認結果:
  - 顧客担当者 `support_start_date` 項目編集ダイアログを開き、デフォルト値欄の date input value が空であることをブラウザ実機で確認済（修正前は本日日付が入力）
  - 対象 PHP ファイル 7 件の syntax check パス
  - TODAY→本日変換ロジックは `Vtiger_Field_Model::getDefaultFieldValue()` に集約し、既存 override 側の冗長分岐を削除