### PR TITLE
[修正] #1742 リスト作成モーダル バリデーションツールチップがヘッダーに埋もれる

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/validation.js
+++ b/public/layouts/v7/modules/Vtiger/resources/validation.js
@@ -965,6 +965,13 @@ function calculateValidationRules(form,params,meta){
 						};
 						positionContainer = overlayElement;
 					}
+					var elRect = element[0].getBoundingClientRect();
+					var overlayHeader = element.closest('.modal-content').find('> .overlayHeader');
+					var blockingBottom = overlayHeader.length ? overlayHeader[0].getBoundingClientRect().bottom : (positionsConf.container[0].getBoundingClientRect ? positionsConf.container[0].getBoundingClientRect().top : 0);
+					if (elRect.top - blockingBottom < 40) {
+						positionsConf.my = 'top left';
+						positionsConf.at = 'bottom left';
+					}
 				}
 
 				element.qtip({


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1742

##  不具合の内容 / Bug
1. 任意モジュールのリスト画面で「新しいリストを作成」モーダルを開き、既存リスト名と同じ名前を入力して保存を試みると、バリデーションエラー用の qtip ツールチップ「表示が既に存在します」がモーダルヘッダー領域に埋もれ、上半分程度が見切れて可読性が低下する。

##  原因 / Cause
1. `public/layouts/v7/modules/Vtiger/resources/validation.js` の `errorPlacement` で qtip の位置指定が `my: 'bottom left', at: 'top left'` の入力欄上部固定になっている。
2. モーダル最上部の入力欄（リスト作成モーダルの `#viewname` 等）ではツールチップが `overlayHeader` と重なり、ヘッダーの背面に隠れて見切れる。

##  変更内容 / Details of Change
1. `errorPlacement` にツールチップ位置反転ロジック追加。
2. `overlayHeader` 底部と入力欄上部の間隔が 40px 未満の場合、qtip の位置指定を `my: 'top left', at: 'bottom left'` に切替、ツールチップを入力欄下部に表示。
3. 上記条件に該当しないフォームは従来通り上部表示を維持。

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- qtip ベースのバリデーションツールチップを利用する全フォーム（`errorPlacement` 共通処理のため）
- 主に `overlayHeader` を持つモーダル最上部の入力欄で表示位置が下部に切替わる
- 具体箇所: リスト作成／編集モーダル（`layouts/v7/modules/CustomView/EditView.tpl`）等

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイルの変更なし
- 変更ファイル: `public/layouts/v7/modules/Vtiger/resources/validation.js`