### PR TITLE
[修正] #1738 リッチテキストエディタ配下フィールドの必須バリデーションが効かない

### DIFF
--- a/e2e/utils/field.ts
+++ b/e2e/utils/field.ts
@@ -171,6 +171,18 @@ export const fillField = async (
     await editor.fill(`${value}`);
     // Joditから隠しtextareaへ値を同期させる
     await editor.blur();
+    // Joditのchangeハンドラがtextarea.valueへ同期するまで待機。
+    // 同期前に保存すると必須バリデーションで空判定されsubmitがブロックされる。
+    await page.waitForFunction(
+      ({ name, expected }) => {
+        const ta = document.querySelector(
+          `textarea[name="${name}"]`
+        ) as HTMLTextAreaElement | null;
+        return !!ta && ta.value.includes(expected);
+      },
+      { name: fieldObj.name, expected: value },
+      { timeout: 5000 }
+    );
   } else if (fieldObj.type.name === "text") {
     /**********************************************************************************************
      * テキスト項目への値登録

--- a/public/layouts/v7/modules/Vtiger/resources/JoditEditor.js
+++ b/public/layouts/v7/modules/Vtiger/resources/JoditEditor.js
@@ -616,6 +616,11 @@ jQuery.Class("Vtiger_Jodit_Js", {
                 );
                 wrapper.lastKnownEditorValue = bodyVal;
                 wrapper.lastKnownData = fullHtml;
+                // textareaへライブ同期。jQuery Validateがsubmit時に読む値を最新化し、
+                // data-rule-required等の必須チェックが実入力内容を判定できるようにする。
+                if (self.element && self.element.length > 0) {
+                    self.element.val(fullHtml);
+                }
             }
         });
         var restoreLastKnownContent = function () {

--- a/public/layouts/v7/modules/Vtiger/resources/validation.js
+++ b/public/layouts/v7/modules/Vtiger/resources/validation.js
@@ -918,13 +918,24 @@ function calculateValidationRules(form,params,meta){
 		'focusInvalid': true,
 		//Refer for explanation on ignore attrbute https://github.com/select2/select2/issues/215
 		//As element with class select2-input doesn't have name attribute is leading to issue
-		'ignore' : ":hidden,.ignore-validation,.select2-input",
+		'ignore' : ":hidden:not(.joditEditorSource),.ignore-validation,.select2-input",
 		errorPlacement: function(error, element) {
 			if($(error).text()) {
 				$(error).text(app.vtranslate($(error).text()));
 
 				if(element.hasClass('select2')) {
 					element = app.helper.getSelect2FromSelect(element);
+				}
+
+				// Jodit配下textareaは:hiddenのため、qtipの位置計算が0となり画面非表示。
+				// 同じ親要素内に生成される可視要素(.jodit-container)へリターゲットして表示可能にする。
+				var isJoditTarget = false;
+				if(element.hasClass('joditEditorSource')) {
+					var joditContainer = element.parent().find('.jodit-container').first();
+					if(joditContainer.length) {
+						element = joditContainer;
+						isJoditTarget = true;
+					}
 				}
 
 				var positionsConf = {
@@ -994,6 +1005,17 @@ function calculateValidationRules(form,params,meta){
 					}
 				});
 				element.trigger('Vtiger.Validation.Show.Messsage');
+				// Jodit配下textareaはerrorPlacement初回呼出時にqtipのshow.eventが初期化直後に
+				// 空振りする(qtip側でrender完了前にtriggerが処理される)ため、次tickで強制表示する。
+				if(isJoditTarget) {
+					var $joditEl = element;
+					setTimeout(function() {
+						var joditApi = $joditEl.qtip('api');
+						if(joditApi) {
+							joditApi.show();
+						}
+					}, 0);
+				}
 			}
 			/*
 			 * Experimental : Using tooltipster


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1738

##  不具合の内容 / Bug
1. FAQ「質問内容」「回答」、チケット「詳細内容」など、Joditエディタが適用された必須フィールドで、空欄のまま保存してもバリデーションエラーが表示されず素通りしてしまう。

##  原因 / Cause
1. Jodit初期化時に \`element.hide()\` で textarea が \`:hidden\` 状態となる
1. jQuery Validate のデフォルト \`ignore: ':hidden,...'\` により Jodit配下textareaが検証対象から除外される
1. さらに、Jodit編集中は textarea へ値がライブ同期されないため、仮に検証対象化しても常に空値と判定される
1. エラー表示（qtip）も hidden textarea 上に配置されるため位置計算が0となり画面上に表示されない
1. 旧CKEditor時代からの既存不具合であり、Jodit移行で顕在化したものではない（v7.4.2でも実測で未動作を確認）

##  変更内容 / Details of Change
1. \`public/layouts/v7/modules/Vtiger/resources/validation.js\`
   - \`ignore\` セレクタを \`:hidden:not(.joditEditorSource),...\` に変更し Jodit配下textareaを検証対象化
   - \`errorPlacement\` で \`.joditEditorSource\` を検出した場合、同じ親要素内の \`.jodit-container\` にリターゲットして qtip を可視要素上に配置
   - 初回描画時に qtip の \`show.event\` が空振りするため、\`setTimeout(0)\` で \`api.show()\` を強制発火
1. \`public/layouts/v7/modules/Vtiger/resources/JoditEditor.js\`
   - \`change\` イベント発生時、退避・復元層を通したフルHTMLを textarea へライブ同期
   - submit時に jQuery Validate が最新の入力内容を判定できるようにする

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- \`joditEditorSource\` クラスが付与される全 textarea を持つモジュール
  - FAQ（質問内容 / 回答）
  - HelpDesk（詳細内容 / 解決方法）
  - Documents（ノート内容）
  - EmailTemplates（本文）
  - PDFTemplates（テンプレート内容）
- 必須フラグが立っていないフィールドでは動作変更なし
- qtipツールチップの表示位置ロジック（Jodit配下のみ）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 動作確認: chrome-devtools MCP でFAQ新規作成・HelpDesk新規作成にて、空欄保存→ツールチップ表示、内容入力→正常保存 を確認
- 言語対応: エラーメッセージ「必須入力です」は既存の共通翻訳キーを使用するため追加リソースなし