### PR TITLE
[修正] #1744 個人設定 多要素認証リスト モバイル表示 列重なり解消

### DIFF
--- a/layouts/v7/modules/Users/DetailViewUserCredentialBlockView.tpl
+++ b/layouts/v7/modules/Users/DetailViewUserCredentialBlockView.tpl
@@ -14,7 +14,7 @@
         <h4>{vtranslate("LBL_MULTI_FACTOR_AUTH","Users")}</h4>
     </div>
     <hr>
-    <div class="blockData multi_factor_credentialList">
+    <div class="blockData multi_factor_credentialList table-responsive">
         <table class="table detailview-table no-border">
             <thead>
                 <tr>

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -1399,16 +1399,17 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
 @media (min-width: 0px) and (max-width: 830px) {
   .multi_factor_credentialList {
     overflow-x: auto !important;
-    width: 100vw !important;
+    -webkit-overflow-scrolling: touch;
+    width: 100% !important;
+    max-width: 100% !important;
     display: block !important;
   }
 
   .multi_factor_credentialList > table {
     display: table !important;
-    table-layout: fixed !important;
-  width: 100% !important;
-  white-space: nowrap !important;
-  overflow-x: auto !important;
+    table-layout: auto !important;
+    width: auto !important;
+    min-width: 100%;
   }
   .multi_factor_credentialList > table tr,
   .multi_factor_credentialList > table td,
@@ -1418,7 +1419,22 @@ input:focus ~ .bar:before, input:focus ~ .bar:after {
   .multi_factor_credentialList > table td,
   .multi_factor_credentialList > table th {
     display: table-cell !important;
-    width: 100% !important;
+    width: auto !important;
+    padding-right: 16px;
+    vertical-align: middle;
+  }
+  .multi_factor_credentialList > table th:last-child,
+  .multi_factor_credentialList > table td:last-child {
+    text-align: center;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .multi_factor_credentialList .textOverflowEllipsis {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: nowrap;
+    display: inline;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1744

##  不具合の内容 / Bug
1. 個人設定画面（`index.php?module=Users&parent=Settings&view=PreferenceDetail&record=<id>`）の「多要素認証」ブロック内、認証情報リストのテーブル列がモバイル幅で重なって表示され、内容が視認できない

##  原因 / Cause
1. `layouts/v7/modules/Users/DetailViewUserCredentialBlockView.tpl` のテーブルが継承先 `.detailview-table` の `table-layout: fixed` により4列均等分割になっていた
2. 各セルに `.textOverflowEllipsis`（`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`）が適用され、狭幅時にヘッダー・本文が切り詰められる／隣接セルの境界を跨いで重なって視認できない状態になっていた

##  変更内容 / Details of Change
1. `.multi_factor_credentialList` ラッパーに `overflow-x: auto` / `-webkit-overflow-scrolling: touch` / `width: 100%; max-width: 100%` を付与し、親ブロック内に収める＋幅超過時は水平スクロールで閲覧可能にした
2. `.multi_factor_credentialList table.detailview-table` に `width: auto !important; min-width: 100%; table-layout: auto !important` を上書きし、列幅を内容に応じて自動決定するよう変更
3. th/td に `white-space: nowrap` と `padding-right: 16px` を付与し、列内容を1行で表示（省略・折返しなし）
4. スコープ限定した `.textOverflowEllipsis` 上書きで `overflow: visible; text-overflow: clip; max-width: none` とし、デバイス名等の切り詰めを無効化
5. 最終列（削除ボタン）は `text-align: center` + `padding-left: 12px; padding-right: 12px` で中央配置

## スクリーンショット / Screenshot
<img width="456" height="239" alt="image" src="https://github.com/user-attachments/assets/ce09036a-86a7-40ba-a0b0-4f866898ac29" />
<img width="448" height="236" alt="image" src="https://github.com/user-attachments/assets/46699632-47c9-4f2e-9871-87a4bc8ab680" />


## 影響範囲  / Affected Area
- 個人設定（Users モジュール）詳細画面の「多要素認証」ブロックの見た目のみ
- 該当テンプレート: `layouts/v7/modules/Users/DetailViewUserCredentialBlockView.tpl`
- ロジック・DB・他画面への影響なし
- CSS はスコープを `.multi_factor_credentialList` 配下に限定しており、他モジュールの `.detailview-table` へは影響しない

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイルの追加・変更なし（表示テキストの改変なし）
- 言語対応チェックは該当なし
- 動作確認: F-RevoCRM ローカル環境の Chrome DevTools MCP で、ビューポート幅を狭めて `vtiger_user_credentials` にテストデータを投入して確認済み