### PR TITLE
[修正] #1734 メールコンバーター LINKアクションで既存レコード検索が常に失敗

### DIFF
--- a/modules/Settings/MailConverter/handlers/MailScanner.php
+++ b/modules/Settings/MailConverter/handlers/MailScanner.php
@@ -269,7 +269,7 @@ class Vtiger_MailScanner {
 			return $this->_cachedContactIds[$email];
 		}
 		$contactid = false;
-		$contactres = $adb->pquery("SELECT contactid FROM vtiger_contactdetails INNER JOIN vtiger_crmentity ON crmid = contactid WHERE setype = ? AND email = ? AND deleted = ?", array('Contacts', $email, 0));
+		$contactres = $adb->pquery("SELECT contactid FROM vtiger_contactdetails INNER JOIN vtiger_crmentity ON crmid = contactid WHERE setype = ? AND email = ? AND vtiger_contactdetails.deleted = ?", array('Contacts', $email, 0));
 		if($adb->num_rows($contactres)) {
 			$deleted = $adb->query_result($contactres, 0, 'deleted');
 			if ($deleted != 1) {
@@ -295,7 +295,7 @@ class Vtiger_MailScanner {
 			return $this->_cachedLeadIds[$email];
 		}
 		$leadid = false;
-		$leadres = $adb->pquery("SELECT leadid FROM vtiger_leaddetails INNER JOIN vtiger_crmentity ON crmid = leadid WHERE setype=? AND email = ? AND converted = ? AND deleted = ?", array('Leads', $email, 0, 0));
+		$leadres = $adb->pquery("SELECT leadid FROM vtiger_leaddetails INNER JOIN vtiger_crmentity ON crmid = leadid WHERE setype=? AND email = ? AND converted = ? AND vtiger_leaddetails.deleted = ?", array('Leads', $email, 0, 0));
 		if ($adb->num_rows($leadres)) {
 			$deleted = $adb->query_result($leadres, 0, 'deleted');
 			if ($deleted != 1) {
@@ -322,7 +322,7 @@ class Vtiger_MailScanner {
 		}
 
 		$accountid = false;
-		$accountres = $adb->pquery("SELECT accountid FROM vtiger_account INNER JOIN vtiger_crmentity ON crmid = accountid WHERE setype=? AND (email1 = ? OR email2 = ?) AND deleted = ?", Array('Accounts', $email, $email, 0));
+		$accountres = $adb->pquery("SELECT accountid FROM vtiger_account INNER JOIN vtiger_crmentity ON crmid = accountid WHERE setype=? AND (email1 = ? OR email2 = ?) AND vtiger_account.deleted = ?", Array('Accounts', $email, $email, 0));
 		if($adb->num_rows($accountres)) {
 			$deleted = $adb->query_result($accountres, 0, 'deleted');
 			if ($deleted != 1) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1734
- refs #899 

##  不具合の内容 / Bug
1. メールコンバーターのルールアクション「顧客担当者/顧客企業/リード に追加 [FROM/TO]」（LINK系）で、対象メールアドレスを持つ既存レコードが存在してもメールの紐付けが行われない。

##  原因 / Cause
1. `modules/Settings/MailConverter/handlers/MailScanner.php` の `LookupContact` / `LookupLead` / `LookupAccount` の SQL で、`vtiger_crmentity` とエンティティテーブル（`vtiger_contactdetails` / `vtiger_leaddetails` / `vtiger_account`）を JOIN しているが、両テーブルとも `deleted` カラムを持つため `WHERE ... AND deleted = ?` が Ambiguous エラー（`ERROR 1052 (23000): Column 'deleted' in where clause is ambiguous`）となる。
1. `pquery` がエラーで false を返し、Lookup 系メソッドが常に false を返却。`__LinkToRecord` の紐付け対象が見つからず処理終了となり、Email レコード生成・関連付けが行われない。

##  変更内容 / Details of Change
1. `LookupContact` の `deleted = ?` を `vtiger_contactdetails.deleted = ?` に修飾。
1. `LookupLead` の `deleted = ?` を `vtiger_leaddetails.deleted = ?` に修飾。
1. `LookupAccount` の `deleted = ?` を `vtiger_account.deleted = ?` に修飾。

## スクリーンショット / Screenshot
（該当なし。DBクエリ修正のため）

## 影響範囲  / Affected Area
- メールコンバーターの LINK 系アクション（顧客担当者/顧客企業/リード に追加 [FROM/TO]）による既存レコードへの紐付け処理。
- 上記 Lookup メソッドは MailScanner 内部のみで使用されており、他機能への影響なし。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [-] 言語対応（日・英）を行った（言語ファイル変更なし）

## 備考 / Remarks
テストサーバーでリード宛メールを実際に送信し、LINK系「リードに追加 [TO]」ルールで対象リードにメールが紐付くことを確認済み。