### PR TITLE
Fix/1759-[要望] リストで複数の条件でソートをしたい

### DIFF
--- a/include/QueryGenerator/EnhancedQueryGenerator.php
+++ b/include/QueryGenerator/EnhancedQueryGenerator.php
@@ -875,13 +875,21 @@ class EnhancedQueryGenerator extends QueryGenerator {
 	 */
 	function getOrderByColumn($fieldName) {
 		$fieldList = $this->getModuleFields();
-		$orderByFieldModel = $fieldList[$fieldName];
 
 		$parentReferenceField = '';
+		$referenceModule = '';
 		preg_match('/(\w+) ; \((\w+)\) (\w+)/', $fieldName, $matches);
 		if (php7_count($matches) != 0) {
 			list($full, $parentReferenceField, $referenceModule, $fieldName) = $matches;
 		}
+		if (!empty($parentReferenceField) && !empty($referenceModule)) {
+			$referenceModuleMeta = $this->getMeta($referenceModule);
+			$referenceModuleFields = $referenceModuleMeta ? $referenceModuleMeta->getModuleFields() : array();
+			$orderByFieldModel = isset($referenceModuleFields[$fieldName]) ? $referenceModuleFields[$fieldName] : null;
+		} else {
+			$orderByFieldModel = isset($fieldList[$fieldName]) ? $fieldList[$fieldName] : null;
+		}
+		$orderByColumn = '';
 		if ($orderByFieldModel && $orderByFieldModel->getFieldDataType() == 'reference') {
 			$referenceModules = $orderByFieldModel->getReferenceList();
 			if (in_array('DocumentFolders', $referenceModules)) {
@@ -907,7 +915,7 @@ class EnhancedQueryGenerator extends QueryGenerator {
 			} else {
 				$orderByColumn = 'COALESCE(CONCAT(vtiger_users.last_name,vtiger_users.first_name),vtiger_groups.groupname)';
 			}
-		} else if (($orderByFieldModel->getFieldName() == 'taskstatus' || $orderByFieldModel->getFieldName() == 'eventstatus') && $this->module == 'Calendar') {
+		} else if ($orderByFieldModel && ($orderByFieldModel->getFieldName() == 'taskstatus' || $orderByFieldModel->getFieldName() == 'eventstatus') && $this->module == 'Calendar') {
 			$orderByColumn = 'status';
 		} else if ($orderByFieldModel) {
 			$orderByColumn = $orderByFieldModel->getTableName().$parentReferenceField.'.'.$orderByFieldModel->getColumnName();

--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -1239,6 +1239,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'Share the list',
+	'LBL_DEFAULT_SORT' => 'Set default sort',
 	'LBL_ADD_USERS_ROLES' => 'Add Users, Roles...',
 	'EmailTemplates' => 'Email Templates',
 	'LBL_BILLING' => 'Billing',
@@ -1721,6 +1722,13 @@ $languageStrings = array(
 	'LBL_PLACEHOLDER_SEARCH_AND_ADD' => 'Search and add %s...',
 	'LBL_PLACEHOLDER_SEARCH_TITLE' => 'Search %s',
 	'LBL_PLACEHOLDER_SELECT' => 'Select %s',
+
+	//Custom view default sort translations.
+	'LBL_SORT_CONDITION_LABEL' => 'Sort %s:',
+	'LBL_ASCENDING' => 'Ascending',
+	'LBL_DESCENDING' => 'Descending',
+	'LBL_ADD_SORT_ROW' => 'Add sort condition',
+	'LBL_REMOVE_SORTING' => 'Remove sorting for this column',
 );
 
 $jsLanguageStrings = array(
@@ -2269,6 +2277,14 @@ $jsLanguageStrings = array(
 	'JS_MAIL_DRAFTED_SUCCESSFULLY'=>'Mail drafted successfully',
 
 	//Custom view default sort translations.
+	'LBL_SORT_CONDITION_LABEL' => 'Sort %s:',
+	'JS_MAX_SORT_CONDITIONS_LIMIT' => 'You can specify up to 5 sort conditions maximum.',
+	'JS_PLEASE_SELECT_SORT_ORDER' => 'Please select a sort order (Ascending or Descending).',
+	'JS_DUPLICATE_SORT_FIELD_NOT_ALLOWED' => 'Duplicate fields are not allowed in sort conditions.',
+	'LBL_ASCENDING' => 'Ascending',
+	'LBL_DESCENDING' => 'Descending',
+	'LBL_ADD_SORT_ROW' => 'Add sort condition',
+	'LBL_REMOVE_SORTING' => 'Remove sorting for this column',
 	'JS_PLEASE_REMOVE_ONE_FIELD_FROM_CHOOSE_COLUMNS_LIST_TO_ADD_DEFAULT_SORT_FIELD' => 'Only 16 columns are allowed in a list view including sort columns.',
 	'JS_DEFAULT_SORT_NOTIFY' => 'List is now sorted on default sort column ',
 	'JS_ENABLED' => 'Enabled',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1244,7 +1244,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'リストを共有',
-	'LBL_DEFAULT_SORT' => '並び順',
+	'LBL_DEFAULT_SORT' => 'デフォルトのソートを設定',
 	'LBL_ADD_USERS_ROLES' => 'ユーザー、役割の追加',
 	'EmailTemplates' => 'メールテンプレート',
 	'LBL_BILLING' => '請求',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1244,6 +1244,7 @@ $languageStrings = array(
 	'LBL_MARKET_PLACE' => 'Market Place',
 
 	'LBL_SHARE_THIS_LIST' => 'リストを共有',
+	'LBL_DEFAULT_SORT' => '並び順',
 	'LBL_ADD_USERS_ROLES' => 'ユーザー、役割の追加',
 	'EmailTemplates' => 'メールテンプレート',
 	'LBL_BILLING' => '請求',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -1727,6 +1727,13 @@ $languageStrings = array(
 	'LBL_PLACEHOLDER_SEARCH_AND_ADD' => '%sを検索して追加...',
 	'LBL_PLACEHOLDER_SEARCH_TITLE' => '%sを検索',
 	'LBL_PLACEHOLDER_SELECT' => '%sを選択してください',
+
+	//Custom view default sort translations.
+	'LBL_SORT_CONDITION_LABEL' => '第%sソート:',
+	'LBL_ASCENDING' => '昇順',
+	'LBL_DESCENDING' => '降順',
+	'LBL_ADD_SORT_ROW' => 'ソート条件を追加',
+	'LBL_REMOVE_SORTING' => 'この項目のソートを解除',
 );
 
 $jsLanguageStrings = array(
@@ -2276,6 +2283,14 @@ $jsLanguageStrings = array(
 	'JS_MAIL_DRAFTED_SUCCESSFULLY'=>'メールが下書きされました',
 
 	//Custom view default sort translations.
+	'LBL_SORT_CONDITION_LABEL' => '第%sソート:',
+	'JS_MAX_SORT_CONDITIONS_LIMIT' => 'ソート条件は最大5個まで指定できます。',
+	'JS_PLEASE_SELECT_SORT_ORDER' => 'ソート順（昇順・降順）を選択してください。',
+	'JS_DUPLICATE_SORT_FIELD_NOT_ALLOWED' => '同じ項目を複数のソート条件に指定することはできません。',
+	'LBL_ASCENDING' => '昇順',
+	'LBL_DESCENDING' => '降順',
+	'LBL_ADD_SORT_ROW' => 'ソート条件を追加',
+	'LBL_REMOVE_SORTING' => 'この項目のソートを解除',
 	'JS_PLEASE_REMOVE_ONE_FIELD_FROM_CHOOSE_COLUMNS_LIST_TO_ADD_DEFAULT_SORT_FIELD' => 'ソート列を含むリストビューでは、16列のみが許可されます。',
 	'JS_DEFAULT_SORT_NOTIFY' => 'リストがデフォルトのソート列でソートされるようになりました',
 	'JS_ENABLED' => '有効',

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -113,7 +113,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
-								<input type="hidden" name="orderby" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
+								<input type="hidden" name="orderby" id="saved_orderby" value='{$CUSTOMVIEW_MODEL->get("orderby")}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -125,13 +125,29 @@
 							</div>
 						</div>
 						<div class="form-group clearfix">
-							<div class="col-sm-2 col-xs-2">
-								<label>
+							<div class="col-sm-2 col-xs-12">
+								<label style="margin-top: 5px;">
 										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
 								</label>
 							</div>
-							<div class=" row col-sm-5 col-xs-5">
-								<select id='orderby' class="select2-container select2">
+							<div class="col-sm-4 col-xs-7">
+								<select id='orderby' name='orderby' class="select2 form-control">
+									<option value="">{vtranslate('LBL_NONE',$MODULE)}</option>
+									{foreach key=BLOCK_LABEL item=BLOCK_FIELDS from=$RECORD_STRUCTURE}
+										<optgroup label='{vtranslate($BLOCK_LABEL, $SOURCE_MODULE)}'>
+											{foreach key=FIELD_NAME item=FIELD_MODEL from=$BLOCK_FIELDS}
+												<option value="{$FIELD_MODEL->get('name')}" {if $CUSTOMVIEW_MODEL->get('orderby') eq $FIELD_MODEL->get('name')}selected{/if}>
+													{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE))}
+												</option>
+											{/foreach}
+										</optgroup>
+									{/foreach}
+								</select>
+							</div>
+							<div class="col-sm-3 col-xs-5">
+								<select id='sortorder' name='sortorder' class="select2 form-control">
+									<option value="ASC" {if $CUSTOMVIEW_MODEL->get('sortorder') neq 'DESC'}selected{/if}>{vtranslate('LBL_ASCENDING', $MODULE)}</option>
+									<option value="DESC" {if $CUSTOMVIEW_MODEL->get('sortorder') eq 'DESC'}selected{/if}>{vtranslate('LBL_DESCENDING', $MODULE)}</option>
 								</select>
 							</div>
 						</div>

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -125,7 +125,7 @@
 							</div>
 						</div>
 						<div class="form-group clearfix">
-							<div class="col-sm-1 col-xs-2">
+							<div class="col-sm-2 col-xs-2">
 								<label>
 										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
 								</label>

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -113,6 +113,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
+								<input type="hidden" name="orderby" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -121,6 +122,17 @@
 							<label class="filterHeaders">{vtranslate('LBL_CHOOSE_FILTER_CONDITIONS', $MODULE)} :</label>
 							<div class="filterElements well filterConditionContainer filterConditionsDiv">
 								{include file='AdvanceFilter.tpl'|@vtemplate_path}
+							</div>
+						</div>
+						<div class="form-group clearfix">
+							<div class="col-sm-1 col-xs-2">
+								<label>
+										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
+								</label>
+							</div>
+							<div class=" row col-sm-5 col-xs-5">
+								<select id='orderby' class="select2-container select2">
+								</select>
 							</div>
 						</div>
 						<div class="checkbox">

--- a/layouts/v7/modules/CustomView/EditView.tpl
+++ b/layouts/v7/modules/CustomView/EditView.tpl
@@ -113,7 +113,7 @@
 									{/foreach}
 								</select>
 								<input type="hidden" name="columnslist" value='{Vtiger_Functions::jsonEncode($SELECTED_FIELDS)}' />
-								<input type="hidden" name="orderby" id="saved_orderby" value='{$CUSTOMVIEW_MODEL->get("orderby")}' />
+								<input type="hidden" id="saved_orderby" value='{$CUSTOMVIEW_MODEL->get("orderby")}' />
 								<input id="mandatoryFieldsList" type="hidden" value='{Vtiger_Util_Helper::toSafeHTML(ZEND_JSON::encode($MANDATORY_FIELDS))}' />
 							</div>
 							<div class="col-lg-2 col-md-2 col-sm-2"></div>
@@ -124,30 +124,65 @@
 								{include file='AdvanceFilter.tpl'|@vtemplate_path}
 							</div>
 						</div>
-						<div class="form-group clearfix">
+						{assign var=SORT_CONDITIONS value=$CUSTOMVIEW_MODEL->getSortConditions()}
+						<div class="form-group clearfix" id="sortConditionsContainer">
 							<div class="col-sm-2 col-xs-12">
 								<label style="margin-top: 5px;">
-										{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
+									{vtranslate('LBL_DEFAULT_SORT',$MODULE)} 
 								</label>
 							</div>
-							<div class="col-sm-4 col-xs-7">
-								<select id='orderby' name='orderby' class="select2 form-control">
-									<option value="">{vtranslate('LBL_NONE',$MODULE)}</option>
+							<div class="col-sm-10 col-xs-12">
+								<div id="sortRowsList">
+									{foreach from=$SORT_CONDITIONS key=INDEX item=SORT_ROW}
+										<div class="sort-condition-row row" style="margin-bottom: 8px;">
+											<div class="col-sm-2 col-xs-3" style="padding-top: 6px;">
+												<span class="sort-prefix-label text-muted" style="font-weight: bold;">{vtranslate('LBL_SORT_CONDITION_LABEL', 'Vtiger')|replace:'%s':($INDEX+1)}</span>
+											</div>
+											<div class="col-sm-5 col-xs-5">
+												<select name="sort_conditions[{$INDEX}][field]" class="select2 form-control sort-field-select">
+													{foreach key=BLOCK_LABEL item=BLOCK_FIELDS from=$RECORD_STRUCTURE}
+														<optgroup label='{vtranslate($BLOCK_LABEL, $SOURCE_MODULE)}'>
+															{foreach key=FIELD_NAME item=FIELD_MODEL from=$BLOCK_FIELDS}
+																{assign var=FIELD_MODULE_NAME value=$FIELD_MODEL->getModule()->getName()}
+																{assign var=WITH_MODULENAME value="("|cat:{vtranslate($FIELD_MODULE_NAME, $SOURCE_MODULE)}|cat:")-"}
+																<option value="{$FIELD_NAME}" {if $SORT_ROW.field eq $FIELD_NAME || ($SORT_ROW.field eq $FIELD_MODEL->get('name') && $FIELD_MODULE_NAME eq $SOURCE_MODULE)}selected{/if}>
+																	{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE)|replace:"-":$WITH_MODULENAME)}
+																</option>
+															{/foreach}
+														</optgroup>
+													{/foreach}
+												</select>
+											</div>
+											<div class="col-sm-3 col-xs-3">
+												<select name="sort_conditions[{$INDEX}][order]" class="select2 form-control sort-order-select">
+													<option value="ASC" {if $SORT_ROW.order neq 'DESC'}selected{/if}>{vtranslate('LBL_ASCENDING', $MODULE)}</option>
+													<option value="DESC" {if $SORT_ROW.order eq 'DESC'}selected{/if}>{vtranslate('LBL_DESCENDING', $MODULE)}</option>
+												</select>
+											</div>
+											<div class="col-sm-2 col-xs-1" style="padding-top: 2px;">
+												<button type="button" class="btn btn-default addSortRowBtn {if $INDEX >= 4}hide{/if}" title="{vtranslate('LBL_ADD_SORT_ROW', $MODULE)}"><i class="fa fa-plus"></i></button>
+												<button type="button" class="btn btn-default deleteSortRowBtn" title="{vtranslate('LBL_DELETE', $MODULE)}"><i class="fa fa-trash"></i></button>
+											</div>
+										</div>
+									{/foreach}
+								</div>
+								<div id="addFirstSortRowContainer" class="{if php7_count($SORT_CONDITIONS) gt 0}hide{/if}" style="margin-top: 4px;">
+									<button type="button" class="btn btn-default addSortRowBtn" title="{vtranslate('LBL_DEFAULT_SORT', $MODULE)}">
+										<i class="fa fa-plus"></i> {vtranslate('LBL_DEFAULT_SORT', $MODULE)}
+									</button>
+								</div>
+								<select id="sortFieldOptionsTemplate" class="hide">
 									{foreach key=BLOCK_LABEL item=BLOCK_FIELDS from=$RECORD_STRUCTURE}
 										<optgroup label='{vtranslate($BLOCK_LABEL, $SOURCE_MODULE)}'>
 											{foreach key=FIELD_NAME item=FIELD_MODEL from=$BLOCK_FIELDS}
-												<option value="{$FIELD_MODEL->get('name')}" {if $CUSTOMVIEW_MODEL->get('orderby') eq $FIELD_MODEL->get('name')}selected{/if}>
-													{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE))}
+												{assign var=FIELD_MODULE_NAME value=$FIELD_MODEL->getModule()->getName()}
+												{assign var=WITH_MODULENAME value="("|cat:{vtranslate($FIELD_MODULE_NAME, $SOURCE_MODULE)}|cat:")-"}
+												<option value="{$FIELD_NAME}">
+													{Vtiger_Util_Helper::toSafeHTML(vtranslate($FIELD_MODEL->get('label'), $SOURCE_MODULE)|replace:"-":$WITH_MODULENAME)}
 												</option>
 											{/foreach}
 										</optgroup>
 									{/foreach}
-								</select>
-							</div>
-							<div class="col-sm-3 col-xs-5">
-								<select id='sortorder' name='sortorder' class="select2 form-control">
-									<option value="ASC" {if $CUSTOMVIEW_MODEL->get('sortorder') neq 'DESC'}selected{/if}>{vtranslate('LBL_ASCENDING', $MODULE)}</option>
-									<option value="DESC" {if $CUSTOMVIEW_MODEL->get('sortorder') eq 'DESC'}selected{/if}>{vtranslate('LBL_DESCENDING', $MODULE)}</option>
 								</select>
 							</div>
 						</div>

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -90,7 +90,7 @@
 				{/if}
 				</th>
 				{foreach item=LISTVIEW_HEADER from=$LISTVIEW_HEADERS}
-					{if $SEARCH_MODE_RESULTS || ($LISTVIEW_HEADER->getFieldDataType() eq 'multipicklist')}
+					{if $SEARCH_MODE_RESULTS || ($LISTVIEW_HEADER->getFieldDataType() eq 'multipicklist') || $IS_DEFAULT_SORT}
 						{assign var=NO_SORTING value=1}
 					{else}
 						{assign var=NO_SORTING value=0}

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -33,7 +33,7 @@
 	<input type="hidden" name="currentSearchParams" value="{Vtiger_Util_Helper::toSafeHTML(Zend_JSON::encode($SEARCH_DETAILS))}" id="currentSearchParams" />
         <input type="hidden" name="currentTagParams" value="{Vtiger_Util_Helper::toSafeHTML(Zend_JSON::encode($TAG_DETAILS))}" id="currentTagParams" />
 	<input type="hidden" name="noFilterCache" value="{$NO_SEARCH_PARAMS_CACHE}" id="noFilterCache" >
-	<input type="hidden" name="orderBy" value="{$ORDER_BY}" id="orderBy">
+	<input type="hidden" name="orderBy" value="{Vtiger_Util_Helper::toSafeHTML($ORDER_BY)}" id="orderBy">
 	<input type="hidden" name="sortOrder" value="{$SORT_ORDER}" id="sortOrder">
 	<input type="hidden" name="list_headers" value='{$LIST_HEADER_FIELDS}'/>
 	<input type="hidden" name="tag" value="{$CURRENT_TAG}" />
@@ -98,20 +98,32 @@
 					{if $LISTVIEW_HEADER->get('uitype') eq '999'}
 						{continue}
 					{/if}
-					<th {if !$MODULE_MODEL->isFilterColumnEnabled() && !$LISTVIEW_ENTRIES_COUNT eq '0'}class="table-bottom-border" {/if}{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')} nowrap="nowrap" {/if}>
-						<a href="#" class="{if $NO_SORTING}noSorting{else}listViewContentHeaderValues{/if}" {if !$NO_SORTING}data-nextsortorderval="{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}{$NEXT_SORT_ORDER}{else}ASC{/if}" data-columnname="{$LISTVIEW_HEADER->get('name')}"{/if} data-field-id='{$LISTVIEW_HEADER->getId()}'>
+					{assign var=HEADER_NAME value=$LISTVIEW_HEADER->get('name')}
+					{assign var=HEADER_SORT_RANK value=0}
+					{assign var=HEADER_SORT_ORDER value='ASC'}
+					{if !empty($SORT_CONDITIONS) && !$IS_DEFAULT_SORT}
+						{foreach from=$SORT_CONDITIONS key=SORT_INDEX item=SORT_COND}
+							{if $SORT_COND.field eq $HEADER_NAME}
+								{assign var=HEADER_SORT_RANK value=$SORT_INDEX+1}
+								{assign var=HEADER_SORT_ORDER value=$SORT_COND.order}
+							{/if}
+						{/foreach}
+					{/if}
+					<th {if !$MODULE_MODEL->isFilterColumnEnabled() && !$LISTVIEW_ENTRIES_COUNT eq '0'}class="table-bottom-border" {/if}{if $HEADER_SORT_RANK gt 0} nowrap="nowrap" {/if}>
+						<a href="#" class="{if $NO_SORTING}noSorting{else}listViewContentHeaderValues{/if}" {if !$NO_SORTING}data-nextsortorderval="{if $HEADER_SORT_RANK gt 0}{if $HEADER_SORT_ORDER eq 'ASC'}DESC{else}ASC{/if}{else}ASC{/if}" data-columnname="{$HEADER_NAME}"{/if} data-field-id='{$LISTVIEW_HEADER->getId()}'>
 							{if !$NO_SORTING}
-								{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}
-									<i class="fa fa-sort {$FASORT_IMAGE}"></i>
+								{if $HEADER_SORT_RANK gt 0}
+									<i class="fa fa-sort {if $HEADER_SORT_ORDER eq 'DESC'}fa-sort-desc{else}fa-sort-asc{/if}"></i>
+									<span class="badge" style="font-size: 9px; padding: 2px 4px; margin-left: 2px; background-color: #5bb75b;">{$HEADER_SORT_RANK}</span>
 								{else}
 									<i class="fa fa-sort customsort"></i>
 								{/if}
 							{/if}
 							&nbsp;{vtranslate($LISTVIEW_HEADER->get('label'), $LISTVIEW_HEADER->getModuleName())}&nbsp;
 						</a>
-						{if $COLUMN_NAME eq $LISTVIEW_HEADER->get('name')}
-							<a href="#" class="removeSorting"><i class="fa fa-remove"></i></a>
-							{/if}
+						{if $HEADER_SORT_RANK gt 0}
+							<a href="#" class="removeSorting" data-remove-column="{$HEADER_NAME}" title="{vtranslate('LBL_REMOVE_SORTING', 'Vtiger')}"><i class="fa fa-remove"></i></a>
+						{/if}
 					</th>
 				{/foreach}
 				</tr>

--- a/modules/Calendar/models/ListView.php
+++ b/modules/Calendar/models/ListView.php
@@ -205,26 +205,9 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
         
-        $orderBy = $this->getForSql('orderby');
-		if(is_countable($querySetFields) && !in_array($orderBy, $querySetFields, true)) {
-			$orderBy = '';
-		}
-		
-		$sortOrder = $this->getForSql('sortorder');
-        if(empty($sortOrder)) {
-            $sortOrder = 'DESC';
-        }
+		$sortConditions = $this->getSortConditions();
+		$this->setupQueryGeneratorForSort($queryGenerator, $sortConditions);
 
-        if(!empty($orderBy)){
-			$queryGenerator = $this->get('query_generator');
-			$fieldModels = $queryGenerator->getModuleFields();
-			$orderByFieldModel = $fieldModels[$orderBy];
-           if($orderByFieldModel && ($orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
-					$orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)){
-                $queryGenerator->addWhereField($orderBy);
-            }
-        }
-		
 		$listQuery = $this->getQuery();
 
 		$sourceModule = $this->get('src_module');
@@ -240,16 +223,7 @@ class Calendar_ListView_Model extends Vtiger_ListView_Model {
 		// If activity is related to two entity records(Contacts/Accounts/...) then we'll get duplicates
         $listQuery .= " GROUP BY $moduleFocus->table_name.$moduleFocus->table_index ";
 
-		
-		if(empty($orderBy)) {
-            $listQuery .= " ORDER BY vtiger_activity.modifiedtime $sortOrder ";
-		} else if($orderBy == 'date_start') {
-            $listQuery .= " ORDER BY str_to_date(concat(date_start,time_start),'%Y-%m-%d %H:%i:%s') $sortOrder ";
-        } else if($orderBy == 'due_date') {
-            $listQuery .= " ORDER BY str_to_date(concat(due_date,time_end),'%Y-%m-%d %H:%i:%s') $sortOrder ";
-        } else if(!empty($orderBy) && $orderByFieldModel) {
-			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
-		}
+		$listQuery .= $this->getOrderBySql($queryGenerator, $sortConditions, $moduleFocus);
 
 		$startIndex = $pagingModel->getStartIndex();
 		$pageLimit = $pagingModel->getPageLimit();

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -58,7 +58,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'viewname' => $request->get('viewname'),
 					'setdefault' => $request->get('setdefault'),
 					'setmetrics' => $request->get('setmetrics'),
-					'status' => $request->get('status')
+					'status' => $request->get('status'),
+					'orderby' => $request->get('orderby')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -29,7 +29,7 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
              * we should clear this from session in order to apply view
              */
             $listViewSessionKey = $sourceModuleName.'_'.$cvId;
-            Vtiger_ListView_Model::deleteParamsSession($listViewSessionKey,'list_headers');
+            Vtiger_ListView_Model::deleteParamsSession($listViewSessionKey, array('list_headers', 'orderby', 'sortorder'));
 			$response->setResult(array('id'=>$cvId, 'listviewurl'=>$moduleModel->getListViewUrl().'&viewname='.$cvId));
 		} else {
 			$response->setError(vtranslate('LBL_CUSTOM_VIEW_NAME_DUPLICATES_EXIST', $moduleName));
@@ -59,7 +59,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'setdefault' => $request->get('setdefault'),
 					'setmetrics' => $request->get('setmetrics'),
 					'status' => $request->get('status'),
-					'orderby' => $request->get('orderby')
+					'orderby' => $request->get('orderby'),
+					'sortorder' => $request->get('sortorder')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/actions/Save.php
+++ b/modules/CustomView/actions/Save.php
@@ -60,7 +60,8 @@ class CustomView_Save_Action extends Vtiger_Action_Controller {
 					'setmetrics' => $request->get('setmetrics'),
 					'status' => $request->get('status'),
 					'orderby' => $request->get('orderby'),
-					'sortorder' => $request->get('sortorder')
+					'sortorder' => $request->get('sortorder'),
+					'sort_conditions' => $request->get('sort_conditions')
 		);
 		$selectedColumnsList = $request->get('columnslist');
 		if(!empty($selectedColumnsList)) {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -272,6 +272,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setDefault = $this->get('setdefault');
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
+		$orderby = $this->get('orderby');
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {
@@ -283,8 +284,8 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$cvId = $db->getUniqueID("vtiger_customview");
 			$this->set('cvid', $cvId);
 
-			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid) VALUES (?,?,?,?,?,?,?)';
-			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId());
+			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby) VALUES (?,?,?,?,?,?,?,?)';
+			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(),$orderby);
 			$db->pquery($sql, $params);
 
 		} else {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -273,6 +273,7 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
 		$orderby = $this->get('orderby');
+		$sortorder = $this->get('sortorder');
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {
@@ -284,14 +285,14 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 			$cvId = $db->getUniqueID("vtiger_customview");
 			$this->set('cvid', $cvId);
 
-			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby) VALUES (?,?,?,?,?,?,?,?)';
-			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(),$orderby);
+			$sql = 'INSERT INTO vtiger_customview(cvid, viewname, setdefault, setmetrics, entitytype, status, userid, orderby, sortorder) VALUES (?,?,?,?,?,?,?,?,?)';
+			$params = array($cvId, $viewName, $setDefault, $setMetrics, $moduleName, $status, $currentUserModel->getId(), $orderby, $sortorder);
 			$db->pquery($sql, $params);
 
 		} else {
 
-			$sql = 'UPDATE vtiger_customview SET viewname=?, setdefault=?, setmetrics=?, status=? WHERE cvid=?';
-			$params = array($viewName, $setDefault, $setMetrics, $status, $cvId);
+			$sql = 'UPDATE vtiger_customview SET viewname=?, setdefault=?, setmetrics=?, status=?, orderby=?, sortorder=? WHERE cvid=?';
+			$params = array($viewName, $setDefault, $setMetrics, $status, $orderby, $sortorder, $cvId);
 			$db->pquery($sql, $params);
 
 			if(!$partial) {

--- a/modules/CustomView/models/Record.php
+++ b/modules/CustomView/models/Record.php
@@ -261,6 +261,16 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 	/**
 	 * Function to save the custom view record
 	 */
+	/**
+	 * Function to get list of sort conditions for this custom view
+	 * @return <Array> Array of array('field' => string, 'order' => 'ASC'|'DESC')
+	 */
+	public function getSortConditions() {
+		$orderby = $this->get('orderby');
+		$sortorder = $this->get('sortorder');
+		return Vtiger_ListView_Model::cleanSortConditions($orderby, $sortorder);
+	}
+
 	public function save($partial = false) {
 		$db = PearDatabase::getInstance();
 		$currentUserModel = Users_Record_Model::getCurrentUserModel();
@@ -272,8 +282,24 @@ class CustomView_Record_Model extends Vtiger_Base_Model {
 		$setDefault = $this->get('setdefault');
 		$setMetrics = $this->get('setmetrics');
 		$status = $this->get('status');
-		$orderby = $this->get('orderby');
-		$sortorder = $this->get('sortorder');
+
+		$sortConditions = $this->get('sort_conditions');
+		if (is_array($sortConditions) && !empty($sortConditions)) {
+			$validConditions = Vtiger_ListView_Model::cleanSortConditions($sortConditions);
+			if (!empty($validConditions)) {
+				$orderby = json_encode($validConditions);
+				$sortorder = $validConditions[0]['order'];
+			} else {
+				$orderby = '';
+				$sortorder = 'ASC';
+			}
+		} else if ($this->has('sort_conditions') && empty($sortConditions)) {
+			$orderby = '';
+			$sortorder = 'ASC';
+		} else {
+			$orderby = $this->get('orderby');
+			$sortorder = $this->get('sortorder');
+		}
 
 		if($status == self::CV_STATUS_PENDING) {
 			if($currentUserModel->isAdminUser()) {

--- a/modules/CustomView/views/EditAjax.php
+++ b/modules/CustomView/views/EditAjax.php
@@ -80,6 +80,7 @@ Class CustomView_EditAjax_View extends Vtiger_IndexAjax_View {
 		$currentUserModel = Users_Record_Model::getCurrentUserModel();
 
 		$viewer->assign('CUSTOMVIEW_MODEL', $customViewModel);
+		$viewer->assign('SORT_CONDITIONS', $customViewModel->getSortConditions());
 		$viewer->assign('RECORD_ID', $record);
 		$viewer->assign('MODULE', $module);
 		$viewer->assign('SOURCE_MODULE',$moduleName);

--- a/modules/Documents/models/ListView.php
+++ b/modules/Documents/models/ListView.php
@@ -173,18 +173,9 @@ class Documents_ListView_Model extends Vtiger_ListView_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
         
-        $orderBy = $this->getForSql('orderby');
-		$sortOrder = $this->getForSql('sortorder');
+		$sortConditions = $this->getSortConditions();
+		$this->setupQueryGeneratorForSort($queryGenerator, $sortConditions);
 
-        if(!empty($orderBy)){
-			$queryGenerator = $this->get('query_generator');
-			$fieldModels = $queryGenerator->getModuleFields();
-			$orderByFieldModel = $fieldModels[$orderBy];
-            if($orderByFieldModel && ($orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
-					$orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)){
-                $queryGenerator->addWhereField($orderBy);
-            }
-        }
         //Document source required in list view for managing delete 
         $listViewFields = $queryGenerator->getFields(); 
         if(!in_array('document_source', $listViewFields)){ 
@@ -214,12 +205,7 @@ class Documents_ListView_Model extends Vtiger_ListView_Model {
 		$startIndex = $pagingModel->getStartIndex();
 		$pageLimit = $pagingModel->getPageLimit();
 
-		if(!empty($orderBy) && $orderByFieldModel) {
-			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
-		} else if(empty($orderBy) && empty($sortOrder)){
-			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_notes.modifiedtime DESC';
-		}
+		$listQuery .= $this->getOrderBySql($queryGenerator, $sortConditions, $moduleFocus);
 
 		$viewid = ListViewSession::getCurrentView($moduleName);
         if(empty($viewid)){

--- a/modules/Migration/schema/738_to_739.php
+++ b/modules/Migration/schema/738_to_739.php
@@ -1,0 +1,14 @@
+<?php
+/*+********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is: vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *********************************************************************************/
+
+if (defined('VTIGER_UPGRADE')) {
+    $db->query('ALTER TABLE vtiger_customview ADD orderby varchar(250);');
+
+}

--- a/modules/PriceBooks/models/ListView.php
+++ b/modules/PriceBooks/models/ListView.php
@@ -73,18 +73,9 @@ class PriceBooks_ListView_Model extends Vtiger_ListView_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
 
-        $orderBy = $this->getForSql('orderby');
-		$sortOrder = $this->getForSql('sortorder');
+		$sortConditions = $this->getSortConditions();
+		$this->setupQueryGeneratorForSort($queryGenerator, $sortConditions);
 
-        if(!empty($orderBy)){
-			$queryGenerator = $this->get('query_generator');
-			$fieldModels = $queryGenerator->getModuleFields();
-			$orderByFieldModel = $fieldModels[$orderBy];
-            if($orderByFieldModel && ($orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
-					$orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)){
-                $queryGenerator->addWhereField($orderBy);
-            }
-        }
 		$listQuery = $this->getQuery();
 
 		$sourceModule = $this->get('src_module');
@@ -101,12 +92,7 @@ class PriceBooks_ListView_Model extends Vtiger_ListView_Model {
 		$startIndex = $pagingModel->getStartIndex();
 		$pageLimit = $pagingModel->getPageLimit();
 
-		if(!empty($orderBy) && $orderByFieldModel) {
-			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
-		} else if(empty($orderBy) && empty($sortOrder)){
-			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY vtiger_pricebook.modifiedtime DESC';
-		}
+		$listQuery .= $this->getOrderBySql($queryGenerator, $sortConditions, $moduleFocus);
 
 		$viewid = ListViewSession::getCurrentView($moduleName);
         if(empty($viewid)){

--- a/modules/Products/models/ListView.php
+++ b/modules/Products/models/ListView.php
@@ -43,18 +43,9 @@ class Products_ListView_Model extends Vtiger_ListView_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
         
-        $orderBy = $this->getForSql('orderby');
-		$sortOrder = $this->getForSql('sortorder');
-		
-        if(!empty($orderBy)){
-			$queryGenerator = $this->get('query_generator');
-			$fieldModels = $queryGenerator->getModuleFields();
-			$orderByFieldModel = $fieldModels[$orderBy];
-			if($orderByFieldModel && ($orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
-					$orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)){
-                $queryGenerator->addWhereField($orderBy);
-            }
-        }
+		$sortConditions = $this->getSortConditions();
+		$this->setupQueryGeneratorForSort($queryGenerator, $sortConditions);
+
 		$listQuery = $this->getQuery();
 
 		if($this->get('subProductsPopup')){
@@ -75,12 +66,7 @@ class Products_ListView_Model extends Vtiger_ListView_Model {
 		$startIndex = $pagingModel->getStartIndex();
 		$pageLimit = $pagingModel->getPageLimit();
 
-		if(!empty($orderBy) && $orderByFieldModel) {
-			$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
-		} else if(empty($orderBy) && empty($sortOrder)){
-			//List view will be displayed on recently created/modified records
-			$listQuery .= ' ORDER BY '.$moduleFocus->table_name.'.modifiedtime DESC';
-		}
+		$listQuery .= $this->getOrderBySql($queryGenerator, $sortConditions, $moduleFocus);
 
 		$viewid = ListViewSession::getCurrentView($moduleName);
         if(empty($viewid)){

--- a/modules/Vtiger/models/ListView.php
+++ b/modules/Vtiger/models/ListView.php
@@ -212,18 +212,9 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 			$queryGenerator->addUserSearchConditions(array('search_field' => $searchKey, 'search_text' => $searchValue, 'operator' => $operator));
 		}
 
-		$orderBy = $this->getForSql('orderby');
-		$sortOrder = $this->getForSql('sortorder');
+		$sortConditions = $this->getSortConditions();
+		$this->setupQueryGeneratorForSort($queryGenerator, $sortConditions);
 
-		if(!empty($orderBy)){
-			$queryGenerator = $this->get('query_generator');
-			$fieldModels = $queryGenerator->getModuleFields();
-			$orderByFieldModel = $fieldModels[$orderBy];
-			if($orderByFieldModel && ($orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
-					$orderByFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)){
-				$queryGenerator->addWhereField($orderBy);
-			}
-		}
 		$listQuery = $this->getQuery();
 
 		$sourceModule = $this->get('src_module');
@@ -239,23 +230,7 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 		$startIndex = $pagingModel->getStartIndex();
 		$pageLimit = $pagingModel->getPageLimit();
 
-		if(!empty($orderBy) && $orderByFieldModel) {
-			if($orderBy == 'roleid' && $moduleName == 'Users'){
-				$listQuery .= ' ORDER BY vtiger_role.rolename '.' '. $sortOrder; 
-			} else {
-				$listQuery .= ' ORDER BY '.$queryGenerator->getOrderByColumn($orderBy).' '.$sortOrder;
-			}
-
-			if ($orderBy == 'first_name' && $moduleName == 'Users') {
-				$listQuery .= ' , last_name '.' '. $sortOrder .' ,  email1 '. ' '. $sortOrder;
-			} 
-		} else if(empty($orderBy) && empty($sortOrder) && $moduleName != "Users"){
-			$baseTable = $moduleFocus->table_name;
-			if(empty($baseTable)) {
-				$baseTable = "vtiger_crmentity";
-			}
-			$listQuery .= " ORDER BY ".$baseTable.".modifiedtime DESC";
-		}
+		$listQuery .= $this->getOrderBySql($queryGenerator, $sortConditions, $moduleFocus);
 
 		$viewid = ListViewSession::getCurrentView($moduleName);
 		if(empty($viewid)) {
@@ -568,5 +543,174 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Helper method to clean and parse sort conditions from array or JSON string.
+	 * @param mixed $rawSortConditions
+	 * @param string $defaultOrder
+	 * @return array
+	 */
+	public static function cleanSortConditions($rawSortConditions, $defaultOrder = 'ASC') {
+		$sortConditions = array();
+		if (empty($rawSortConditions)) {
+			return $sortConditions;
+		}
+
+		$decoded = null;
+		if (is_array($rawSortConditions)) {
+			$decoded = $rawSortConditions;
+		} else if (is_string($rawSortConditions)) {
+			$decoded = json_decode($rawSortConditions, true);
+			if (!is_array($decoded)) {
+				$decoded = json_decode(html_entity_decode($rawSortConditions, ENT_QUOTES, 'UTF-8'), true);
+			}
+			if (!is_array($decoded)) {
+				$decoded = json_decode(htmlspecialchars_decode($rawSortConditions), true);
+			}
+			if (!is_array($decoded)) {
+				$decoded = json_decode(stripslashes($rawSortConditions), true);
+			}
+		}
+
+		if (is_array($decoded) && !empty($decoded)) {
+			foreach ($decoded as $item) {
+				if (is_object($item)) $item = (array)$item;
+				if (is_array($item) && !empty($item['field']) && is_string($item['field'])) {
+					$field = trim($item['field']);
+					$order = (!empty($item['order']) && is_string($item['order']) && strtoupper($item['order']) === 'DESC') ? 'DESC' : 'ASC';
+					$sortConditions[] = array('field' => $field, 'order' => $order);
+				}
+			}
+		} else if (is_string($rawSortConditions) && strpos($rawSortConditions, '[') === false && strpos($rawSortConditions, '{') === false) {
+			$field = trim($rawSortConditions);
+			if (!empty($field)) {
+				$order = (strtoupper($defaultOrder) === 'DESC') ? 'DESC' : 'ASC';
+				$sortConditions[] = array('field' => $field, 'order' => $order);
+			}
+		}
+		return $sortConditions;
+	}
+
+	public function getSortConditions() {
+		$moduleName = $this->getModule()->get('name');
+		$orderBy = $this->get('orderby');
+		$sortOrder = $this->get('sortorder');
+
+		$sortConditions = array();
+		if (!empty($orderBy)) {
+			$sortConditions = self::cleanSortConditions($orderBy, $sortOrder);
+		} else {
+			$viewid = ListViewSession::getCurrentView($moduleName);
+			if (!empty($viewid)) {
+				$cvModel = CustomView_Record_Model::getInstanceById($viewid);
+				if ($cvModel) {
+					$sortConditions = $cvModel->getSortConditions();
+				}
+			}
+		}
+		return $sortConditions;
+	}
+
+	public function setupQueryGeneratorForSort($queryGenerator, $sortConditions) {
+		if (!empty($sortConditions)) {
+			$fieldModels = $queryGenerator->getModuleFields();
+			foreach ($sortConditions as $cond) {
+				if (is_object($cond)) $cond = (array)$cond;
+				$rawFieldName = isset($cond['field']) ? $cond['field'] : '';
+				if (empty($rawFieldName)) continue;
+
+				$pureFieldName = $rawFieldName;
+				$parentField = '';
+				preg_match('/(\w+) ; \((\w+)\) (\w+)/', $rawFieldName, $m);
+				if (!empty($m[1])) {
+					$parentField = $m[1];
+					$pureFieldName = $m[3];
+				}
+
+				$checkField = !empty($parentField) ? $parentField : $pureFieldName;
+				if (isset($fieldModels[$checkField])) {
+					$condFieldModel = $fieldModels[$checkField];
+					if ($condFieldModel && ($condFieldModel->getFieldDataType() == Vtiger_Field_Model::REFERENCE_TYPE ||
+							$condFieldModel->getFieldDataType() == Vtiger_Field_Model::OWNER_TYPE)) {
+						$queryGenerator->addWhereField($rawFieldName);
+					}
+				}
+			}
+		}
+	}
+
+	public function getOrderBySql($queryGenerator, $sortConditions, $moduleFocus = null) {
+		$moduleName = $this->getModule()->get('name');
+		$orderBySql = '';
+		if (!empty($sortConditions)) {
+			$fieldModels = $queryGenerator->getModuleFields();
+			$orderByParts = array();
+			foreach ($sortConditions as $cond) {
+				if (is_object($cond)) $cond = (array)$cond;
+				$rawFieldName = isset($cond['field']) ? $cond['field'] : '';
+				if (empty($rawFieldName)) continue;
+				$order = (!empty($cond['order']) && strtoupper($cond['order']) === 'DESC') ? 'DESC' : 'ASC';
+
+				$pureFieldName = $rawFieldName;
+				$parentField = '';
+				preg_match('/(\w+) ; \((\w+)\) (\w+)/', $rawFieldName, $m);
+				if (!empty($m[1])) {
+					$parentField = $m[1];
+					$pureFieldName = $m[3];
+				}
+
+				// Whitelist validation: check if field exists in module or is an allowed special field
+				$checkField = !empty($parentField) ? $parentField : $pureFieldName;
+				$isValidField = isset($fieldModels[$checkField]);
+				if (!$isValidField && $moduleName === 'Users' && ($pureFieldName === 'roleid' || $pureFieldName === 'first_name')) {
+					$isValidField = true;
+				}
+				if (!$isValidField && $moduleName === 'Calendar' && ($pureFieldName === 'date_start' || $pureFieldName === 'due_date')) {
+					$isValidField = true;
+				}
+
+				if (!$isValidField) {
+					continue;
+				}
+
+				if ($pureFieldName == 'roleid' && $moduleName == 'Users') {
+					$orderByParts[] = 'vtiger_role.rolename ' . $order;
+				} else if ($pureFieldName == 'date_start' && $moduleName == 'Calendar') {
+					$orderByParts[] = "str_to_date(concat(date_start,time_start),'%Y-%m-%d %H:%i:%s') " . $order;
+				} else if ($pureFieldName == 'due_date' && $moduleName == 'Calendar') {
+					$orderByParts[] = "str_to_date(concat(due_date,time_end),'%Y-%m-%d %H:%i:%s') " . $order;
+				} else {
+					$columnSql = $queryGenerator->getOrderByColumn($rawFieldName);
+					if (!empty($columnSql)) {
+						$orderByParts[] = $columnSql . ' ' . $order;
+					}
+				}
+			}
+			if (!empty($orderByParts)) {
+				$orderBySql = ' ORDER BY ' . implode(', ', $orderByParts);
+				if (isset($sortConditions[0]['field']) && $sortConditions[0]['field'] == 'first_name' && $moduleName == 'Users') {
+					$existingFields = array();
+					foreach ($sortConditions as $cond) {
+						$f = isset($cond['field']) ? $cond['field'] : '';
+						preg_match('/(\w+) ; \((\w+)\) (\w+)/', $f, $m);
+						$existingFields[] = !empty($m[3]) ? $m[3] : $f;
+					}
+					if (!in_array('last_name', $existingFields)) {
+						$orderBySql .= ' , last_name ' . $sortConditions[0]['order'];
+					}
+					if (!in_array('email1', $existingFields)) {
+						$orderBySql .= ' , email1 ' . $sortConditions[0]['order'];
+					}
+				}
+			}
+		} else if ($moduleName != "Users") {
+			$baseTable = $moduleFocus ? $moduleFocus->table_name : '';
+			if(empty($baseTable)) {
+				$baseTable = "vtiger_crmentity";
+			}
+			$orderBySql = " ORDER BY ".$baseTable.".modifiedtime DESC";
+		}
+		return $orderBySql;
 	}
 }

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -181,14 +181,6 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		} else {
 			$listViewModel = $this->listViewModel;
 		}
-		if($orderBy == ''){
-			global $db;
-			$db = PearDatabase::getInstance();
-			$query = "SELECT orderby from vtiger_customview WHERE cvid = ?";
-			$result = $db->pquery($query, array($cvId));//orderbyの連結完了
-			$orderBy = $db->query_result($result,'orderby');
-
-		}
 
 		if(!empty($requestViewName) && empty($tag)) {
 			unset($_SESSION[$tagSessionKey]);
@@ -262,6 +254,24 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			}
 			$listViewModel->setSortParamsSession($listViewSessionKey, $params);
 		}
+		$isDefaultSort = false;
+		global $db;
+		$db = PearDatabase::getInstance();
+		$query = "SELECT orderby, sortorder from vtiger_customview WHERE cvid = ?";
+		$result = $db->pquery($query, array($cvId));
+		$db_orderBy = '';
+		$db_sortOrder = '';
+		if ($result && $db->num_rows($result) > 0) {
+			$db_orderBy = $db->query_result($result, 0, 'orderby');
+			$db_sortOrder = $db->query_result($result, 0, 'sortorder');
+		}
+
+		if (!empty($db_orderBy)) {
+			// If a default sort is set, it locks the sorting for this custom view.
+			$orderBy = $db_orderBy;
+			$sortOrder = $db_sortOrder;
+			$isDefaultSort = true;
+		}
 		if($sortOrder == "ASC"){
 			$nextSortOrder = "DESC";
 			$sortImage = "icon-chevron-down";
@@ -300,6 +310,19 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$viewer->assign('OPERATOR',$operator);
 			$viewer->assign('ALPHABET_VALUE',$searchValue);
 		}
+		$viewer->assign('ORDER_BY',$orderBy);
+		$viewer->assign('SORT_ORDER',$sortOrder);
+		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
+		$viewer->assign('SORT_IMAGE',$sortImage);
+		$viewer->assign('FASORT_IMAGE',$faSortImage);
+		if(!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME',$orderBy);
+			$viewer->assign('IS_DEFAULT_SORT', false);
+		} else {
+			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('IS_DEFAULT_SORT', true);
+		}
+		
 		if(!empty($searchKey) && !empty($searchValue)) {
 			$listViewModel->set('search_key', $searchKey);
 			$listViewModel->set('search_value', $searchValue);
@@ -392,7 +415,13 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
 		$viewer->assign('SORT_IMAGE',$sortImage);
 		$viewer->assign('FASORT_IMAGE',$faSortImage);
-		$viewer->assign('COLUMN_NAME',$orderBy);
+		if(!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME',$orderBy);
+			$viewer->assign('IS_DEFAULT_SORT', false);
+		} else {
+			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('IS_DEFAULT_SORT', true);
+		}
 		$viewer->assign('VIEWNAME',$this->viewName);
 
 		$viewer->assign('LISTVIEW_ENTRIES_COUNT',$noOfEntries);

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -181,6 +181,14 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		} else {
 			$listViewModel = $this->listViewModel;
 		}
+		if($orderBy == ''){
+			global $db;
+			$db = PearDatabase::getInstance();
+			$query = "SELECT orderby from vtiger_customview WHERE cvid = ?";
+			$result = $db->pquery($query, array($cvId));//orderbyの連結完了
+			$orderBy = $db->query_result($result,'orderby');
+
+		}
 
 		if(!empty($requestViewName) && empty($tag)) {
 			unset($_SESSION[$tagSessionKey]);

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -216,6 +216,12 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$listViewModel->deleteParamsSession($listViewSessionKey, array('orderby', 'sortorder'));
 			$orderBy = '';
 			$sortOrder = '';
+			$request->set('orderby', '');
+			$request->set('sortorder', '');
+			if (is_array($orderParams)) {
+				$orderParams['orderby'] = '';
+				$orderParams['sortorder'] = '';
+			}
 		}
 		if(empty($listHeaders) && is_array($orderParams)) {
 			$listHeaders = $orderParams['list_headers'];
@@ -226,51 +232,56 @@ class Vtiger_List_View extends Vtiger_Index_View {
                     $tagParams = $orderParams['tag_params'];
 		}
                 
-		if(empty($orderBy) && empty($searchValue) && empty($pageNumber)) {
-			if($orderParams) {
-				$pageNumber = $orderParams['page'];
-				$orderBy = $orderParams['orderby'];
-				$sortOrder = $orderParams['sortorder'];
-				$searchKey = $orderParams['search_key'];
-				$searchValue = $orderParams['search_value'];
-				$operator = $orderParams['operator'];
-                                if(empty($tagParams)){
-					$tagParams = $orderParams['tag_params'];
-				}
-				if(empty($searchParams)) {
-					$searchParams = $orderParams['search_params']; 
-				}
+		$requestOrderBy = $request->get('orderby');
+		$requestSortOrder = $request->get('sortorder');
 
-				if(empty($starFilterMode)) {
-					$starFilterMode = $orderParams['star_filter_mode'];
-				}
+		$customViewModel = CustomView_Record_Model::getInstanceById($cvId);
+		$cvSortConditions = ($customViewModel) ? $customViewModel->getSortConditions() : array();
+		$rawCvOrderBy = ($customViewModel) ? $customViewModel->get('orderby') : '';
+
+		if (!empty($requestOrderBy)) {
+			// 1. Direct user action on list header column
+			$sortConditions = Vtiger_ListView_Model::cleanSortConditions($requestOrderBy, $requestSortOrder);
+			if (!empty($sortConditions)) {
+				$orderBy = json_encode($sortConditions);
+				$sortOrder = $sortConditions[0]['order'];
+			} else {
+				$orderBy = '';
+				$sortOrder = '';
 			}
-		} else if($request->get('nolistcache') != 1) {
+			$isDefaultSort = false;
+		} else if ($orderParams && !empty($orderParams['orderby']) && empty($orderParams['is_default_sort'])) {
+			// 2. User manual sort state restored from session
+			$sortConditions = Vtiger_ListView_Model::cleanSortConditions($orderParams['orderby'], isset($orderParams['sortorder']) ? $orderParams['sortorder'] : 'ASC');
+			if (!empty($sortConditions)) {
+				$orderBy = json_encode($sortConditions);
+				$sortOrder = $sortConditions[0]['order'];
+			} else {
+				$orderBy = '';
+				$sortOrder = '';
+			}
+			$isDefaultSort = false;
+		} else if (!empty($cvSortConditions)) {
+			// 3. CustomView default sort conditions
+			$sortConditions = $cvSortConditions;
+			$orderBy = $rawCvOrderBy;
+			$sortOrder = !empty($sortConditions[0]['order']) ? $sortConditions[0]['order'] : 'ASC';
+			$isDefaultSort = true;
+		} else {
+			$sortConditions = array();
+			$orderBy = '';
+			$sortOrder = '';
+			$isDefaultSort = false;
+		}
+
+		if ($request->get('nolistcache') != 1 && !empty($orderBy)) {
 			$params = array('page' => $pageNumber, 'orderby' => $orderBy, 'sortorder' => $sortOrder, 'search_key' => $searchKey,
-				'search_value' => $searchValue, 'operator' => $operator, 'tag_params' => $tagParams,'star_filter_mode'=> $starFilterMode,'search_params' =>$searchParams);
+				'search_value' => $searchValue, 'operator' => $operator, 'tag_params' => $tagParams,'star_filter_mode'=> $starFilterMode,'search_params' =>$searchParams, 'is_default_sort' => $isDefaultSort);
 
 			if(!empty($listHeaders)) {
 				$params['list_headers'] = $listHeaders;
 			}
 			$listViewModel->setSortParamsSession($listViewSessionKey, $params);
-		}
-		$isDefaultSort = false;
-		global $db;
-		$db = PearDatabase::getInstance();
-		$query = "SELECT orderby, sortorder from vtiger_customview WHERE cvid = ?";
-		$result = $db->pquery($query, array($cvId));
-		$db_orderBy = '';
-		$db_sortOrder = '';
-		if ($result && $db->num_rows($result) > 0) {
-			$db_orderBy = $db->query_result($result, 0, 'orderby');
-			$db_sortOrder = $db->query_result($result, 0, 'sortorder');
-		}
-
-		if (!empty($db_orderBy)) {
-			// If a default sort is set, it locks the sorting for this custom view.
-			$orderBy = $db_orderBy;
-			$sortOrder = $db_sortOrder;
-			$isDefaultSort = true;
 		}
 		if($sortOrder == "ASC"){
 			$nextSortOrder = "DESC";
@@ -310,16 +321,19 @@ class Vtiger_List_View extends Vtiger_Index_View {
 			$viewer->assign('OPERATOR',$operator);
 			$viewer->assign('ALPHABET_VALUE',$searchValue);
 		}
-		$viewer->assign('ORDER_BY',$orderBy);
-		$viewer->assign('SORT_ORDER',$sortOrder);
-		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
-		$viewer->assign('SORT_IMAGE',$sortImage);
-		$viewer->assign('FASORT_IMAGE',$faSortImage);
-		if(!$isDefaultSort) {
-			$viewer->assign('COLUMN_NAME',$orderBy);
+		$rawOrderByString = is_array($orderBy) ? json_encode($orderBy) : $orderBy;
+		$firstSortField = (!empty($sortConditions)) ? $sortConditions[0]['field'] : $rawOrderByString;
+		$viewer->assign('ORDER_BY', $rawOrderByString);
+		$viewer->assign('SORT_CONDITIONS', $sortConditions);
+		$viewer->assign('SORT_ORDER', $sortOrder);
+		$viewer->assign('NEXT_SORT_ORDER', $nextSortOrder);
+		$viewer->assign('SORT_IMAGE', $sortImage);
+		$viewer->assign('FASORT_IMAGE', $faSortImage);
+		if (!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME', $firstSortField);
 			$viewer->assign('IS_DEFAULT_SORT', false);
 		} else {
-			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('COLUMN_NAME', '');
 			$viewer->assign('IS_DEFAULT_SORT', true);
 		}
 		
@@ -410,16 +424,19 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		$listViewController = $listViewModel->get('listview_controller');
 		$selectedHeaderFields = $listViewController->getListViewHeaderFields();
 
-		$viewer->assign('ORDER_BY',$orderBy);
-		$viewer->assign('SORT_ORDER',$sortOrder);
-		$viewer->assign('NEXT_SORT_ORDER',$nextSortOrder);
-		$viewer->assign('SORT_IMAGE',$sortImage);
-		$viewer->assign('FASORT_IMAGE',$faSortImage);
-		if(!$isDefaultSort) {
-			$viewer->assign('COLUMN_NAME',$orderBy);
+		$rawOrderByString = is_array($orderBy) ? json_encode($orderBy) : $orderBy;
+		$firstSortField = (!empty($sortConditions)) ? $sortConditions[0]['field'] : $rawOrderByString;
+		$viewer->assign('ORDER_BY', $rawOrderByString);
+		$viewer->assign('SORT_CONDITIONS', $sortConditions);
+		$viewer->assign('SORT_ORDER', $sortOrder);
+		$viewer->assign('NEXT_SORT_ORDER', $nextSortOrder);
+		$viewer->assign('SORT_IMAGE', $sortImage);
+		$viewer->assign('FASORT_IMAGE', $faSortImage);
+		if (!$isDefaultSort) {
+			$viewer->assign('COLUMN_NAME', $firstSortField);
 			$viewer->assign('IS_DEFAULT_SORT', false);
 		} else {
-			$viewer->assign('COLUMN_NAME','');
+			$viewer->assign('COLUMN_NAME', '');
 			$viewer->assign('IS_DEFAULT_SORT', true);
 		}
 		$viewer->assign('VIEWNAME',$this->viewName);

--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -239,6 +239,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		this.makeColumnListSortable();
 		this.registerToogleShareList();
 		this.registerOnlyAllUsersInSharedList();
+		this.addColumnsOrderbyList();
 		var customViewForm = jQuery('#CustomView');
 
 		if(customViewForm.length > 0) {
@@ -247,7 +248,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					var form = jQuery(form); 
 						  var selectElement = form.find('#viewColumnsSelect'); 
 						  var mandatoryFieldsList = JSON.parse(jQuery('#mandatoryFieldsList').val()); 
-						  var selectedOptions = selectElement.val(); 
+						  var selectedOptions = selectElement.val();
 						  var mandatoryFieldsMissing = true; 
 						  for(var i=0; i<selectedOptions.length; i++) { 
 						if(jQuery.inArray(selectedOptions[i], mandatoryFieldsList) >= 0) { 
@@ -270,6 +271,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					}
 					var selectValues = JSON.stringify(selectedValues);
 					jQuery('input[name="columnslist"]', self.getContainer()).val(selectValues);
+					jQuery('input[name="orderby"]').val(jQuery('#orderby').val());
 					var allUsersStatusEle = jQuery('#allUsersStatusValue');
 					if(self.isAllUsersSelected() && (jQuery('[data-toogle-members]').is(":checked"))){
 						allUsersStatusEle.val(allUsersStatusEle.data('public'));
@@ -346,5 +348,40 @@ jQuery.Class("Vtiger_CustomView_Js",{
 				target.trigger('post.ToggleDefault.saved',data);
 			})
 		});
+	},
+
+	addElementsforOrderbyList :function(){
+		selectElement = this.getColumnSelectElement();
+		selectedOptions = selectElement.select2('data');
+		
+		for (var i= 0;i<selectedOptions.length;i++){
+			selectedOptionid = selectedOptions[i].id.split(':');
+			const newOption = document.createElement("option");
+			newOption.value = selectedOptionid[1];
+			newOption.textContent = selectedOptions[i].text;
+			jQuery("#orderby").append(newOption);
+		}
+	},
+
+	addColumnsOrderbyList :function(){
+		selectfield = document.getElementById('s2id_viewColumnsSelect');
+		this.addElementsforOrderbyList();
+
+		var observer = new MutationObserver(function(){
+			customview = new Vtiger_CustomView_Js();
+			var parent = document.getElementById("orderby");
+			
+			while(parent.lastChild){
+				parent.removeChild(parent.lastChild);
+			}
+			customview.addElementsforOrderbyList();
+		});
+		const config = { 
+			attributes: false, 
+			childList: true, 
+			characterData: false,
+			subtree:true
+		};
+		observer.observe(selectfield, config);
 	}
 });

--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -224,6 +224,26 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		});
 	},
 
+	registerOrderbyChangeEvent : function() {
+		var form = jQuery('#CustomView');
+		var orderBySelect = form.find('#orderby');
+		var sortOrderSelect = form.find('#sortorder');
+		// The container is the parent div of the sortorder select
+		var sortOrderContainer = sortOrderSelect.closest('div.col-sm-3, div.col-xs-4');
+
+		if(orderBySelect.length > 0) {
+			orderBySelect.on('change', function() {
+				if(jQuery(this).val() == '') {
+					sortOrderContainer.hide();
+				} else {
+					sortOrderContainer.show();
+				}
+			});
+			// Trigger on load to set initial state
+			orderBySelect.trigger('change');
+		}
+	},
+
 	/**
 	 * Function which will register the select2 elements for columns selection
 	 */
@@ -239,7 +259,7 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		this.makeColumnListSortable();
 		this.registerToogleShareList();
 		this.registerOnlyAllUsersInSharedList();
-		this.addColumnsOrderbyList();
+		this.registerOrderbyChangeEvent();
 		var customViewForm = jQuery('#CustomView');
 
 		if(customViewForm.length > 0) {
@@ -271,7 +291,6 @@ jQuery.Class("Vtiger_CustomView_Js",{
 					}
 					var selectValues = JSON.stringify(selectedValues);
 					jQuery('input[name="columnslist"]', self.getContainer()).val(selectValues);
-					jQuery('input[name="orderby"]').val(jQuery('#orderby').val());
 					var allUsersStatusEle = jQuery('#allUsersStatusValue');
 					if(self.isAllUsersSelected() && (jQuery('[data-toogle-members]').is(":checked"))){
 						allUsersStatusEle.val(allUsersStatusEle.data('public'));
@@ -350,38 +369,4 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		});
 	},
 
-	addElementsforOrderbyList :function(){
-		selectElement = this.getColumnSelectElement();
-		selectedOptions = selectElement.select2('data');
-		
-		for (var i= 0;i<selectedOptions.length;i++){
-			selectedOptionid = selectedOptions[i].id.split(':');
-			const newOption = document.createElement("option");
-			newOption.value = selectedOptionid[1];
-			newOption.textContent = selectedOptions[i].text;
-			jQuery("#orderby").append(newOption);
-		}
-	},
-
-	addColumnsOrderbyList :function(){
-		selectfield = document.getElementById('s2id_viewColumnsSelect');
-		this.addElementsforOrderbyList();
-
-		var observer = new MutationObserver(function(){
-			customview = new Vtiger_CustomView_Js();
-			var parent = document.getElementById("orderby");
-			
-			while(parent.lastChild){
-				parent.removeChild(parent.lastChild);
-			}
-			customview.addElementsforOrderbyList();
-		});
-		const config = { 
-			attributes: false, 
-			childList: true, 
-			characterData: false,
-			subtree:true
-		};
-		observer.observe(selectfield, config);
-	}
 });

--- a/public/layouts/v7/modules/CustomView/resources/CustomView.js
+++ b/public/layouts/v7/modules/CustomView/resources/CustomView.js
@@ -152,6 +152,38 @@ jQuery.Class("Vtiger_CustomView_Js",{
 		var aDeferred = jQuery.Deferred();
 		var formElement = jQuery("#CustomView");
 
+		var hasInvalidSort = false;
+		var fieldsUsed = [];
+		var hasDuplicateSortField = false;
+		formElement.find('.sort-condition-row').each(function() {
+			var row = jQuery(this);
+			var fieldSelect = row.find('.sort-field-select');
+			// select2 v3 対応: select2 が適用されている場合は select2('val') で正確な値を取得
+			var fieldVal = fieldSelect.data('select2') ? fieldSelect.select2('val') : fieldSelect.val();
+			var orderSelect = row.find('.sort-order-select');
+			var orderVal = orderSelect.data('select2') ? orderSelect.select2('val') : orderSelect.val();
+			if (fieldVal && !orderVal) {
+				hasInvalidSort = true;
+			}
+			if (fieldVal) {
+				if (fieldsUsed.indexOf(fieldVal) !== -1) {
+					hasDuplicateSortField = true;
+				} else {
+					fieldsUsed.push(fieldVal);
+				}
+			}
+		});
+		if (hasInvalidSort) {
+			app.helper.showErrorNotification({message: app.vtranslate('JS_PLEASE_SELECT_SORT_ORDER')});
+			aDeferred.reject();
+			return aDeferred.promise();
+		}
+		if (hasDuplicateSortField) {
+			app.helper.showErrorNotification({message: app.vtranslate('JS_DUPLICATE_SORT_FIELD_NOT_ALLOWED')});
+			aDeferred.reject();
+			return aDeferred.promise();
+		}
+
 		// Temporarily disable filter value inputs to prevent them from being serialized
 		var filterValueInputs = formElement.find('.filterConditionsDiv [data-value="value"]');
 		filterValueInputs.each(function() {
@@ -226,22 +258,214 @@ jQuery.Class("Vtiger_CustomView_Js",{
 
 	registerOrderbyChangeEvent : function() {
 		var form = jQuery('#CustomView');
-		var orderBySelect = form.find('#orderby');
-		var sortOrderSelect = form.find('#sortorder');
-		// The container is the parent div of the sortorder select
-		var sortOrderContainer = sortOrderSelect.closest('div.col-sm-3, div.col-xs-4');
+		var sortContainer = form.find('#sortConditionsContainer');
+		if (sortContainer.length === 0) return;
 
-		if(orderBySelect.length > 0) {
-			orderBySelect.on('change', function() {
-				if(jQuery(this).val() == '') {
-					sortOrderContainer.hide();
+		var sortRowsList = sortContainer.find('#sortRowsList');
+		var addFirstContainer = sortContainer.find('#addFirstSortRowContainer');
+
+		var updateRowVisibility = function() {
+			var rows = sortRowsList.find('.sort-condition-row');
+			if (rows.length === 0) {
+				addFirstContainer.removeClass('hide');
+			} else {
+				addFirstContainer.addClass('hide');
+			}
+
+			rows.each(function(index, rowElement) {
+				var row = jQuery(rowElement);
+				var addBtn = row.find('.addSortRowBtn');
+				var deleteBtn = row.find('.deleteSortRowBtn');
+				var prefixLabel = row.find('.sort-prefix-label');
+
+				if (prefixLabel.length > 0) {
+					var labelTpl = app.vtranslate('LBL_SORT_CONDITION_LABEL');
+					prefixLabel.text(labelTpl.replace('%s', index + 1));
+				}
+
+				deleteBtn.removeClass('hide');
+
+				if (index === rows.length - 1 && rows.length < 5) {
+					addBtn.removeClass('hide');
 				} else {
-					sortOrderContainer.show();
+					addBtn.addClass('hide');
 				}
 			});
-			// Trigger on load to set initial state
-			orderBySelect.trigger('change');
-		}
+		};
+
+		var reindexRows = function() {
+			var rows = sortRowsList.find('.sort-condition-row');
+			rows.each(function(index, rowElement) {
+				var row = jQuery(rowElement);
+				var fieldSelect = row.find('.sort-field-select');
+				var orderSelect = row.find('.sort-order-select');
+				fieldSelect.attr('name', 'sort_conditions[' + index + '][field]');
+				orderSelect.attr('name', 'sort_conditions[' + index + '][order]');
+			});
+			updateRowVisibility();
+		};
+
+		// Initialize select2 for existing sort selects
+		sortRowsList.find('select.select2').each(function() {
+			vtUtils.showSelect2ElementView(jQuery(this));
+		});
+
+		updateRowVisibility();
+
+		// select2 の val() 変更が change を再発火させるのを防ぐフラグ
+		var isReverting = false;
+
+		sortContainer.on('change', '.sort-field-select', function() {
+			if (isReverting) return;
+
+			var changedSelect = jQuery(this);
+			var changedVal = changedSelect.val();
+			if (!changedVal) return;
+
+			// 同じ項目が他の行で既に選ばれていないかチェック
+			var rows = sortRowsList.find('.sort-condition-row');
+			var duplicateFound = false;
+			rows.each(function() {
+				var fieldSelect = jQuery(this).find('.sort-field-select');
+				if (fieldSelect[0] === changedSelect[0]) return; // 自分自身はスキップ
+				if (fieldSelect.val() === changedVal) {
+					duplicateFound = true;
+					return false;
+				}
+			});
+
+			if (duplicateFound) {
+				var msg = app.vtranslate('JS_DUPLICATE_SORT_FIELD_NOT_ALLOWED');
+				app.helper.showErrorNotification({message: msg});
+				// 直前の値（変更前）に戻す
+				var prevVal = changedSelect.data('prev-sort-val');
+				if (prevVal) {
+					isReverting = true;
+					// select2 v3 は select2('val') で UI ごと正しく戻す
+					if (changedSelect.data('select2')) {
+						changedSelect.select2('val', prevVal);
+					} else {
+						changedSelect.val(prevVal);
+					}
+					isReverting = false;
+				}
+			} else {
+				// 正常な選択：今の値を「前の値」として保存
+				changedSelect.data('prev-sort-val', changedVal);
+			}
+		});
+
+		// 初期値を記憶しておく（編集時は DB から来た値がそのまま入る）
+		sortRowsList.find('.sort-field-select').each(function() {
+			var sel = jQuery(this);
+			sel.data('prev-sort-val', sel.val());
+		});
+
+		sortContainer.on('click', '.addSortRowBtn', function() {
+			var rows = sortRowsList.find('.sort-condition-row');
+			if (rows.length >= 5) return;
+
+			var selectedFields = [];
+			rows.each(function() {
+				var val = jQuery(this).find('.sort-field-select').val();
+				if (val) selectedFields.push(val);
+			});
+
+			var newRow;
+			if (rows.length > 0) {
+				var lastRow = rows.last();
+				newRow = lastRow.clone();
+				newRow.find('.select2-container').remove();
+				newRow.find('select').each(function() {
+					var sel = jQuery(this);
+					sel.removeClass('select2-offscreen select2-hidden-accessible');
+					sel.removeAttr('id');
+					sel.removeData('select2');
+					sel.removeData();
+				});
+
+				newRow.find('option').prop('selected', false).prop('disabled', false).removeClass('hide');
+
+				// 既存の行で選ばれていない最初の項目を初期値にする
+				var nextFieldOpt = null;
+				newRow.find('.sort-field-select option').each(function() {
+					var optVal = jQuery(this).val();
+					if (optVal && selectedFields.indexOf(optVal) === -1 && !nextFieldOpt) {
+						nextFieldOpt = optVal;
+					}
+				});
+
+				if (nextFieldOpt) {
+					newRow.find('.sort-field-select option').filter(function() {
+						return jQuery(this).val() === nextFieldOpt;
+					}).prop('selected', true);
+					newRow.find('.sort-field-select').val(nextFieldOpt);
+				}
+				newRow.find('.sort-order-select option[value="ASC"]').prop('selected', true);
+				newRow.find('.sort-order-select').val('ASC');
+
+				lastRow.after(newRow);
+			} else {
+				var fieldOptionsTemplate = form.find('#sortFieldOptionsTemplate');
+				var fieldOptionsHtml = '';
+				if (fieldOptionsTemplate.length > 0) {
+					fieldOptionsHtml = fieldOptionsTemplate.html();
+				} else {
+					var fieldSelect = form.find('.columnsSelect');
+					fieldSelect.find('optgroup').each(function() {
+						var grp = jQuery(this);
+						fieldOptionsHtml += '<optgroup label="' + grp.attr('label') + '">';
+						grp.find('option').each(function() {
+							var opt = jQuery(this);
+							var fieldVal = opt.attr('data-field-name') || opt.data('fieldName') || opt.val();
+							fieldOptionsHtml += '<option value="' + fieldVal + '">' + opt.text().replace(/\s*\*\s*$/, '') + '</option>';
+						});
+						fieldOptionsHtml += '</optgroup>';
+					});
+				}
+				var rowHtml = '<div class="sort-condition-row row" style="margin-bottom: 8px;">' +
+					'<div class="col-sm-2 col-xs-3" style="padding-top: 6px;">' +
+						'<span class="sort-prefix-label text-muted" style="font-weight: bold;">' + app.vtranslate('LBL_SORT_CONDITION_LABEL').replace('%s', 1) + '</span>' +
+					'</div>' +
+					'<div class="col-sm-5 col-xs-5">' +
+						'<select class="select2 form-control sort-field-select">' + fieldOptionsHtml + '</select>' +
+					'</div>' +
+					'<div class="col-sm-3 col-xs-3">' +
+						'<select class="select2 form-control sort-order-select">' +
+							'<option value="ASC">' + app.vtranslate('LBL_ASCENDING') + '</option>' +
+							'<option value="DESC">' + app.vtranslate('LBL_DESCENDING') + '</option>' +
+						'</select>' +
+					'</div>' +
+					'<div class="col-sm-2 col-xs-1" style="padding-top: 2px;">' +
+						'<button type="button" class="btn btn-default addSortRowBtn" title="' + app.vtranslate('LBL_ADD_SORT_ROW') + '"><i class="fa fa-plus"></i></button>' +
+						'<button type="button" class="btn btn-default deleteSortRowBtn" title="' + app.vtranslate('LBL_DELETE') + '"><i class="fa fa-trash"></i></button>' +
+					'</div>' +
+				'</div>';
+				newRow = jQuery(rowHtml);
+				sortRowsList.append(newRow);
+			}
+
+			newRow.find('select').each(function() {
+				var selectEl = jQuery(this);
+				if (selectEl.hasClass('select2')) {
+					vtUtils.showSelect2ElementView(selectEl);
+				}
+			});
+
+			// 新しい行の初期値を記憶
+			newRow.find('.sort-field-select').each(function() {
+				var sel = jQuery(this);
+				sel.data('prev-sort-val', sel.val());
+			});
+
+			reindexRows();
+		});
+
+		sortContainer.on('click', '.deleteSortRowBtn', function() {
+			var row = jQuery(this).closest('.sort-condition-row');
+			row.remove();
+			reindexRows();
+		});
 	},
 
 	/**
@@ -279,6 +503,26 @@ jQuery.Class("Vtiger_CustomView_Js",{
 						  if(mandatoryFieldsMissing){ 
 						app.helper.showErrorNotification({message: app.vtranslate('Select atleast one mandatory value.')}); 
 							  return false; 
+					} 
+
+					var fieldsUsed = [];
+					var hasDuplicateSortField = false;
+					form.find('.sort-condition-row').each(function() {
+						var row = jQuery(this);
+						var fieldSelect = row.find('.sort-field-select');
+						// select2 v3 対応: select2 が適用されている場合は select2('val') で正確な値を取得
+						var fieldVal = fieldSelect.data('select2') ? fieldSelect.select2('val') : fieldSelect.val();
+						if (fieldVal) {
+							if (fieldsUsed.indexOf(fieldVal) !== -1) {
+								hasDuplicateSortField = true;
+							} else {
+								fieldsUsed.push(fieldVal);
+							}
+						}
+					});
+					if (hasDuplicateSortField) {
+						app.helper.showErrorNotification({message: app.vtranslate('JS_DUPLICATE_SORT_FIELD_NOT_ALLOWED')});
+						return false;
 					} 
 					//handled advanced filters saved values.
 					var advfilterlist = self.advanceFilterInstance.getValues();

--- a/public/layouts/v7/modules/Vtiger/resources/List.js
+++ b/public/layouts/v7/modules/Vtiger/resources/List.js
@@ -316,13 +316,73 @@ Vtiger.Class("Vtiger_List_Js", {
 	noRecordSelectedAlert: function () {
 		return app.helper.showAlertBox({message: app.vtranslate('JS_PLEASE_SELECT_ONE_RECORD')});
 	},
+	getSortConditionsFromInput: function (listViewContainer) {
+		if (typeof listViewContainer === 'undefined' || !listViewContainer) {
+			listViewContainer = this.getListViewContainer();
+		}
+		var currentOrderByRaw = listViewContainer.find('[name="orderBy"]').val();
+		var currentSortConditions = [];
+		if (currentOrderByRaw) {
+			try {
+				var decoded = JSON.parse(currentOrderByRaw);
+				if (!Array.isArray(decoded) && typeof app.helper.decodeHTML === 'function') {
+					decoded = JSON.parse(app.helper.decodeHTML(currentOrderByRaw));
+				}
+				if (Array.isArray(decoded)) {
+					currentSortConditions = decoded;
+				}
+			} catch (err) {
+				try {
+					if (typeof app.helper.decodeHTML === 'function') {
+						var decoded2 = JSON.parse(app.helper.decodeHTML(currentOrderByRaw));
+						if (Array.isArray(decoded2)) {
+							currentSortConditions = decoded2;
+						}
+					}
+				} catch (e2) {
+					currentSortConditions = [];
+				}
+			}
+			if (currentSortConditions.length === 0 && typeof currentOrderByRaw === 'string' && currentOrderByRaw.indexOf('[') === -1 && currentOrderByRaw.indexOf('{') === -1) {
+				var trimmedField = jQuery.trim(currentOrderByRaw);
+				if (trimmedField) {
+					var currentSortOrder = listViewContainer.find('[name="sortOrder"]').val() || 'ASC';
+					currentSortConditions.push({field: trimmedField, order: currentSortOrder});
+				}
+			}
+		}
+		return currentSortConditions;
+	},
 	registerRemoveListViewSort: function () {
 		var listViewContainer = this.getListViewContainer();
 		var thisInstance = this;
 
 		listViewContainer.on('click', '.removeSorting', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			var removeColumn = jQuery(e.currentTarget).data('removeColumn');
+			var currentSortConditions = thisInstance.getSortConditionsFromInput(listViewContainer);
+
+			if (removeColumn && currentSortConditions.length > 0) {
+				var newConditions = currentSortConditions.filter(function(item) {
+					return item.field !== removeColumn;
+				});
+				if (newConditions.length > 0) {
+					var newOrderByJson = JSON.stringify(newConditions);
+					var newSortOrder = newConditions[0].order;
+					listViewContainer.find('[name="sortOrder"]').val(newSortOrder);
+					listViewContainer.find('[name="orderBy"]').val(newOrderByJson);
+					thisInstance.loadListViewRecords({'orderby': newOrderByJson, 'sortorder': newSortOrder});
+					return;
+				}
+			}
+
 			var cvId = thisInstance.getCurrentCvId();
-			thisInstance.loadFilter(cvId, {'mode': 'removeSorting'});
+			listViewContainer.find('[name="orderBy"]').val('');
+			listViewContainer.find('#orderBy').val('');
+			listViewContainer.find('[name="sortOrder"]').val('');
+			listViewContainer.find('#sortOrder').val('');
+			thisInstance.loadFilter(cvId, {'mode': 'removeSorting', 'orderby': '', 'sortorder': ''});
 		});
 	},
 	registerResetColumnWidths: function () {
@@ -442,15 +502,54 @@ Vtiger.Class("Vtiger_List_Js", {
 		var listViewContainer = this.getListViewContainer();
 		var thisInstance = this;
 		listViewContainer.on('click', '.listViewContentHeaderValues', function (e) {
-			var fieldName = jQuery(e.currentTarget).data('columnname');
-			var sortOrderVal = jQuery(e.currentTarget).data('nextsortorderval');
-			if (sortOrderVal === 'ASC') {
-				jQuery('i', e.currentTarget).addClass('fa-sort-asc');
-			} else {
-				jQuery('i', e.currentTarget).addClass('fa-sort-desc');
+			var element = jQuery(e.currentTarget);
+			var fieldName = element.data('columnname');
+			var sortOrderVal = element.data('nextsortorderval');
+
+			// ソートアイコン（i要素）またはその直近がクリックされた場合、上下の位置で昇順/降順を直接決定
+			var target = jQuery(e.target);
+			var iconEl = target.is('i') ? target : target.closest('.listViewContentHeaderValues').find('i.fa');
+			if (target.is('i') || target.hasClass('fa-sort') || target.hasClass('customsort')) {
+				var offset = iconEl.offset();
+				var height = iconEl.outerHeight() || 14;
+				var clickY = e.pageY - offset.top;
+				if (clickY > height / 2) {
+					sortOrderVal = 'DESC';
+				} else {
+					sortOrderVal = 'ASC';
+				}
 			}
-			listViewContainer.find('[name="sortOrder"]').val(sortOrderVal);
-			listViewContainer.find('[name="orderBy"]').val(fieldName);
+
+			var currentSortConditions = thisInstance.getSortConditionsFromInput(listViewContainer);
+
+			var foundIndex = -1;
+			for (var i = 0; i < currentSortConditions.length; i++) {
+				if (currentSortConditions[i].field === fieldName) {
+					foundIndex = i;
+					break;
+				}
+			}
+
+			if (foundIndex !== -1) {
+				currentSortConditions[foundIndex].order = sortOrderVal;
+			} else {
+				if (currentSortConditions.length >= 5) {
+					app.helper.showAlertBox({message: app.vtranslate('JS_MAX_SORT_CONDITIONS_LIMIT')});
+					return;
+				}
+				currentSortConditions.push({field: fieldName, order: sortOrderVal});
+			}
+
+			if (sortOrderVal === 'ASC') {
+				jQuery('i', element).removeClass('fa-sort-desc customsort').addClass('fa-sort-asc');
+			} else {
+				jQuery('i', element).removeClass('fa-sort-asc customsort').addClass('fa-sort-desc');
+			}
+
+			var newOrderByJson = JSON.stringify(currentSortConditions);
+			listViewContainer.find('[name="sortOrder"]').val(currentSortConditions[0].order);
+			listViewContainer.find('[name="orderBy"]').val(newOrderByJson);
+
 			var cvId = thisInstance.getCurrentCvId();
 			thisInstance.loadListViewRecords();
 		});

--- a/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
+++ b/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * マイグレーション: add_orderby_to_customview
+ * 生成日時: 20260625044739
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260625044739_AddOrderbyToCustomview extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     * ここにマイグレーション処理を記述してください
+     */
+    public function process() {
+        $sql = "ALTER TABLE vtiger_customview ADD orderby varchar(250)";
+        $this->db->pquery($sql, array());
+        
+        $this->log("マイグレーション add_orderby_to_customview が正常に完了しました");
+    }
+}

--- a/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
+++ b/setup/migration/scripts/20260625044739_add_orderby_to_customview.php
@@ -13,7 +13,12 @@ class Migration20260625044739_AddOrderbyToCustomview extends FRMigrationClass {
      * ここにマイグレーション処理を記述してください
      */
     public function process() {
-        $sql = "ALTER TABLE vtiger_customview ADD orderby varchar(250)";
+        $result = $this->db->pquery("SHOW COLUMNS FROM vtiger_customview LIKE 'orderby'", array());
+        if ($result && $this->db->num_rows($result) > 0) {
+            $sql = "ALTER TABLE vtiger_customview MODIFY orderby varchar(1000)";
+        } else {
+            $sql = "ALTER TABLE vtiger_customview ADD orderby varchar(1000)";
+        }
         $this->db->pquery($sql, array());
         
         $this->log("マイグレーション add_orderby_to_customview が正常に完了しました");

--- a/setup/migration/scripts/20260625054700_add_sortorder_to_customview.php
+++ b/setup/migration/scripts/20260625054700_add_sortorder_to_customview.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * マイグレーション: add_sortorder_to_customview
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260625054700_AddSortorderToCustomview extends FRMigrationClass {
+    
+    /**
+     * マイグレーションを実行する
+     */
+    public function process() {
+        $db = PearDatabase::getInstance();
+        $result = $db->pquery("SHOW COLUMNS FROM vtiger_customview LIKE 'sortorder'", array());
+        if ($db->num_rows($result) == 0) {
+            $db->pquery("ALTER TABLE vtiger_customview ADD sortorder varchar(250) DEFAULT 'ASC'", array());
+            $this->log("sortorderカラムをvtiger_customviewに追加しました。");
+        }
+        $this->log("マイグレーション add_sortorder_to_customview が正常に完了しました");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1759 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. リスト（一覧表示）で複数の条件でそれぞれ昇順・降順にソートを出来るようにしたい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. ソート機能が単一のフィールド名のみしか扱えない設計となっていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. DB（マイグレーション）
vtiger_customview の orderby カラムサイズを拡張し、複数ソート条件を保存可能に変更。
2. バックエンド（SQL生成・モデル）
複数ソート条件の受け取り・共通フォーマット化処理を追加。
各項目ごとに個別指定された昇順/降順を反映し、ORDER BY カラム1 [ASC|DESC], カラム2 [ASC|DESC] ... の形式で動的に SQL句を組み立てるロジックを実装（各モジュールの ListView および CustomView）。
3. カスタムビュー編集画面 (UI)
デフォルトソート条件を最大5個まで動的に追加・削除できる UI を追加。
各行で項目および昇順/降順を独立して設定可能にし、同じ項目の重複選択を防止するチェック処理を追加。
4. 一覧表示画面 (UI)
ヘッダーカラムのクリックでソート条件を追加・昇順/降順切り替え（最大5個）できるように拡張。
アイコンの上/下クリックでの昇順/降順ダイレクト指定、および特定項目のソート解除機能に対応。
5. 多言語対応 (i18n)
第%sソート条件、条件重複時の警告メッセージなどの文言を日本語・英語ファイルに追加。


## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
デフォルトソートの設定画面
<img width="886" height="394" alt="image" src="https://github.com/user-attachments/assets/34b5bafc-d0b8-41a3-9abf-9b09c31f1492" />
生成されるリスト
<img width="886" height="192" alt="image" src="https://github.com/user-attachments/assets/7ab5bda3-ffaf-4333-a45f-4f0f256ac21d" />
手動ソートの設定画面と生成されるリスト
<img width="886" height="181" alt="image" src="https://github.com/user-attachments/assets/82952942-2711-452c-b2db-8154a8aee42c" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->