### PR TITLE
[修正] #1755 概要画面 関連タブ件数バッジ非表示 (Emails権限クエリ TypeError修正)

### DIFF
--- a/modules/Emails/Emails.php
+++ b/modules/Emails/Emails.php
@@ -534,7 +534,7 @@ class Emails extends CRMEntity {
 				== 1 && $defaultOrgSharingPermission[$tabId] == 3) {
 			$tableName = 'vt_tmp_u' . $user->id;
 			$sharingRuleInfoVariable = $module . '_share_read_permission';
-			$sharingRuleInfo = $sharingRuleInfoVariable;
+			$sharingRuleInfo = isset($$sharingRuleInfoVariable) ? $$sharingRuleInfoVariable : null;
 			$sharedTabId = null;
 			if (!empty($sharingRuleInfo) && (php7_count($sharingRuleInfo['ROLE']) > 0 ||
 					php7_count($sharingRuleInfo['GROUP']) > 0)) {


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1755

##  不具合の内容 / Bug
1. 非管理者ユーザーでレコード概要画面を開いた際、関連タブアイコン上の件数バッジ (`.numberCircle`) が全モジュールで表示されない。
2. タブクリック時の関連一覧側の件数は正常表示されるため、バッジ 0 / 一覧 N件 の乖離が発生する。

##  原因 / Cause
1. `modules/Emails/Emails.php:537` の `getNonAdminAccessControlQuery()` 内で、可変変数展開の `$` が1つ抜けており、変数名文字列がそのまま代入されていた。
   ```php
   $sharingRuleInfoVariable = $module . '_share_read_permission';
   $sharingRuleInfo = $sharingRuleInfoVariable; // 変数名の文字列を代入
   if (!empty($sharingRuleInfo) && (php7_count($sharingRuleInfo['ROLE']) > 0 ... // stringにoffsetアクセス
   ```
2. PHP 8+ では文字列に対する連想キーオフセットアクセスが TypeError となり、`RelatedRecordsAjax::getRelatedRecordsCount` API が Fatal error で応答不能となる。
3. Detail.js の `updateRelatedRecordsCount` が結果を受け取れず全バッジが `hide` のまま残る。
4. 親クラス相当の `data/CRMEntity.php:3093` は `$sharingRuleInfo = $$sharingRuleInfoVariable;` と正しく記述されており、Emails.php のみ潜在バグとなっていた。
5. 発火条件: `is_admin == false` かつ `profileGlobalPermission[1] == 1` かつ `profileGlobalPermission[2] == 1` かつ `defaultOrgSharingPermission[Emails tabid] == 3`

##  変更内容 / Details of Change
1. `modules/Emails/Emails.php:537` を可変変数展開に修正。
   ```php
   $sharingRuleInfo = isset($$sharingRuleInfoVariable) ? $$sharingRuleInfoVariable : null;
   ```
   親クラスの `data/CRMEntity.php:3093` と等価の実装に揃え、未定義時は `null` を明示的に代入して以降の `!empty()` 判定で安全にスキップされるようにした。

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- 概要画面の関連タブ件数バッジ表示全般（`Vtiger_RelatedRecordsAjax_Action::getRelatedRecordsCount`）
- Emails モジュールを関連候補に含む全親モジュール（HelpDesk、Accounts、Contacts、Leads 等）
- 非管理者ユーザーかつ Emails 共有=Private 環境の全ユーザー
- Emails 権限クエリを利用する他の呼び出し（レポートの Emails 絡み等、`getNonAdminAccessControlQuery('Emails', ...)` 経由の全処理）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- ローカル環境（PHP 8.x）で修正前後の両方を再現・検証済み。
  - 修正前: HTTP 200 / Fatal error `Cannot access offset of type string on string`
  - 修正後: HTTP 200 / `{"success":true,"result":{...}}` 正常JSON応答
- Initial commit から存在する潜在バグで、PHP 8 移行により顕在化。言語ファイル修正は不要のためチェック済み扱い。