### PR TITLE
[修正] #1753 クイック作成 ステータス・活動タイプ 必須バリデーション不発

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -18,7 +18,7 @@ import { usePicklistDependency } from "./hooks/usePicklistDependency";
 import { useCalendarFields } from "./hooks/useCalendarFields";
 import { useRecordData } from "./hooks/useRecordData";
 import { QuickCreateProps } from "../../types/quickcreate";
-import { FieldInfo, FieldValue, UI_TYPES } from "../../types/field";
+import { FieldInfo, FieldValue } from "../../types/field";
 import { cn } from "../../lib/utils";
 import { TranslationProvider } from "../../contexts/TranslationContext";
 import { useTranslation } from "../../hooks/useTranslation";
@@ -491,16 +491,9 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
       if (field.name === "assigned_user_id") {
         return (window as any)._USERMETA?.id || "1";
       }
-      // 必須のpicklistフィールドは先頭の選択肢をデフォルト値として設定
-      // ただし、multipicklistは複数選択のため、ユーザーに選択させる（自動選択しない）
-      if (
-        field.mandatory &&
-        field.picklistValues &&
-        field.picklistValues.length > 0 &&
-        field.uitype !== UI_TYPES.MULTIPICKLIST
-      ) {
-        return field.picklistValues[0].value;
-      }
+      // 必須picklistでも自動選択しない（従来のEdit画面挙動と揃える）。
+      // カレンダー設定でデフォルトを空選択にしたユーザーは「未選択」を期待するため、
+      // ここで picklistValues[0] を強制すると意図と食い違いバリデーションも回避される。
       return undefined;
     };
 

--- a/modules/Calendar/models/EditRecordStructure.php
+++ b/modules/Calendar/models/EditRecordStructure.php
@@ -53,14 +53,16 @@ class Calendar_EditRecordStructure_Model extends Vtiger_EditRecordStructure_Mode
 								$currentUserModel = Users_Record_Model::getCurrentUserModel();
 								$defaulteventstatus = $currentUserModel->get('defaulteventstatus');
 								$fieldValue = $defaulteventstatus;
-								if(!$defaulteventstatus || $defaulteventstatus=='Select an Option'){
+								$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+								if(!$defaulteventstatus || $defaulteventstatus=='Select an Option' || $defaulteventstatus===$selectOptionLabel){
 									$fieldValue=$fieldModel->getDefaultFieldValue();
 								}
 							} else if($fieldName == 'activitytype' && empty($fieldValue)) {
 								$currentUserModel = Users_Record_Model::getCurrentUserModel();
 								$defaultactivitytype = $currentUserModel->get('defaultactivitytype');
 								$fieldValue = $defaultactivitytype;
-								if(!$defaultactivitytype || $defaultactivitytype=='Select an Option'){
+								$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+								if(!$defaultactivitytype || $defaultactivitytype=='Select an Option' || $defaultactivitytype===$selectOptionLabel){
 									$fieldValue=$fieldModel->getDefaultFieldValue();
 								}
 							}

--- a/modules/Calendar/models/QuickCreateRecordStructure.php
+++ b/modules/Calendar/models/QuickCreateRecordStructure.php
@@ -43,7 +43,8 @@ class Calendar_QuickCreateRecordStructure_Model extends Vtiger_QuickCreateRecord
 				$currentUserModel = Users_Record_Model::getCurrentUserModel();
 				$defaulteventstatus = $currentUserModel->get('defaulteventstatus');
 				$fieldValue = $defaulteventstatus;
-				if (!$defaulteventstatus || $defaulteventstatus == 'Select an Option') {
+				$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+				if (!$defaulteventstatus || $defaulteventstatus == 'Select an Option' || $defaulteventstatus === $selectOptionLabel) {
 					$fieldValue = $fieldModel->getDefaultFieldValue();
 				}
 				$fieldModel->set('fieldvalue', $fieldValue);
@@ -51,7 +52,8 @@ class Calendar_QuickCreateRecordStructure_Model extends Vtiger_QuickCreateRecord
 				$currentUserModel = Users_Record_Model::getCurrentUserModel();
 				$defaultactivitytype = $currentUserModel->get('defaultactivitytype');
 				$fieldValue = $defaultactivitytype;
-				if (!$defaultactivitytype || $defaultactivitytype == 'Select an Option') {
+				$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+				if (!$defaultactivitytype || $defaultactivitytype == 'Select an Option' || $defaultactivitytype === $selectOptionLabel) {
 					$fieldValue = $fieldModel->getDefaultFieldValue();
 				}
 				$fieldModel->set('fieldvalue', $fieldValue);

--- a/modules/ProjectTask/models/GanttQuickEditRecordStructure.php
+++ b/modules/ProjectTask/models/GanttQuickEditRecordStructure.php
@@ -36,7 +36,8 @@ class ProjectTask_GanttQuickEditRecordStructure_Model extends Vtiger_QuickCreate
 				$currentUserModel = Users_Record_Model::getCurrentUserModel();
 				$defaulteventstatus = $currentUserModel->get('defaulteventstatus');
 				$fieldValue = $defaulteventstatus;
-				if (!$defaulteventstatus || $defaulteventstatus == 'Select an Option') {
+				$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+				if (!$defaulteventstatus || $defaulteventstatus == 'Select an Option' || $defaulteventstatus === $selectOptionLabel) {
 					$fieldValue = $fieldModel->getDefaultFieldValue();
 				}
 				$fieldModel->set('fieldvalue', $fieldValue);
@@ -44,7 +45,8 @@ class ProjectTask_GanttQuickEditRecordStructure_Model extends Vtiger_QuickCreate
 				$currentUserModel = Users_Record_Model::getCurrentUserModel();
 				$defaultactivitytype = $currentUserModel->get('defaultactivitytype');
 				$fieldValue = $defaultactivitytype;
-				if (!$defaultactivitytype || $defaultactivitytype == 'Select an Option') {
+				$selectOptionLabel = vtranslate('LBL_SELECT_OPTION', 'Vtiger');
+				if (!$defaultactivitytype || $defaultactivitytype == 'Select an Option' || $defaultactivitytype === $selectOptionLabel) {
 					$fieldValue = $fieldModel->getDefaultFieldValue();
 				}
 				$fieldModel->set('fieldvalue', $fieldValue);


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1753

##  不具合の内容 / Bug
1. 個人設定 → カレンダー設定でデフォルトのステータス／活動タイプを空選択で保存後、活動のクイック作成を開いてステータス・活動タイプが空のまま保存すると、必須項目にもかかわらずバリデーションが発動せず保存処理が走ってしまう。
2. クイック作成で「計画済み」「電話」が勝手に初期選択される一方、活動一覧から編集画面（`view=Edit`）を開いた場合はどちらも未選択となり挙動が食い違っていた。

##  原因 / Cause
1. カレンダー設定で空選択を保存すると `vtiger_users.defaulteventstatus` / `defaultactivitytype` に空文字ではなく現行言語ラベル `オプションの選択` が格納される（admin 実データで確認）。
2. `Calendar_EditRecordStructure_Model` 等の空判定が英語リテラル `'Select an Option'` のみ比較しており、日本語ラベル `オプションの選択` が空扱いにならずすり抜けていた。結果、GetFields API の `defaultValue` に `オプションの選択` が混入し、React 側 `getFieldInitialValue` が非空文字列として初期値採用、必須バリデーション `value === ""` 判定を通過して保存処理が実行されていた。
3. 加えて React QuickCreate 側の `getFieldInitialValue` に mandatory picklist の先頭値を自動選択するフォールバックがあり、旧 Edit 画面（未選択のまま表示）と挙動が不整合になっていた。

##  変更内容 / Details of Change
1. \`modules/Calendar/models/EditRecordStructure.php\` の eventstatus / activitytype 空判定に \`vtranslate('LBL_SELECT_OPTION', 'Vtiger')\` 比較を追加。
2. \`modules/Calendar/models/QuickCreateRecordStructure.php\` の同判定にも同じ比較を追加。
3. \`modules/ProjectTask/models/GanttQuickEditRecordStructure.php\` の同判定にも同じ比較を追加。
4. \`assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx\` の \`getFieldInitialValue\` から mandatory picklist の先頭値自動選択フォールバックを削除し、旧 Edit 画面と同じ「未選択」挙動に統一。

## スクリーンショット / Screenshot
別途添付（\`docs/pr/20260717/1753/verify/after/\` 配下）。

## 影響範囲  / Affected Area
- 活動（Events）／TODO（Calendar）のクイック作成・編集時のステータス／活動タイプ初期値。
- プロジェクトタスクの Gantt クイック編集の同フィールド初期値。
- WebComponents 版 QuickCreate 全モジュールにおける、defaultvalue 未定義の mandatory picklist の初期表示（従来: 先頭値自動選択 → 変更後: 未選択）。
- 既存の \`defaulteventstatus\` / \`defaultactivitytype\` に不正ラベル値が保存されている環境で、初期値が正しくフィールドデフォルトに戻る。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語ファイルの追加・変更はなし（既存 \`LBL_SELECT_OPTION\` を参照するのみ）。
- \`modules/Vtiger/models/QuickCreateRecordStructure.php\` はコア扱いのため本 PR では変更していない。Calendar モジュールは同クラスをオーバーライドしており、本 PR の修正で本件の再現は解消する。
- WebComponents ビルド成果物（\`public/resources/web-components/*\`）は gitignore のため本コミットには含まれない。デプロイ時にビルド実行が必要。