### PR TITLE
#1618 スケジュールレポートのCSV出力件数が画面表示より少なくなる不具合を修正

### DIFF
--- a/modules/Reports/models/ScheduleReports.php
+++ b/modules/Reports/models/ScheduleReports.php
@@ -334,7 +334,7 @@ class Reports_ScheduleReports_Model extends Vtiger_Base_Model {
 			if($reportType == 'chart') {
 				$status = $scheduledReport->sendEmail();
 			} else {
-				$query = $reportRecordModel->getReportSQL();
+				$query = $reportRecordModel->getReportSQL(false, 'PDF');
 				$countQuery = $reportRecordModel->generateCountQuery($query);
 				if($reportRecordModel->getReportsCount($countQuery) > 0){
 					$status = $scheduledReport->sendEmail();


### PR DESCRIPTION
本文
##  関連Issue / Related Issue
- fix #1618

##  不具合の内容 / Bug
1. スケジュールレポートで出力されるレポートの件数が、画面表示の件数より少なくなる。

1. `Reports_ScheduleReports_Model::runScheduledReports()` が `Reports_Record_Model::getReportSQL()` を引数なしで呼んでおり、出力フォーマット未指定（既定値 `$format = false`）のままSQLが生成されていた。
1. `ReportRun::getQueryColumnsList()` は出力フォーマットが `HTML` / `PDF` / `PRINT` のときのみ選択列に `vtiger_crmentity.crmid AS <Module>_LBL_ACTION` を追加する。フォーマット未指定ではこの列が付かない。
1. レポートSQLは `SELECT DISTINCT` のため、一意キーとなる `crmid` を欠くと「選択列の値がすべて同一の別レコード」が1件に集約され、件数が減る。画面表示は `GenerateReport('PDF', ...)` 経由で `crmid` を含むため件数が正しく、スケジュール実行との差が生じていた。

##  変更内容 / Details of Change
1. `runScheduledReports()` の呼び出しを `getReportSQL(false, 'PDF')` に変更し、画面表示と同じ選択列でSQLを生成するようにした。
1. `getReportSQL()` の呼び出し点はリポジトリ内に2箇所のみで、もう一方の `Reports_DetailAjax_Action`（画面の件数表示）はすでに `'PDF'` を指定している。本変更はこれに揃えるもの。

## スクリーンショット / Screenshot
画面出力
<img width="524" height="394" alt="image" src="https://github.com/user-attachments/assets/666ac5f7-9031-485e-872b-db8e5c4b9612" />
<img width="545" height="402" alt="image" src="https://github.com/user-attachments/assets/6e114684-5d62-45a9-9c14-1c343a0ba2ec" />
Cron出力
<img width="1212" height="706" alt="image" src="https://github.com/user-attachments/assets/0042cd8b-c87e-4a9f-b075-9a2efd25b715" />
<img width="706" height="652" alt="image" src="https://github.com/user-attachments/assets/d34cbf52-d102-4d08-a642-083414ff81e7" />
<img width="1210" height="697" alt="image" src="https://github.com/user-attachments/assets/db10b822-9533-40cc-8009-c1b7d8e7b784" />
<img width="606" height="463" alt="image" src="https://github.com/user-attachments/assets/18706a82-d430-482e-a171-e27b15fa118b" />

## 影響範囲  / Affected Area
- スケジュールレポートの件数判定（`getReportsCount()`）およびメール添付されるレポートの内容
- 変更箇所はスケジュール実行経路のみ。画面からのレポート表示・手動出力は変更なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った