### PR TITLE
[修正] #1731 メールアドレスにアポストロフィ「'」を含む場合の送信・本文空時のFatal error

### DIFF
--- a/assets/react-web-components/src/utils/validation.test.ts
+++ b/assets/react-web-components/src/utils/validation.test.ts
@@ -57,6 +57,12 @@ describe("validateEmail", () => {
     expect(validateEmail("user+tag@example.com")).toEqual({ valid: true });
   });
 
+  it("アポストロフィを含むアドレスを許可 (issue #1482)", () => {
+    expect(validateEmail("o'brien@example.com")).toEqual({ valid: true });
+    expect(validateEmail("'foo@example.com")).toEqual({ valid: true });
+    expect(validateEmail("foo'@example.com")).toEqual({ valid: true });
+  });
+
   it("無効なメールアドレスを拒否", () => {
     const result1 = validateEmail("invalid");
     expect(result1.valid).toBe(false);

--- a/assets/react-web-components/src/utils/validation.ts
+++ b/assets/react-web-components/src/utils/validation.ts
@@ -56,10 +56,11 @@ export function validateEmail(value: string): ValidationResult {
   }
 
   const trimmedValue = value.trim();
-  // 従来と同じ正規表現パターン（旧版と完全一致させるため冗長なエスケープも保持）
+  // 従来の validation.js と同等パターン。ローカル部にアポストロフィ「'」を許容
+  // （RFC上は不可だが docomo など実在アドレス対応。issue #1482 参照）
   // prettier が代入を改行分割するため、行末 disable でregex行を直接対象にする
   const emailFilter =
-    /^[_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?[a-zA-Z0-9/_/-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/; // eslint-disable-line no-useless-escape
+    /^['_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?['a-zA-Z0-9/_-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/; // eslint-disable-line no-useless-escape
 
   if (!emailFilter.test(trimmedValue)) {
     return {

--- a/modules/Emails/models/Mailer.php
+++ b/modules/Emails/models/Mailer.php
@@ -101,6 +101,10 @@ class Emails_Mailer_Model extends Vtiger_Mailer {
 	}
 
 	public function convertToValidURL($htmlContent) {
+		// 本文空 → DOMDocument::loadHTML が PHP8 で ValueError スロー。空はそのまま返す
+		if ($htmlContent === null || trim((string)$htmlContent) === '') {
+			return (string)$htmlContent;
+		}
 		if (!$this->dom) {
 			$this->dom = new DOMDocument();
 			@$this->dom->loadHTML($htmlContent);

--- a/public/layouts/v7/modules/Vtiger/resources/validation.js
+++ b/public/layouts/v7/modules/Vtiger/resources/validation.js
@@ -380,7 +380,8 @@ jQuery.validator.addMethod("time", function(value, element, params) {
 
 jQuery.validator.addMethod("email", function(value, element, params) {
 		value = value.trim();
-		var emailFilter = /^[_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?[a-zA-Z0-9/_/-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/;
+		// ローカル部に「'」を許容 (issue #1482: docomo 等実在アドレス対応)
+		var emailFilter = /^['_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?['a-zA-Z0-9/_-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/;
 
 		if(!value) return true;
 
@@ -392,10 +393,13 @@ jQuery.validator.addMethod("email", function(value, element, params) {
 );
 
 jQuery.validator.addMethod("multiEmails", function(value, element, params) {
-		var emailFilter = /^[_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?[a-zA-Z0-9/_/-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/;
+		// ローカル部に「'」を許容 (issue #1482: docomo 等実在アドレス対応)
+		var emailFilter = /^['_/a-zA-Z0-9*]+([!"#$%&'()*+,./:;<=>?\^_`'{|}~-]?['a-zA-Z0-9/_-])*@[a-zA-Z0-9]+([\_\.]?[a-zA-Z0-9\-]+)*\.([\-\_]?[a-zA-Z0-9])+(\.?[a-zA-Z0-9]+)?$/;
 
 		if(!value) return true;
-		var fieldValuesList = value.split(',');
+		// テンプレート由来のHTMLエンティティ (&#039; 等) をデコードしてから検証
+		var decoded = jQuery('<div/>').html(value).text();
+		var fieldValuesList = decoded.split(',');
 		for (var i in fieldValuesList) {
 			var splittedFieldValue = fieldValuesList[i];
 			splittedFieldValue = splittedFieldValue.trim();


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1731

##  不具合の内容 / Bug
1. 顧客担当者などのメールアドレスに「'」を含む場合、「メールを送る」画面で「有効なメールアドレスを入力してください。」というフロントバリデーションで弾かれ送信できない。
2. 「メールを送る」画面で本文を空にして送信すると、サーバ側で `DOMDocument::loadHTML(): Argument #1 (\$source) must not be empty` の Fatal error が発生し送信失敗する。

##  原因 / Cause
1. `validation.js` / `validation.ts` のメール正規表現でローカル部先頭・末尾に「'」を許容していない。RFC 5322 の atext ではアポストロフィが許容されており（`atext = ALPHA / DIGIT / "!" / "#" / "\$" / "%" / "&" / "'" / ...`）、docomo 等の実在アドレスにも存在する。また `multiEmails` バリデータが Smarty 側で HTML エスケープされた `&#039;` を含む文字列をそのまま正規表現検証し、無効判定していた。
2. `Emails/models/Mailer.php::convertToValidURL()` が本文文字列を無条件に `DOMDocument::loadHTML()` に渡しており、PHP 8 系では空文字を渡すと `ValueError` が発生する。

##  変更内容 / Details of Change
1. `public/layouts/v7/modules/Vtiger/resources/validation.js`
   - `email` / `multiEmails` の正規表現ローカル部に「'」を追加（先頭・末尾も許容）。
   - `multiEmails` で入力値を HTML エンティティデコード（`jQuery('<div/>').html(value).text()`）してから `,` split・検証。
2. `assets/react-web-components/src/utils/validation.ts`
   - React 側の `validateEmail` 正規表現をレガシー側と揃え、ローカル部に「'」を許容。
3. `assets/react-web-components/src/utils/validation.test.ts`
   - `o'brien@example.com` / `'foo@example.com` / `foo'@example.com` を有効ケースとして追加。
4. `modules/Emails/models/Mailer.php`
   - `convertToValidURL()` 冒頭で本文が null / 空文字のとき早期 return し、`DOMDocument::loadHTML()` を呼ばないよう修正。

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- メール送信フォーム（顧客担当者 / 顧客企業 / リード等の詳細・一覧からの送信、一括メール送信）
- メールアドレスバリデーションが利用される全画面（`data-rule-multiEmails` / `data-rule-email` 付与フィールド、React 製 Web コンポーネントで `validateEmail` を利用する箇所）
- メール送信処理全般（`convertToValidURL` を経由する送信フロー）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 動作確認: 顧客担当者 `test'aaa@example.com` から「メールを送る」→ 送信成功・MailHog 到達確認済み。本文空で送信しても Fatal error なく成功。
- 既存 vitest 21 件通過。
- 関連 issue: #1482（メール送信時のエスケープ問題）。同 issue と方針整合。
- 言語対応: 表示メッセージ改修なし・該当なし。