### PR TITLE
Fix/1767-[不具合] URL型項目のクイック編集で初回のみHTMLタグ（<a>タグ）が入力欄に表示される

### DIFF
--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1167,7 +1167,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			fieldName = multiPicklistFieldName[0];
 		}
 
-		var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','currencyList','text', 'documentsFolder'];
+		var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','currencyList','text', 'documentsFolder', 'url'];
 		if(jQuery.inArray(fieldType, customHandlingFields) !== -1){
 			value = rawValue;
 		}
@@ -1310,7 +1310,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			}
 
 			// prev Value should be taken based on field Type
-			var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','boolean']; 
+			var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','boolean', 'url']; 
 			if(jQuery.inArray(fieldType, customHandlingFields) !== -1){
 				previousValue = fieldBasicData.data('value');
 			}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1767

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1.  レコード詳細画面において、顧客企業の「Webサイト」などのURL型項目（uitype=17）の鉛筆アイコン（編集アイコン）をクリックしてクイック編集を開くと、初回表示時のみ入力欄にURL本体ではなくHTMLタグ付き文字列が表示される。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 詳細画面のクイック編集処理において、編集初期値に生値（data-value）を使用する対象フィールドリスト（customHandlingFields）にurl型が含まれておらず、リンク用HTMLタグ付きの表示値（data-displayvalue）が入力欄にセットされていたため。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. public/layouts/v7/modules/Vtiger/resources/Detail.js： publicajaxEditHandlingのURL型のクイック編集要素を初回生成する際、初期値としてHTML文字列であるdata-displayvalueではなく生値であるdata-valueをセットするように変更。
2. public/layouts/v7/modules/Vtiger/resources/Detail.js： registerAjaxEditSaveEventの保存処理前の差分チェック（変更があったかどうかの判定）において、比較対象のpreviousValueに生値であるdata-valueを使用するように変更。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前の初回クリック時
<img width="469" height="48" alt="image" src="https://github.com/user-attachments/assets/4c4df067-b708-465c-b523-251576b2228c" />

変更後の初回クリック時
<img width="463" height="47" alt="image" src="https://github.com/user-attachments/assets/ee6df06f-1957-44f3-9193-7453c413f2f4" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
全モジュールの詳細画面における URL型項目（uitype=17）のクイック編集機能。

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->