### PR TITLE
[修正] #1736 カレンダー活動(Events)のCSVインポートが常に失敗する

### DIFF
--- a/modules/Events/models/Record.php
+++ b/modules/Events/models/Record.php
@@ -174,13 +174,25 @@ class Events_Record_Model extends Calendar_Record_Model {
             $mail_data['assign_type'] = $this->get('assigntype');
             $mail_data['group_name'] = getGroupName($this->get('assigned_user_id'));
             $mail_data['mode'] = $this->get('mode');
-            //TODO : remove dependency on request;
-            $value = getaddEventPopupTime($_REQUEST['time_start'],$_REQUEST['time_end'],'24');
+            // レコードモデルから直接取得。インポート等 $_REQUEST が空のコンテキストでも動作させる。
+            $timeStart = $this->get('time_start') ?: ($_REQUEST['time_start'] ?? '');
+            $timeEnd   = $this->get('time_end')   ?: ($_REQUEST['time_end']   ?? '');
+            $dateStart = $this->get('date_start') ?: ($_REQUEST['date_start'] ?? '');
+            $dueDate   = $this->get('due_date')   ?: ($_REQUEST['due_date']   ?? '');
+            $activityMode = ($this->getModuleName() == 'Calendar') ? 'Task' : 'Events';
+
+            $value = getaddEventPopupTime($timeStart, $timeEnd, '24');
             $start_hour = $value['starthour'].':'.$value['startmin'].''.$value['startfmt'];
-            if($_REQUEST['activity_mode']!='Task')
+            $end_hour = '';
+            if ($activityMode != 'Task') {
                 $end_hour = $value['endhour'] .':'.$value['endmin'].''.$value['endfmt'];
-            $startDate = new DateTimeField($_REQUEST['date_start']." ".$start_hour);
-            $endDate = new DateTimeField($_REQUEST['due_date']." ".$end_hour);
+            }
+            // date_start/due_date は DB では日付部のみ保持されている可能性があるが、
+            // datetime 文字列で渡されるケースもあるため空白で分割して日付部だけを使う。
+            $dateStartDay = explode(' ', trim($dateStart))[0];
+            $dueDateDay   = explode(' ', trim($dueDate))[0];
+            $startDate = new DateTimeField($dateStartDay." ".$start_hour);
+            $endDate = new DateTimeField($dueDateDay." ".$end_hour);
             $mail_data['st_date_time'] = $startDate->getDBInsertDateTimeValue();
             $mail_data['end_date_time'] = $endDate->getDBInsertDateTimeValue();
             $mail_data['location']=$this->get('location');

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -416,6 +416,10 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 									$createdRecords[] = $entityIdComponents[1];
 								}
 							} catch (Exception $e) {
+								global $log;
+								if ($log) {
+									$log->error('[Import create] failed: '.$e->getMessage()."\n".$e->getTraceAsString());
+								}
 							}
 						}
 					} catch (ImportException $e) {
@@ -1157,12 +1161,13 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 					if ($fieldDataType == 'picklist') {
 						$fieldValue = trim($recordData[$fieldName]);
 						$picklistValues = $fieldModel->getPicklistValues();
+						// getPicklistValues() は [key(DB値) => label(翻訳)] を返す。
+						// この段階の $fieldValue は transformForImport で既に DB キーへ変換済みのため、
+						// キーとラベル両方を許容してチェックする。
+						$picklistCandidates = array_merge(array_keys($picklistValues), array_values($picklistValues));
 
 						$fieldValueInLowerCase = strtolower($fieldValue);
-						$picklistValuesInLowerCase = array_map('strtolower', $picklistValues);
-						if (sizeof($picklistValuesInLowerCase)&& sizeof($picklistValues)) {
-							$picklistDetails = array_combine($picklistValuesInLowerCase, $picklistValues);
-						}
+						$picklistValuesInLowerCase = array_map('strtolower', $picklistCandidates);
 
 						if (!in_array($fieldValueInLowerCase, $picklistValuesInLowerCase)
 								&& $fieldName !== 'visibility'
@@ -1216,6 +1221,10 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 						}
 					}
 				} catch (Exception $e) {
+					global $log;
+					if ($log) {
+						$log->error('[Import Calendar] '.$operation.' failed: '.$e->getMessage()."\n".$e->getTraceAsString());
+					}
 					if ($operation != 'create') {
 						$entityInfo['status'] = self::$IMPORT_RECORD_SKIPPED;
 					}
@@ -1259,6 +1268,10 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				}
 			}
 		} catch (Exception $e) {
+			global $log;
+			if ($log) {
+				$log->error('[Import '.$this->module.'] '.$operation.' failed: '.$e->getMessage()."\n".$e->getTraceAsString());
+			}
 			if ($operation != 'create') {
 				$entityInfo['status'] = self::$IMPORT_RECORD_SKIPPED;
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1736

##  不具合の内容 / Bug
1. カレンダー一覧から「エクスポート → タイトル変更 → インポート」の通常操作で、活動(Events)レコードがすべて「失敗レコード」として扱われ登録できない。
2. エクスポートCSVには「終了日時」列があるが、インポート項目マッピングには「終了日時」ラベルが存在せず「完了日」にマッピングする必要があり、その状態で実行しても失敗する。
3. エラーは画面・ログに何も出ず失敗理由の特定が困難。

##  原因 / Cause
1. `Events_Record_Model::getInviteUserMailData()` が `$_REQUEST['time_start']` 等に依存しており、$_REQUEST が空となるインポート実行時に不正な datetime 文字列 `" 0:"` を生成し `DateTimeField` が例外を投げる → 招待メール生成→`save()` 全体が失敗。
2. `Import_Data_Action::importRecord()` の Calendar 分岐にある picklist 存在チェックが `getPicklistValues()` の返却値（キー => ラベル）のラベル(翻訳後)のみと比較していたが、`transformForImport` で既に DB キーへ変換済みの値と比較するため一致せず `null` を返して失敗扱いになっていた。
3. 保存例外を `catch (Exception)` で握り潰していたためログに残らず、原因調査ができない状態だった。

##  変更内容 / Details of Change
1. `modules/Events/models/Record.php` : `getInviteUserMailData()` の `$_REQUEST` 依存を排除し `$this->get()` から取得するよう修正。`$_REQUEST` は後方互換のためフォールバックとして残す。`activity_mode` 判定も `getModuleName()` ベースに変更。`date_start`/`due_date` に datetime 文字列が渡されるケースにも対応。
2. `modules/Import/actions/Data.php` : Calendar 分岐の picklist 存在チェックを keys と labels 両方許容するよう修正。
3. `modules/Import/actions/Data.php` : 握り潰していた保存例外 3 箇所に `$log->error()` を追加し、失敗理由をログに残せるよう修正。

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- カレンダー(活動/TODO)のCSVインポート
- 活動(Events)保存時の招待メール処理（画面からの追加・更新・インポート全て）
- 他モジュールのインポート時の例外ログ出力（挙動変化はログ追加のみ、業務ロジックは不変）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
- 動作確認: ChromeDevTools MCP でインポート → 成功、招待メール MailHog 受信確認済み
- UI からの活動追加（招待メール送信ON）も回帰テスト実施済み
- 言語対応: 新規文言追加なしのため対象外
- 事前修正: 招待者メアド decode 済み (PR #1732 / #1733 が main にマージ済み)