### PR TITLE
[修正] #1751 クイック作成 事前にメール送信 保存・引継されない

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -1044,6 +1044,31 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       });
     }
 
+    // reminder_time (分) → set_reminder/remdays/remhrs/remmin へ展開。
+    // Edit.php は set_reminder + remdays/remhrs/remmin を見てリマインダーの
+    // 初期表示を組み立てるため、これを送らないと引き継がれない。
+    if (isCalendarVariant) {
+      const reminderTimeRaw = processedFormData.reminder_time;
+      const reminderTotalMinutes =
+        reminderTimeRaw !== undefined &&
+        reminderTimeRaw !== null &&
+        reminderTimeRaw !== ""
+          ? parseInt(String(reminderTimeRaw), 10)
+          : 0;
+      if (reminderTotalMinutes > 0) {
+        processedFormData.set_reminder = 1;
+        const remdays = Math.floor(reminderTotalMinutes / (24 * 60));
+        const remhrs = Math.floor(
+          (reminderTotalMinutes - remdays * 24 * 60) / 60,
+        );
+        const remmin = reminderTotalMinutes % 60;
+        processedFormData.remdays = remdays;
+        processedFormData.remhrs = remhrs;
+        processedFormData.remmin = remmin;
+      }
+      delete processedFormData.reminder_time;
+    }
+
     if (onGoToFullForm) {
       onGoToFullForm({ editUrl: editViewUrl, formData: processedFormData });
       return;

--- a/assets/react-web-components/src/components/QuickCreate/hooks/useQuickCreateSave.ts
+++ b/assets/react-web-components/src/components/QuickCreate/hooks/useQuickCreateSave.ts
@@ -114,6 +114,31 @@ export function useQuickCreateSave(
           processedData = transformProductTaxData(processedData, fields);
         }
 
+        // reminder_time (分) → set_reminder/remdays/remhrs/remmin へ展開。
+        // Activity::insertIntoReminderTable が $_REQUEST から読む前提のため、
+        // これを送らないと通知設定が保存されない。
+        if (isCalendarModule) {
+          const reminderTimeRaw = processedData.reminder_time;
+          const reminderTotalMinutes =
+            reminderTimeRaw !== undefined &&
+            reminderTimeRaw !== null &&
+            reminderTimeRaw !== ""
+              ? parseInt(String(reminderTimeRaw), 10)
+              : 0;
+          if (reminderTotalMinutes > 0) {
+            processedData.set_reminder = 1;
+            const remdays = Math.floor(reminderTotalMinutes / (24 * 60));
+            const remhrs = Math.floor(
+              (reminderTotalMinutes - remdays * 24 * 60) / 60,
+            );
+            const remmin = reminderTotalMinutes % 60;
+            processedData.remdays = remdays;
+            processedData.remhrs = remhrs;
+            processedData.remmin = remmin;
+          }
+          delete processedData.reminder_time;
+        }
+
         // Calendar/Events用のcalendarModuleパラメータ追加
         // VtigerのSaveAjaxはCalendarモジュール保存時にcalendarModuleパラメータを必要とする
         if (isCalendarModule) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1751

##  不具合の内容 / Bug
1. カレンダー画面のクイック作成（React WebComponents 版）で「事前にメールを送信」を有効化し保存しても、DB `vtiger_activity_reminder` に登録されず、詳細画面でリマインダーが未設定となる
2. クイック作成から「詳細入力」ボタンで詳細入力画面に遷移した際、リマインダー設定が引き継がれず、チェック OFF・値未入力状態で表示される

##  原因 / Cause
1. React QuickCreate のリマインダー UI は `reminder_time`（分単位の合計値）のみを保持・送信していた
2. バックエンドは以下のパラメータを前提としているため、`reminder_time` 単独では認識できず未設定扱いになっていた
   - 保存時: `modules/Calendar/Activity.php` の `insertIntoReminderTable` が `$_REQUEST['set_reminder']` / `remdays` / `remhrs` / `remmin` を参照
   - 詳細入力遷移時: `modules/Calendar/views/Edit.php:146-151` が `set_reminder` / `remdays` / `remhrs` / `remmin` を参照して初期表示
3. 旧 Smarty フォーム版クイック作成（`layouts/v7/modules/Vtiger/uitypes/Reminder.tpl`）は上記パラメータを直接送っていたため動作していた

##  変更内容 / Details of Change
1. `assets/react-web-components/src/components/QuickCreate/hooks/useQuickCreateSave.ts`
   - 保存リクエスト送信直前に `reminder_time`（分）を `set_reminder=1` / `remdays` / `remhrs` / `remmin` へ展開する処理を追加（Calendar / Events モジュール限定）
   - `reminder_time` は送信ボディから除外
2. `assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx`
   - 「詳細入力」ボタン押下時（`goToFullForm`）にも上記と同じ展開処理を追加

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- カレンダー画面のクイック作成モーダル（ToDo / イベント）における「事前にメールを送信」設定の保存・詳細入力画面への引継
- 旧 Smarty フォーム版クイック作成、および詳細入力画面（Edit）自体の挙動には変更なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）

## 備考 / Remarks
- 影響バージョン: WebComponents 版 QuickCreate 導入以降（PR #1440 / 2026-02-12 マージ以降）
- 動作確認: Chrome DevTools 経由で以下2シナリオを実機確認済
  - クイック作成保存 → DB `vtiger_activity_reminder` に `reminder_time=150`（2h30m）登録
  - 「詳細入力」押下 → Edit 画面で「事前にメールを送信」チェック ON / 日数・時間・分の各値が引継されて表示