### PR TITLE
[修正] #1748 概要画面 活動一覧が非管理者ユーザーで0件になるバグ

### DIFF
--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -1102,7 +1102,25 @@ class Vtiger_Module_Model extends Vtiger_Module {
 			}
 		}
 
+		// Task の共有権限判定を SQL 段で行う。
+		// PHP 側の isToDoPermittedBySharing() で unset するだけだと、SQL の LIMIT 内が全部
+		// 権限外 Task で埋まったとき、Event 等が残っていても取得できず 0 件になる。
+		$permittedTaskOwnerIds = self::getPermittedTaskOwnerIdsForCalendar($currentUser);
+		$taskOwnerCondition = '';
+		if ($permittedTaskOwnerIds !== null) {
+			if (!empty($permittedTaskOwnerIds)) {
+				$placeholders = generateQuestionMarks($permittedTaskOwnerIds);
+				$taskOwnerCondition = " AND (vtiger_activity.activitytype != 'Task' OR vtiger_crmentity.smownerid IN ($placeholders))";
+			} else {
+				$taskOwnerCondition = " AND vtiger_activity.activitytype != 'Task'";
+			}
+			$query .= $taskOwnerCondition;
+		}
+
 		$params = array($this->getName());
+		if (!empty($permittedTaskOwnerIds)) {
+			$params = array_merge($params, $permittedTaskOwnerIds);
+		}
 
 		if ($recordId) {
 			$query .= " AND vtiger_seactivityrel.crmid = ?";
@@ -1179,6 +1197,43 @@ class Vtiger_Module_Model extends Vtiger_Module {
 		}
 
 		return $activities;
+	}
+
+	/**
+	 * カレンダーの Task で SQL 段の smownerid IN 絞り込みに使う ID 集合を返す。
+	 * isToDoPermittedBySharing() の判定を SQL 化するためのもの。
+	 * - 管理者、または profileGlobalPermission が全許可のユーザーは絞り込み不要 → null
+	 * - それ以外は「自分 + 部下ロール配下ユーザー + 全グループ」を許可
+	 *   （グループ所有 Task と自分より下位ロールの Task は isToDoPermittedBySharing で常に 'Yes'）
+	 */
+	private static function getPermittedTaskOwnerIdsForCalendar($currentUser) {
+		if ($currentUser->isAdminUser()) {
+			return null;
+		}
+		$userId = $currentUser->getId();
+		require('user_privileges/user_privileges_'.$userId.'.php');
+		// $profileGlobalPermission[1]==0 or [2]==0 のとき isToDoPermittedBySharing は常に 'Yes' なので絞り込み不要
+		if ((isset($profileGlobalPermission[1]) && $profileGlobalPermission[1] == 0)
+			|| (isset($profileGlobalPermission[2]) && $profileGlobalPermission[2] == 0)) {
+			return null;
+		}
+		$ids = array((int)$userId);
+		if (!empty($subordinate_roles_users) && is_array($subordinate_roles_users)) {
+			foreach ($subordinate_roles_users as $roleUsers) {
+				if (is_array($roleUsers)) {
+					foreach ($roleUsers as $uid) {
+						$ids[] = (int)$uid;
+					}
+				}
+			}
+		}
+		$db = PearDatabase::getInstance();
+		$rs = $db->pquery('SELECT groupid FROM vtiger_groups', array());
+		$n = $db->num_rows($rs);
+		for ($i = 0; $i < $n; $i++) {
+			$ids[] = (int)$db->query_result($rs, $i, 'groupid');
+		}
+		return array_values(array_unique($ids));
 	}
 
 	/**


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1748

##  不具合の内容 / Bug
1. 非管理者ユーザーで、レコード概要画面の「活動一覧」ウィジェットが 0 件表示になる場合がある。関連一覧タブでは同じ活動が正しく表示されており、概要側だけ不整合となる。

##  原因 / Cause
1. `Vtiger_Module_Model::getCalendarActivities()` において、SQL の `ORDER BY date_start DESC, time_start DESC LIMIT (limit+1)` で取得した後、PHP 側で `isToDoPermittedBySharing()` により権限外 Task を `unset` する実装になっている。
1. このため、SQL 結果の先頭 LIMIT 件が全て権限外 Task で埋まった場合、Event/Call が LIMIT 外に押し出されて取得されず、`unset` 実行後に 0 件となる。
1. Contacts / Accounts / Leads 等は独自の `getCalendarActivities()` 実装を持つため顕在化しにくいが、`Vtiger_Module_Model` にフォールバックするモジュール（HelpDesk 等）で発生しやすい。

##  変更内容 / Details of Change
1. `modules/Vtiger/models/Module.php` の `Vtiger_Module_Model::getCalendarActivities()` に、SQL 段階で Task の閲覧許可範囲を絞り込む WHERE 条件を追加。
1. ヘルパーメソッド `getPermittedTaskOwnerIdsForCalendar()` を追加。管理者・全許可プロファイルのユーザーは絞り込み対象外（`null` 返却で挙動不変）。非管理者かつ非全許可プロファイルの場合のみ、「自分 + 部下ロール配下ユーザー + 全グループ」を許可対象として SQL の `smownerid IN (...)` に注入する。
1. これにより LIMIT 前に権限外 Task が除外され、Event/Call が LIMIT 内に到達可能となり、既存の `isToDoPermittedBySharing()` unset ロジックによる 0 件化が解消される。

## スクリーンショット / Screenshot
別途添付予定（修正前: 「活動はありません。」表示 / 修正後: Call 5 件と「さらに表示」表示）

## 影響範囲  / Affected Area
- `Vtiger_Module_Model::getCalendarActivities()` にフォールバックする全モジュールの概要画面「活動一覧」ウィジェット（HelpDesk 等）
- `getCalendarActivities()` を独自実装するモジュール（Contacts / Accounts / Leads / Home / Potentials 等）は本修正の対象外（挙動不変）
- 管理者ユーザー、および `profileGlobalPermission[1]==0` または `[2]==0` のプロファイル所属ユーザーは早期リターンで挙動不変

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 関連一覧タブ側と概要側で表示件数が一致することを、ローカル環境（HelpDesk record 113、Task 6件 + Call 6件、testuser1665 [H3, Support Profile] でログイン）で確認済。
- pager「1 to 12」表記のズレは別事象のため本 PR 対象外（別 Issue で対応予定）。