### PR TITLE
[修正] #1771 インポートで参照項目の従来形式「モジュール名::::レコード名」が全行スキップされる問題を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -602,8 +602,29 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 						if (php7_count($fieldValueDetails) > 1) {
 							$referenceModuleName = trim($fieldValueDetails[0]);
-							$referenceValueList = $fieldDetails;
-							$entityId = getEntityIdByColumns($referenceModuleName, $referenceValueList, $cache);
+							if (empty($fieldDetails) && php7_count($fieldValueDetails) == 2) {
+								// 従来形式「モジュール名::::レコード名」の場合はラベルで参照解決する（7.4.2までの動作）
+								// 「====」を含まない値をgetEntityIdByColumnsに渡すとImportExceptionにより行全体がスキップされるため
+								$entityLabel = trim($fieldValueDetails[1]);
+								if ($referenceModuleName == 'Users') {
+									$query = "SELECT id FROM vtiger_users WHERE trim(concat(last_name,' ',first_name)) = ? ;";
+									$result = $adb->pquery($query, array($entityLabel));
+									if ($adb->num_rows($result) > 0) {
+										$entityId = $adb->query_result($result, 0, "id");
+									} elseif ($fieldInstance->isMandatory()) {
+										$entityId = $this->user->id;
+									}
+								} else {
+									try {
+										$entityId = getEntityId($referenceModuleName, decode_html($entityLabel));
+									} catch (ImportException $e) {
+										$entityId = 0;
+									}
+								}
+							} else {
+								$referenceValueList = $fieldDetails;
+								$entityId = getEntityIdByColumns($referenceModuleName, $referenceValueList, $cache);
+							}
 						} else {
 							$referencedModules = $fieldInstance->getReferenceList();
 							$entityLabel = $referenceEntry;


### PR DESCRIPTION
## 概要

close #1771

CSVインポートで、参照項目（uitype 10）の値に従来形式 `モジュール名::::レコード名`（例: `ServiceContracts::::契約A`）を指定すると、参照先レコードが存在していても全行がスキップされる問題を修正します。7.4.2までは取り込めていた形式のため、バージョンアップ後に既存のCSV資産が読めなくなるリグレッションです。

## 原因

`transformForImport()` では `::::` を含む値（分割後2要素以上）が一律 `getEntityIdByColumns()` に渡されますが、この関数は新形式「`モジュール名::::列名====値`」専用です。従来形式では `====` が含まれず `$fieldDetails` が空のまま渡されるため、`getEntityIdByColumns()` 冒頭の

```php
if (empty($cache[$module])||empty($referenceValueList)){
    throw new ImportException("No reference exists");
}
```

により `ImportException` がスローされ、行全体がスキップ扱いになります。

## 修正内容

分割後がちょうど2要素かつ `====` を含まない（＝従来形式の）場合に限り、7.4.2までのラベルによる参照解決（`getEntityId()`、Usersは氏名検索）にフォールバックするようにしました。新形式（`列名====値`）および単独ラベル形式の動作は従来どおり変更ありません。

## 動作確認

- F-RevoCRM 8.0.3（PHP 8.4.20 / MariaDB 10.5）の実環境で、チケット（HelpDesk）へ従来形式の参照値（`ServiceContracts::::…` を含むCSV 3行）をインポートし、スキップされず正常に登録されることを確認
- 新形式（8.0のエクスポートで出力したCSV）のインポートが従来どおり成功することを確認
- 参照解決失敗時は従来同様、行をスキップせず参照項目のみ空で登録されます
