### PR TITLE
[修正] #1746 チケット概要「さらに表示」押下で活動一覧が全消失

### DIFF
--- a/assets/react-web-components/src/components/ActivityList/ActivityListItem.tsx
+++ b/assets/react-web-components/src/components/ActivityList/ActivityListItem.tsx
@@ -51,9 +51,9 @@ const getIconColor = (activityType: string): string => {
  * Get badge variant based on status
  */
 const getStatusVariant = (
-  status: string,
+  status: string | null | undefined,
 ): "default" | "success" | "warning" | "destructive" | "secondary" => {
-  const lowerStatus = status.toLowerCase();
+  const lowerStatus = (status ?? "").toLowerCase();
 
   if (
     lowerStatus.includes("completed") ||

--- a/assets/react-web-components/src/components/ActivityList/ActivityStatusEditor.tsx
+++ b/assets/react-web-components/src/components/ActivityList/ActivityStatusEditor.tsx
@@ -32,9 +32,9 @@ export interface ActivityStatusEditorProps {
  * Get badge variant based on status
  */
 const getStatusVariant = (
-  status: string,
+  status: string | null | undefined,
 ): "default" | "success" | "warning" | "destructive" | "secondary" => {
-  const lowerStatus = status.toLowerCase();
+  const lowerStatus = (status ?? "").toLowerCase();
 
   if (
     lowerStatus.includes("completed") ||

--- a/modules/Calendar/apis/GetActivities.php
+++ b/modules/Calendar/apis/GetActivities.php
@@ -178,7 +178,7 @@ class Calendar_GetActivities_Api extends Vtiger_Api_Controller {
             // Status can be in different fields depending on which Module's getCalendarActivities is used:
             // - Accounts_Module_Model uses 'status' (from CASE WHEN in SQL)
             // - Vtiger_Module_Model uses 'eventstatus' or 'taskstatus' directly from vtiger_activity
-            $status = $activityModel->get('status') ?: $activityModel->get('eventstatus') ?: $activityModel->get('taskstatus');
+            $status = $activityModel->get('status') ?: $activityModel->get('eventstatus') ?: $activityModel->get('taskstatus') ?: '';
             $dateStart = $activityModel->get('date_start');
             $timeStart = $activityModel->get('time_start');
             $dueDate = $activityModel->get('due_date');


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1746

##  不具合の内容 / Bug
1. チケットレコード概要画面の「活動」欄で、活動が6件以上紐づいている際に表示される「さらに表示」ボタンを押すと、活動一覧が全て表示されなくなる。ブラウザコンソールに `TypeError: Cannot read properties of null (reading 'toLowerCase')` が出力される。

##  原因 / Cause
1. Calendar API `GetActivities` が `status` / `eventstatus` / `taskstatus` いずれも空の活動について `status: null` を返していた。
2. React 側 `ActivityListItem` / `ActivityStatusEditor` の `getStatusVariant()` が null ガード無しで `status.toLowerCase()` を呼び出しており、null 混入時に例外を発生させ、React ツリー全体をアンマウントさせていた。

##  変更内容 / Details of Change
1. `modules/Calendar/apis/GetActivities.php`: `$status` 取得ロジックの末尾に `?: ''` を追加し、API レスポンスから null を排除。
2. `assets/react-web-components/src/components/ActivityList/ActivityListItem.tsx`: `getStatusVariant()` の引数型を `string | null | undefined` に変更し、`(status ?? "").toLowerCase()` で null ガード。
3. `assets/react-web-components/src/components/ActivityList/ActivityStatusEditor.tsx`: 同上の null ガードを適用。

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- チケット・顧客企業・顧客担当者・営業案件等、React 製「活動」欄を表示するレコード概要画面全般
- 活動ステータスバッジの表示およびインライン編集

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [ ] 言語対応（日・英）を行った（言語ファイル変更なしのため該当外）

## 備考 / Remarks
- 修正前・修正後の動作確認をローカルで実施し、7件以上の活動（うち1件 \`eventstatus=NULL\`）で「さらに表示」押下→全件表示・エラー無しを確認済み。