### PR TITLE
[修正] #1729 Inventory系インポート スキップ件数と詳細行数の不一致

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -1028,7 +1028,8 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 	public static function getImportDetails($user, $moduleName, $importid) {
 		$adb = PearDatabase::getInstance();
 		$tableName = Import_Utils_Helper::getDbTableName($user, $importid);
-		$result = $adb->pquery("SELECT * FROM $tableName where status IN (?,?)", array(self::$IMPORT_RECORD_SKIPPED, self::$IMPORT_RECORD_FAILED));
+		$groupBy = in_array($moduleName, getInventoryModules()) ? ' GROUP BY subject' : '';
+		$result = $adb->pquery("SELECT * FROM $tableName where status IN (?,?)" . $groupBy, array(self::$IMPORT_RECORD_SKIPPED, self::$IMPORT_RECORD_FAILED));
 		$importRecords = array();
 		if ($result) {
 			$moduleModel = Vtiger_Module_Model::getInstance($moduleName);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1729

##  不具合の内容 / Bug
1. Inventory系モジュール（受注 / 請求 / 発注 / 見積）のCSVインポート結果画面で、「スキップしたレコード数」と、その詳細を開いた際に表示される件数が一致しない（詳細側の方が多く表示される）

##  原因 / Cause
1. カウント側（`include/utils/InventoryUtils.php` の `getImportStatusCount`）は `GROUP BY subject` でsubject単位に集計するが、詳細取得側（`modules/Import/actions/Data.php` の `getImportDetails`）は生SELECTで明細行込み全件取得しているため、Inventory系のように1subject複数明細行を持つデータで N倍差が発生していた
2. `createRecords`（`InventoryUtils.php`）はsubject単位で処理し、subjectグループ内の全明細行を同一statusで更新するため、SKIPPEDになったsubjectの明細行数分だけ詳細側が多重表示される

##  変更内容 / Details of Change
1. `modules/Import/actions/Data.php` の `getImportDetails` にInventoryモジュール判定を追加し、`getInventoryModules()` に含まれる場合のみ `GROUP BY subject` を付与
2. カウント側（`InventoryUtils.php` の `getImportStatusCount`）と同一集計方針に統一

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- Invoice / PurchaseOrder / SalesOrder / Quotes の各モジュール インポート結果詳細画面（スキップ／失敗レコード表示）
- 上記以外のモジュール（非Inventory系）は分岐で従来通り生SELECTのため影響なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- Inventory系の `importRecord` は例外時すべて `SKIPPED` に集約される仕様（`InventoryUtils.php:1537`）のため、参照先レコード不在・必須欠落・picklist不一致など内部エラーが起きるとスキップが増える。この設計自体は本PRの対象外
- 言語ファイル修正なし（コード修正のみ、翻訳文字列変更なし）