### PR TITLE
[修正] #1768 ワークフローのメール送信タスク編集画面でassigned_user_id未定義モジュールがFatalになる不具合修正

### DIFF
--- a/modules/Settings/Workflows/views/EditTask.php
+++ b/modules/Settings/Workflows/views/EditTask.php
@@ -136,8 +136,10 @@ class Settings_Workflows_EditTask_View extends Settings_Vtiger_Index_View {
 		}
         
         $usersModuleModel = Vtiger_Module_Model::getInstance('Users');
-        $emailFieldoptions .= '<option value=",$(general : (__VtigerMeta__) reports_to_id)"> '.
-                                    vtranslate($moduleModel->getField('assigned_user_id')->get('label'),'Users').' : (' . vtranslate('Users','Users') . ') '. vtranslate($usersModuleModel->getField('reports_to_id')->get('label'),'Users') .'</option>';
+        if($moduleModel->getField('assigned_user_id')) {
+            $emailFieldoptions .= '<option value=",$(general : (__VtigerMeta__) reports_to_id)"> '.
+                                        vtranslate($moduleModel->getField('assigned_user_id')->get('label'),'Users').' : (' . vtranslate('Users','Users') . ') '. vtranslate($usersModuleModel->getField('reports_to_id')->get('label'),'Users') .'</option>';
+        }
         
 		$nameFields = $recordStructureInstance->getNameFields();
 		$fromEmailFieldOptions = '<option value="">'. vtranslate('Optional', $qualifiedModuleName) .'</option>';


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1768

##  不具合の内容 / Bug
1. assigned_user_id フィールドを持たないモジュール（PriceBooks 等）に対するワークフロー「メール送信」タスクの編集画面を開くと Fatal error が発生する（`Call to a member function get() on false` in `modules/Settings/Workflows/views/EditTask.php`）。

##  原因 / Cause
1. `modules/Settings/Workflows/views/EditTask.php` で `$moduleModel->getField('assigned_user_id')->get('label')` を無条件で呼び出しているため、`getField()` が false を返すモジュールで `->get()` が Fatal となる。直下の `assignedrole` 側は if でガードされているが、`assigned_user_id` 側にガードが無かった。

##  変更内容 / Details of Change
1. `modules/Settings/Workflows/views/EditTask.php` の該当箇所を `if($moduleModel->getField('assigned_user_id')) { ... }` で囲み、`assignedrole` と同じパターンで戻り値をガードするよう修正。

## スクリーンショット / Screenshot
別途添付予定

## 影響範囲  / Affected Area
- ワークフロー設定「メール送信」タスクの編集画面
- assigned_user_id を持たないモジュール（PriceBooks 等）で Fatal を回避し、当該モジュールでは reports_to_id 用のオプション行が非表示となる（元々当該モジュールでは意味を成さないため意図された挙動）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 言語対応: 該当なし（言語ファイル `languages/` に変更なし）
- 「自らテストを行った」は未実施のためチェックせず。動作確認済であればチェック指示を下さい。