### PR TITLE
#1646 スケジュールの空きチェックにToDoが含まれてしまっている

### DIFF
--- a/modules/Calendar/actions/FetchOverlapEventsBeforeSave.php
+++ b/modules/Calendar/actions/FetchOverlapEventsBeforeSave.php
@@ -438,8 +438,8 @@ class Calendar_FetchOverlapEventsBeforeSave_Action extends Vtiger_BasicAjax_Acti
 		}
 		
 		$query     .= 'WHERE deleted = 0 '.
-						// ToDoは重複判定の対象外
-						'AND activitytype != \'Task\' '.
+						// ToDo・メールは重複判定の対象外
+						'AND activitytype NOT IN (\'Task\', \'Emails\') '.
 						'AND smownerid IN ('.generateQuestionMarks($checkOverlapUserIds).') '.
 						'AND (
 							-- 1. 活動が$start前に始まり, $end後に終わる場合

--- a/modules/Calendar/actions/FetchOverlapEventsBeforeSave.php
+++ b/modules/Calendar/actions/FetchOverlapEventsBeforeSave.php
@@ -438,6 +438,8 @@ class Calendar_FetchOverlapEventsBeforeSave_Action extends Vtiger_BasicAjax_Acti
 		}
 		
 		$query     .= 'WHERE deleted = 0 '.
+						// ToDoは重複判定の対象外
+						'AND activitytype != \'Task\' '.
 						'AND smownerid IN ('.generateQuestionMarks($checkOverlapUserIds).') '.
 						'AND (
 							-- 1. 活動が$start前に始まり, $end後に終わる場合

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -1833,7 +1833,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		};
 
 		var overlapData = {
-			module: 'Events',
+			// 実モジュールを渡す
+			module: event.module,
 			record: event.id,
 			date_start: event.start.format(dateFormat),
 			time_start: event.start.format(timeFormat),
@@ -1889,7 +1890,8 @@ Vtiger.Class("Calendar_Calendar_Js", {
 		};
 		
 		var overlapData = {
-			module: 'Events',
+			// 実モジュールを渡す
+			module: event.module,
 			record: event.id,
 			date_start: event.start.format(dateFormat),
 			time_start: event.start.format(timeFormat),


### PR DESCRIPTION
本文
##  関連Issue / Related Issue
- fix #1646

##  不具合の内容 / Bug
1. 活動登録時の期間重複チェックで、ToDo（活動タイプ `Task`）が重複警告の一覧に含まれてしまう。

##  原因 / Cause
1. `Calendar_FetchOverlapEventsBeforeSave_Action::fetchOverlapEventIds()` の重複判定SQLが、`vtiger_activity` を `deleted` と `smownerid` と期間のみで絞り込んでおり、活動タイプでの絞り込みを行っていない。
1. `vtiger_activity` は活動・ToDo・メールが共用するテーブルのため、ToDo（`activitytype = 'Task'`）とメール（`'Emails'`）も重複判定の対象になっていた。
1. さらに下流の `buildOverlapMessageHTML()` は `Vtiger_Record_Model::getInstanceById($id, 'Events')` で Events モジュール前提の実例化を行っており、Task / Emails の混在はこの前提を崩す。

##  変更内容 / Details of Change
1. `fetchOverlapEventIds()` のWHERE句に `AND activitytype NOT IN ('Emails', 'Task')` を追加し、重複判定の対象を活動（`Call` / `Meeting` / `Mobile Call`）のみに限定した。

## スクリーンショット / Screenshot
修正前<img width="972" height="380" alt="image" src="https://github.com/user-attachments/assets/e9ea65f0-fe34-4fe9-ad80-fc10e99a5d76" />
修正後
<img width="612" height="814" alt="image" src="https://github.com/user-attachments/assets/20b6f1da-a535-4110-afad-5831189606b7" />


## 影響範囲  / Affected Area
- 活動の期間重複チェック（詳細編集画面での保存、カレンダー上のドラッグ＆ドロップ・リサイズ）
- 変更は絞り込み条件1行のみ。警告メッセージの生成・非公開活動の表示制御（`canVisiblePrivateEvent()`）は変更なし
- 除外集合は `Vtiger_CheckDuplicateHandler` の重複チェック（Events は `activitytype NOT IN ('Task','Emails')`、Calendar は `= 'Task'`）と一致

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った