### PR TITLE
[修正] #1757 クイック作成 uitype=10 入力欄開始位置ずれ

### DIFF
--- a/assets/react-web-components/src/components/FieldRenderer.tsx
+++ b/assets/react-web-components/src/components/FieldRenderer.tsx
@@ -804,6 +804,7 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
             disabled={disabled || field.readonly}
             error={error}
             className={className}
+            labelClassName={labelClassName}
           />
         );
 

--- a/assets/react-web-components/src/components/ReferenceField.tsx
+++ b/assets/react-web-components/src/components/ReferenceField.tsx
@@ -42,6 +42,8 @@ export interface ReferenceFieldProps {
   error?: string;
   /** カスタムクラス */
   className?: string;
+  /** ラベルのカスタムクラス名（縦並び時の左寄せなどに使用） */
+  labelClassName?: string;
 }
 
 /**
@@ -60,6 +62,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
   disabled = false,
   error,
   className,
+  labelClassName,
 }) => {
   // 翻訳フック（TranslationProvider外でも安全に使用可能）
   const { t } = useOptionalTranslation();
@@ -589,22 +592,47 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
 
   return (
     <div className={cn("flex items-start gap-2", className)}>
-      {/* ラベル（旧版スタイル：右寄せ） */}
-      <span
-        className={cn(
-          "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
-          disabled && "text-gray-400",
-        )}
-      >
-        {label}
-      </span>
-      {/* 必須マーク：固定幅で位置を確保し、入力欄の開始位置を揃える */}
-      <span
-        className="w-3 leading-[30px] text-red-500 text-center flex-shrink-0"
-        aria-hidden="true"
-      >
-        {mandatory ? "*" : ""}
-      </span>
+      {labelClassName ? (
+        <div className="flex items-baseline md:contents">
+          <span
+            className={cn(
+              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              disabled && "text-gray-400",
+              labelClassName,
+            )}
+          >
+            {label}
+            {mandatory && (
+              <span className="text-red-500" aria-hidden="true">
+                *
+              </span>
+            )}
+            {mandatory && <span className="sr-only"> (必須)</span>}
+          </span>
+          <span
+            className="w-3 flex-shrink-0 hidden md:block"
+            aria-hidden="true"
+          />
+        </div>
+      ) : (
+        <>
+          <span
+            className={cn(
+              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              disabled && "text-gray-400",
+            )}
+          >
+            {label}
+            {mandatory && <span className="sr-only"> (必須)</span>}
+          </span>
+          <span
+            className="w-3 leading-[30px] text-red-500 text-center flex-shrink-0"
+            aria-hidden="true"
+          >
+            {mandatory ? "*" : ""}
+          </span>
+        </>
+      )}
 
       {/* 入力エリア */}
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1757

##  不具合の内容 / Bug
1. クイック作成画面において、uitype=10 の参照フィールド（例: 案件モジュールの「顧客企業名」）のみ、入力欄の左端が他フィールドより約 12.5px 右にずれる。ラベル列と入力列の縦位置整列が崩れ、視覚的に不揃いになる。

##  原因 / Cause
1. `ReferenceField` コンポーネントが `labelClassName` プロップ未対応。`FieldRenderer` 経由でクイック作成フォームから渡される `labelClassName`（`md:contents` ラッパーを用いた desktop レイアウト整列パターン）が適用されない。
2. 結果、必須マーク用の `w-3` span が md+ ブレークポイントでも常時表示され（幅 7.5px + gap 5px = 12.5px 分）、入力欄が右にシフトする。
3. 他フィールド（`OwnerField` 等）は既に `labelClassName` プロップ対応済みで、md+ 時は必須マークをラベル span 内にインライン化＋スペーサーを `hidden md:block` で非表示にしている。

##  変更内容 / Details of Change
1. `assets/react-web-components/src/components/ReferenceField.tsx`
   - `ReferenceFieldProps` に `labelClassName?: string` を追加
   - コンポーネント引数に `labelClassName` を追加
   - `labelClassName` プロップ有無で `OwnerField` と同一の三項演算パターンでラベル部を分岐。`labelClassName` あり時は `md:contents` ラッパー内で必須マークをラベル span 内インライン化、スペーサーは `hidden md:block`。
2. `assets/react-web-components/src/components/FieldRenderer.tsx`
   - `<ReferenceField>` 呼出しに `labelClassName={labelClassName}` を追加

## スクリーンショット / Screenshot
別途添付予定（修正前: 顧客企業名が 12.5px 右にシフト / 修正後: 他フィールドと左端揃い）

## 影響範囲  / Affected Area
- `ReferenceField` を使用する全 uitype: 10, 51 (REFERENCE_ACCOUNT), 52 (REFERENCE_USER), 57 (REFERENCE_CONTACT), 58 (REFERENCE_CAMPAIGN), 59, 66, 73, 75, 76, 77, 78, 80, 81, 101
- クイック作成モーダル（`QuickCreateForm`）のレイアウト整列のみ改善。既存機能（検索・選択・クリア・Drawer）は変更なし。
- 詳細画面・編集画面（`labelClassName` を渡さないコンテキスト）は `labelClassName` 未指定時の従来分岐を維持しているため、挙動不変。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 動作確認: chrome-devtools MCP でクイック作成モーダルを開き、修正前 顧客企業名 input offset=127.5px、修正後 offset=115.0px（他フィールドと一致）を実測確認。
- 言語対応: 該当なし。UIコンポーネントのレイアウト調整のみで `languages/` 配下ファイル無変更。
- 関連: `MultireferenceField.tsx` にも同一パターン欠如あり。別 issue 起票候補（本 PR スコープ外）。
- ビルド: `npm run build` 成功確認済。