### PR TITLE
[修正] #1740 週次繰り返し予定で終了日と同週の後方曜日が生成されない

### DIFF
--- a/include/utils/RecurringType.php
+++ b/include/utils/RecurringType.php
@@ -351,7 +351,15 @@ class RecurringType {
 			$dayDiff = $dateDiff/3600/24;
 		}
 
-		while ($tempdate <= $enddate) {
+		// 週次は基準日(tempdate)と生成日(repeatDate)が最大±6日ズレる。
+		// 基準日単独で判定するとenddateと同週の未処理曜日を取りこぼすため、週次のみ6日分許容。
+		// 実際の採否は内側の $repeatDate <= $enddate で担保。
+		$loopEnddate = $enddate;
+		if ($this->recur_type == 'Weekly') {
+			$loopEnddate = date('Y-m-d', strtotime($enddate . ' +6 days'));
+		}
+
+		while ($tempdate <= $loopEnddate) {
 			$date = $tempdateObj->get_Date();
 			$month = $tempdateObj->getMonth();
 			$year = $tempdateObj->getYear();


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1740

##  不具合の内容 / Bug
1. 活動モジュールで週次繰り返し予定を作成した際、開始日の曜日より後の曜日を繰り返し曜日に指定し、その曜日が繰り返し終了日と同じ週にある場合、その予定が生成されない

##  原因 / Cause
1. `include/utils/RecurringType.php` の `_getRecurringDates()` 週次分岐で、ループ終了判定に基準日 (開始曜日ベースの `tempdate`) を単独で使用していた
2. 週次は 1 周期で複数日 (指定曜日全て) を生成する構造だが、基準日が繰り返し終了日を超えた時点で `while ($tempdate <= $enddate)` を抜けるため、同週の未処理曜日 (開始曜日より後ろの曜日) が取りこぼされる
3. 例: 開始 2026-04-04 (土)、終了 2026-04-30、Mon/Wed 指定の場合、基準日 04-25 (土) の次 05-02 (土) が終了日超過でループ終了 → 同週の Mon=04-27 / Wed=04-29 が未生成

##  変更内容 / Details of Change
1. 週次繰り返し (`recur_type == 'Weekly'`) の場合のみ、ループ終了判定用の日付を繰り返し終了日 + 6 日に緩和
2. 実際に生成する日付の採否は既存の内側条件 `$repeatDate > $startdate && $repeatDate <= $enddate` で担保されるため、過剰生成なし
3. 日次・月次・年次は「基準日 == 生成対象日」のため既存動作維持

## スクリーンショット / Screenshot
なし（内部ロジック修正）

## 影響範囲  / Affected Area
- 活動モジュール (Events) の週次繰り返し予定生成
- 日次・月次・年次への影響なし
- 変更ファイル: `include/utils/RecurringType.php`

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（言語ファイル変更なし）

## 備考 / Remarks
検証内容:
- バグ再現ケース (start 2026-04-04 土 / end 2026-04-30 / Mon,Wed) → 04-06, 04-08, 04-13, 04-15, 04-20, 04-22, 04-27, 04-29 の 8 件生成を確認
- 端界ケース (end=2026-04-21 火) → 04-22 (水) が生成されないこと確認 (過剰生成なし)
- 端界ケース (end=2026-04-22 水) → 04-22 が生成されること確認