### PR TITLE
[修正] #1731 招待者ユーザーのメールアドレスにアポストロフィを含む場合に招待メールが送信されない

### DIFF
--- a/modules/Calendar/CalendarCommon.php
+++ b/modules/Calendar/CalendarCommon.php
@@ -164,7 +164,7 @@ function sendInvitation($inviteesid,$mode,$recordModel,$desc) {
 			$attachment = generateIcsAttachment($desc, $inviteeid);
 			$description=getActivityDetails($desc,$inviteeid,"invite",$recordModel);
 			$description = getMergedDescription($description, $recordModel->getId(), 'Events');
-			$to_email = getUserEmailId('id',$inviteeid);
+			$to_email = decode_html(getUserEmailId('id',$inviteeid));
 			$to_name = getUserFullName($inviteeid);
             $mail = new Vtiger_Mailer();
             $mail->IsHTML(true);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1731

##  不具合の内容 / Bug
1. 顧客担当者・リード等の詳細画面で「活動の追加」を実行し、招待者に「メールアドレスにアポストロフィ（`'`）を含むユーザー」を指定して「メール送信する」にチェックを入れて保存した場合、当該招待者に招待メールが送信されない。UIエラー・PHPエラーログ共に出力されず、静かに送信スキップされる。
2. 本挙動は #1731 で既に対応済みの一連の不具合（Emailsモジュール経由の送信不可・本文空時のFatal error）と同種の原因（HTMLエンティティ由来）だが、Calendar 招待メール経路は未対応であった。

##  原因 / Cause
1. `modules/Calendar/CalendarCommon.php::sendInvitation()` で招待者メールアドレスを `getUserEmailId('id', $inviteeid)` で取得しているが、`vtiger_users.email1` に格納された `test'1@example.com` のような値が DB取得の過程でHTMLエンティティ化され `test&#039;1@example.com` として返却される。
2. これを `Vtiger_Mailer::SendTo()` → `PHPMailer::AddAddress()` に渡すと、`PHPMailer::validateAddress()` が `&`, `#`, `;` を含むアドレスを invalid と判定し、例外もエラーログも出さずに送信をスキップする。

##  変更内容 / Details of Change
1. `modules/Calendar/CalendarCommon.php::sendInvitation()` で `getUserEmailId()` の戻り値を `decode_html()` でデコードしてから `SendTo()` に渡すよう修正。
   ```diff
   - $to_email = getUserEmailId('id',$inviteeid);
   + $to_email = decode_html(getUserEmailId('id',$inviteeid));
   ```
   同関数内の `$to_name` は既に `decode_html` 済であり、それに揃える形。

## スクリーンショット / Screenshot
別途添付予定（動作確認: 招待者 `test'1@example.com` 宛にMailhogでメール到達を確認）。

## 影響範囲  / Affected Area
- 活動（イベント）保存時の招待メール送信経路のみ。
- `sendInvitation()` の招待者向けメール送信で、招待者のメールアドレスに `'` `<` `>` `&` `"` 等HTMLエンティティ化される文字を含むケース全般（RFC5321的にはアポストロフィはメールアドレスに合法）。
- 既存の正常なメールアドレス（英数のみ）宛の招待メール送信には影響なし（decode_html は該当エンティティを含まない場合は入力を素通しするため）。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- Issue #1731 は既にPR #1732 で一部対応済みだが、Calendar招待メール経路が漏れていたため、同issueの追加対応として本PRを起票。
- 修正1行のみ。言語ファイル変更なし。