### PR TITLE
Fix/1765　見積等の品目に表示名称の欄を追加

### DIFF
--- a/include/InventoryPDFController.php
+++ b/include/InventoryPDFController.php
@@ -131,6 +131,9 @@ class Vtiger_InventoryPDFController {
 			$totaltaxes = number_format($totaltaxes, $no_of_decimal_places,'.','');
 			$discountPercentage = $productLineItem["discount_percent{$productLineItemIndex}"];
 			$productName = decode_html($productLineItem["productName{$productLineItemIndex}"]);
+			if (!empty($productLineItem["displayname{$productLineItemIndex}"])) {
+				$productName = decode_html($productLineItem["displayname{$productLineItemIndex}"]);
+			}
 			//get the sub product
 			$subProducts = $productLineItem["subProductArray{$productLineItemIndex}"];
 			if($subProducts != '') {
@@ -748,6 +751,9 @@ class Vtiger_InventoryPDFController {
 		foreach($relatedProducts as $key => $product) {
 			$block = $blocktemplate;
 			$product = self::getPDFDisplayValue($product, $cnt);
+			if (!empty($product["displayname{$cnt}"])) {
+				$product["productName{$cnt}"] = $product["displayname{$cnt}"];
+			}
 			foreach($product as $name => $value) {
 				if(is_array($value)) {
 					continue;

--- a/include/utils/EditViewUtils.php
+++ b/include/utils/EditViewUtils.php
@@ -194,6 +194,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		$productname=$adb->query_result($result,$i-1,'productname');
 		$productdescription=$adb->query_result($result,$i-1,'description');
 		$comment=$adb->query_result($result,$i-1,'comment');
+		$displayname=$adb->query_result($result,$i-1,'displayname');
 		$qtyinstock=$adb->query_result($result,$i-1,'qtyinstock');
 		$qty=$adb->query_result($result,$i-1,'quantity');
 		$unitprice=$adb->query_result($result,$i-1,'unit_price');
@@ -292,6 +293,7 @@ function getAssociatedProducts($module, $focus, $seid = '', $refModuleName = fal
 		}else {
             $product_Detail[$i]['comment'.$i]= $comment;
 		}
+		$product_Detail[$i]['displayname'.$i] = from_html($displayname);
 
 		if($module != 'PurchaseOrder' && $focus->object_name != 'Order') {
 			$checkpresenceresult = $adb->pquery("SELECT * FROM vtiger_field WHERE fieldname=? AND tabid=?",array("qtyinstock", Vtiger_Functions::getModuleId('Products')));

--- a/include/utils/InventoryUtils.php
+++ b/include/utils/InventoryUtils.php
@@ -661,6 +661,7 @@ function saveInventoryProductDetails(&$focus, $module, $update_prod_stock='false
         $qty = vtlib_purify($_REQUEST['qty'.$i]);
         $listprice = vtlib_purify($_REQUEST['listPrice'.$i]);
 		$comment = vtlib_purify($_REQUEST['comment'.$i]);
+		$displayname = vtlib_purify($_REQUEST['displayname'.$i]);
 		$purchaseCost = vtlib_purify($_REQUEST['purchaseCost'.$i]);
 		$margin = vtlib_purify($_REQUEST['margin'.$i]);
 		$usageunit = vtlib_purify($_REQUEST['usageunit'.$i]);
@@ -677,9 +678,9 @@ function saveInventoryProductDetails(&$focus, $module, $update_prod_stock='false
 			}
 		}
 
-		$query = 'INSERT INTO vtiger_inventoryproductrel(id, productid, sequence_no, quantity, listprice, comment, description, purchase_cost, margin, usageunit, reducedtaxrate)
-		VALUES(?,?,?,?,?,?,?,?,?,?,?)';
-		$qparams = array($focus->id,$prod_id,$prod_seq,$qty,$listprice,$comment,$description, $purchaseCost, $margin, $usageunit, $reducedtaxrate);
+		$query = 'INSERT INTO vtiger_inventoryproductrel(id, productid, sequence_no, quantity, listprice, comment, description, purchase_cost, margin, usageunit, reducedtaxrate, displayname)
+		VALUES(?,?,?,?,?,?,?,?,?,?,?,?)';
+		$qparams = array($focus->id,$prod_id,$prod_seq,$qty,$listprice,$comment,$description, $purchaseCost, $margin, $usageunit, $reducedtaxrate, $displayname);
 		$adb->pquery($query,$qparams);
 
 		$lineitem_id = $adb->getLastInsertID();

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -1659,6 +1659,8 @@ $languageStrings = array(
 	'LBL_TASK_SEND_EMAIL_WHEN_COMMENTED' => 'Workflow to Send an Email to a Portal User Who Is a Customer Representative When a Comment Is Added',
 	'LBL_A_WORKFLOW_TO_SEND_AN_EMAIL_WHEN_A_COMMENT_IS_ADDED' => 'Workflow to Send an Email When a Comment Is Added',
 	'LBL_ELIGIBLE_FOR_REDUCED_TAX_RATE' => 'Eligible for Reduced Tax Rate',
+	'LBL_DISPLAY_NAME' => 'Display Name',
+	'LBL_DISPLAY_NAME_PLACEHOLDER' => 'Uses product name if left blank',
 	'LBL_TESTMAIL_SMTP_BODY' => 'Dear <br><br><b>This is a test email sent to verify if the configured SMTP server is working correctly.</b><br>You may delete this email.<br><br>Best regards,<br>F-RevoCRM<br><br>',
 	
 	

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1664,6 +1664,8 @@ $languageStrings = array(
 	'LBL_TASK_SEND_EMAIL_WHEN_COMMENTED' => 'コメントが追加されたときポータルユーザーである顧客担当者にメールを送るワークフロー',
 	'LBL_A_WORKFLOW_TO_SEND_AN_EMAIL_WHEN_A_COMMENT_IS_ADDED' => 'コメントが追加された際にメールを送るワークフロー',
 	'LBL_ELIGIBLE_FOR_REDUCED_TAX_RATE' => '軽減税率対象',
+	'LBL_DISPLAY_NAME' => '表示名称',
+	'LBL_DISPLAY_NAME_PLACEHOLDER' => '未入力の場合は商品名を表示',
 	'LBL_TESTMAIL_SMTP_BODY' => 'さん <br><br><b> これは、設定したSMTPサーバーを介してメールが実際に送信され' .
 			'ているかどうかを確認するために送信されるテストメールです。 </b><br>削除していただいてかまいません。' .
 			'<br><br>よろしくお願いいたします。<br> F-RevoCRM <br><br>',

--- a/layouts/v7/modules/Inventory/LineItemsDetail.tpl
+++ b/layouts/v7/modules/Inventory/LineItemsDetail.tpl
@@ -21,6 +21,7 @@
 {assign var=LIST_PRICE_VIEWABLE value=false}
 {assign var=MARGIN_VIEWABLE value=false}
 {assign var=COMMENT_VIEWABLE value=false}
+{assign var=DISPLAYNAME_VIEWABLE value=false}
 {assign var=ITEM_DISCOUNT_AMOUNT_VIEWABLE value=false}
 {assign var=ITEM_DISCOUNT_PERCENT_VIEWABLE value=false}
 {assign var=SH_PERCENT_VIEWABLE value=false}
@@ -53,6 +54,9 @@
 {/if}
 {if $LINEITEM_FIELDS['comment']}
     {assign var=COMMENT_VIEWABLE value=$LINEITEM_FIELDS['comment']->isViewable()}
+{/if}
+{if $LINEITEM_FIELDS['displayname']}
+    {assign var=DISPLAYNAME_VIEWABLE value=$LINEITEM_FIELDS['displayname']->isViewable()}
 {/if}
 {if $LINEITEM_FIELDS['discount_amount']}
     {assign var=ITEM_DISCOUNT_AMOUNT_VIEWABLE value=$LINEITEM_FIELDS['discount_amount']->isViewable()}
@@ -164,6 +168,11 @@
                                 <div>
                                     {$LINE_ITEM_DETAIL["subprod_names$INDEX"]}
                                 </div>
+                                {if $DISPLAYNAME_VIEWABLE && !empty($LINE_ITEM_DETAIL["displayname$INDEX"])}
+                                    <div>
+                                        <strong>{vtranslate('LBL_DISPLAY_NAME',$MODULE)}:</strong> {decode_html($LINE_ITEM_DETAIL["displayname$INDEX"])}
+                                    </div>
+                                {/if}
                                 {if $COMMENT_VIEWABLE && !empty($LINE_ITEM_DETAIL["productName$INDEX"])}
                                     <div>
                                         {decode_html($LINE_ITEM_DETAIL["comment$INDEX"])|nl2br}

--- a/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsContent.tpl
@@ -15,6 +15,7 @@
     {assign var="hdnProductId" value="hdnProductId"|cat:$row_no}
     {assign var="productName" value="productName"|cat:$row_no}
     {assign var="comment" value="comment"|cat:$row_no}
+    {assign var="displayname" value="displayname"|cat:$row_no}
     {assign var="productDescription" value="productDescription"|cat:$row_no}
     {assign var="qtyInStock" value="qtyInStock"|cat:$row_no}
     {assign var="qty" value="qty"|cat:$row_no}
@@ -125,6 +126,12 @@
 					{/if}
 				</div>
 			{else}
+				{if $DISPLAYNAME_EDITABLE}
+					<div><br>
+						<label class="lineItemDisplayNameLabel">{vtranslate('LBL_DISPLAY_NAME',$MODULE)}</label>
+						<input type="text" id="{$displayname}" name="{$displayname}" class="lineItemDisplayNameBox form-control" style="width: 400px; max-width: 650px;" placeholder="{vtranslate('LBL_DISPLAY_NAME_PLACEHOLDER',$MODULE)}" value="{decode_html($data.$displayname)}">
+					</div>
+				{/if}
 				{if $COMMENT_EDITABLE}
 					<div><br><textarea id="{$comment}" name="{$comment}" class="lineItemCommentBox" style="width: 400px; max-width: 650px; height:150px;">{decode_html($data.$comment)}</textarea></div>
 				{/if}

--- a/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
+++ b/layouts/v7/modules/Inventory/partials/LineItemsEdit.tpl
@@ -38,6 +38,9 @@
 {if $LINEITEM_FIELDS['comment']}
 	{assign var=COMMENT_EDITABLE value=$LINEITEM_FIELDS['comment']->isEditable()}
 {/if}
+{if $LINEITEM_FIELDS['displayname']}
+	{assign var=DISPLAYNAME_EDITABLE value=$LINEITEM_FIELDS['displayname']->isEditable()}
+{/if}
 {if $LINEITEM_FIELDS['discount_amount']}
 	{assign var=ITEM_DISCOUNT_AMOUNT_EDITABLE value=$LINEITEM_FIELDS['discount_amount']->isEditable()}
 {/if}

--- a/modules/Inventory/models/Record.php
+++ b/modules/Inventory/models/Record.php
@@ -658,6 +658,7 @@ class Inventory_Record_Model extends Vtiger_Record_Model {
 			$productData["hdnProductId$i"]	= $productId;
 			$productData["productName$i"]	= $itemRecordModel->getName();
 			$productData["comment$i"]		= $requestData["comment$i"];
+			$productData["displayname$i"]	= $requestData["displayname$i"];
 			$productData["qtyInStock$i"]	= $itemRecordModel->get('qtyinstock');
 			$productData["qty$i"]			= $requestData["qty$i"];
 			$productData["listPrice$i"]		= number_format($requestData["listPrice$i"], $noOfDecimalPlaces, '.', '');

--- a/setup/migration/scripts/20260807131934_add_displayname_to_lineitems.php
+++ b/setup/migration/scripts/20260807131934_add_displayname_to_lineitems.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * マイグレーション: add_displayname_to_lineitems
+ * 生成日時: 20260807131934
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260807131934_AddDisplaynameToLineitems extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     * 見積・受注・発注・請求の品目(LBL_ITEM_DETAILS)に「表示名称」列を追加する
+     */
+    public function process() {
+        $moduleNames = array('Quotes', 'PurchaseOrder', 'SalesOrder', 'Invoice');
+        foreach ($moduleNames as $moduleName) {
+            $moduleInstance = Vtiger_Module::getInstance($moduleName);
+            $blockInstance = Vtiger_Block::getInstance('LBL_ITEM_DETAILS', $moduleInstance);
+
+            $field = new Vtiger_Field();
+            $field->name        = 'displayname';
+            $field->label       = 'LBL_DISPLAY_NAME';
+            $field->table       = 'vtiger_inventoryproductrel';
+            $field->column      = 'displayname';
+            $field->columntype  = 'VARCHAR(255)';
+            $field->uitype      = 19;
+            $field->typeofdata  = 'V~O';
+            $field->readonly    = 0;
+            $field->displaytype = 5;
+            $field->masseditable = 1;
+            $blockInstance->addField($field);
+
+            $this->log("{$moduleName} に displayname フィールドを追加しました");
+        }
+
+        $this->log("マイグレーション add_displayname_to_lineitems が正常に完了しました");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1765

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 見積、受注、発注、請求モジュールの品目欄に表示名称の欄を追加してほしい。
2. 請求書などでは表示名称を表示することで、自由な品名を表示できるようにしたい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. vtiger_inventoryproductrel に displayname (表示名称)列を追加するマイグレーションを実装（見積/受注/発注/請求の4モジュール共通）
2. 品目の保存・読み込み処理に表示名称の入出力を追加
3. 編集画面・詳細画面に表示名称の入力/表示欄を追加（既存の「備考」欄と同様の位置）
4. PDFテンプレート／PDF出力で、表示名称が入力されていれば商品名の代わりに印字するよう対応（未入力時は従来通りマスタ商品名を使用、既存テンプレートへの影響なし）

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
表示名称を品目の下に追加
<img width="128" height="125" alt="image" src="https://github.com/user-attachments/assets/22d49689-e356-4921-9916-0f25acb81e30" />
請求書等では商品名を表示名称で記載
<img width="153" height="90" alt="image" src="https://github.com/user-attachments/assets/9b78acaf-7c6d-4c89-b2f2-1c7fc63a238c" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
見積・受注・発注・請求の4モジュール

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->