### PR TITLE
[修正] #1727 未翻訳ラベル露出（ドキュメント移動モーダル / Inventory系PDFエクスポート）

### DIFF
--- a/languages/en_us/Documents.php
+++ b/languages/en_us/Documents.php
@@ -117,4 +117,5 @@ $jsLanguageStrings = array(
     'JS_UPLOAD_FAILED' => 'File Upload Failed',
     'JS_DOCUMENT_CREATED' => 'Document created',
     'JS_DOCUMENT_CREATION_FAILED' => 'Document creation failed',
+    'JS_SELECT_A_FOLDER' => 'Please select a folder',
  );

--- a/languages/ja_jp/Documents.php
+++ b/languages/ja_jp/Documents.php
@@ -117,4 +117,5 @@ $jsLanguageStrings = array(
     'JS_UPLOAD_FAILED' => 'アップロードに失敗しました',
     'JS_DOCUMENT_CREATED' => 'ドキュメントを登録しました',
     'JS_DOCUMENT_CREATION_FAILED' => 'ドキュメントの登録に失敗しました',
+    'JS_SELECT_A_FOLDER' => 'フォルダを選択してください',
  );

--- a/modules/Inventory/models/ListView.php
+++ b/modules/Inventory/models/ListView.php
@@ -89,7 +89,7 @@ class Inventory_ListView_Model extends Vtiger_ListView_Model {
 			$templateId = $adb->query_result($result, $i, 'templateid');
 			$templateName = $adb->query_result($result, $i, 'templatename');
 			$exportPDFLink = array(
-				'linklabel' => vtranslate('LBL_EXPORT_TO_PDF', $moduleName).'('.htmlentities($templateName).')',
+				'linklabel' => vtranslate('LBL_EXPORT_TO_PDF', $moduleName).'('.vtranslate(htmlentities($templateName), $moduleName).')',
 				'linkurl' => 'javascript:Vtiger_List_Js.triggerPDFExportAction("'.$this->getModule()->getPDFExportUrl().'&templateName='.htmlentities($templateName).'&template='.$templateId.'")',
 				'linkicon' => ''
 			);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1727

##  不具合の内容 / Bug
1. ドキュメント一覧「フォルダに移動」モーダルで、存在しないフォルダ名を検索→未選択のまま移動押下時、アラートに翻訳キー「JS_SELECT_A_FOLDER」がそのまま表示される。
2. 見積・受注・請求・発注（Quotes / SalesOrder / Invoice / PurchaseOrder）の一覧「その他＞PDFにエクスポート」メニューで、テンプレート名が翻訳キーのまま表示される（例:「PDFにエクスポート(LBL_EXPERIENCE_BOOK)」）。

##  原因 / Cause
1. `public/layouts/v7/modules/Documents/resources/List.js:91` で `app.vtranslate('JS_SELECT_A_FOLDER')` を呼び出しているが、`languages/ja_jp/Documents.php` および `languages/en_us/Documents.php` に該当キーが未定義。生キーが返却される。
2. `modules/Inventory/models/ListView.php:92` の `linklabel` 生成箇所で `\$templateName`（DB `vtiger_pdftemplates.templatename` の翻訳キー）を `vtranslate` に通さず出力していた。詳細画面 `modules/Vtiger/models/DetailView.php:151` は `vtranslate` 済みで、一覧側の実装漏れ。

##  変更内容 / Details of Change
1. `languages/ja_jp/Documents.php` に `'JS_SELECT_A_FOLDER' => 'フォルダを選択してください'` を追加。
2. `languages/en_us/Documents.php` に `'JS_SELECT_A_FOLDER' => 'Please select a folder'` を追加。
3. `modules/Inventory/models/ListView.php:92` の `\$templateName` を `vtranslate(htmlentities(\$templateName), \$moduleName)` で包み、詳細画面と同一パターンに揃えた。

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- ドキュメント一覧「フォルダに移動」モーダル
- 見積・受注・請求・発注 一覧の「その他＞PDFにエクスポート」メニュー表示ラベル
- 翻訳キー追加のみ（既存キー変更なし）。他モジュールへの影響なし。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
現象2の翻訳キー（`LBL_EXPERIENCE_BOOK` / `RecurringInvoice` / `LBL_REQUEST_FOR_ANNOTATION` / `LBL_PURCHASE_ORDER`）は既に `languages/ja_jp/Vtiger.php` 等に定義済みのため、翻訳ファイル追加は現象1のみ。

ChromeMCPにて以下を確認:
- ドキュメント: `app.vtranslate('JS_SELECT_A_FOLDER')` が「フォルダを選択してください」を返却
- 見積一覧「その他」メニュー: 「PDFにエクスポート(見積書)」表示
- 受注一覧「その他」メニュー: 「PDFにエクスポート(注文請書)」表示