### PR TITLE
[要望] #1773 テキスト項目内のURLを自動リンク表示

### DIFF
--- a/includes/runtime/Viewer.php
+++ b/includes/runtime/Viewer.php
@@ -86,7 +86,7 @@ class Vtiger_Viewer extends Smarty {
 			'Vtiger_Tag_Model', 'Settings_Vtiger_Module_Model', 'PBXManager_Server_Model',
 			'Vtiger_Functions', 'Users', 'CurrencyField', 'Reports_Field_Model', 
 			'DateTimeField', 'Calendar_Time_UIType', 'Calendar_Field_Model',
-			'Vtiger_Date_UIType', 'Vtiger_Time_UIType', 'Vtiger_RelationListView_Model',
+			'Vtiger_Date_UIType', 'Vtiger_Time_UIType', 'Vtiger_Text_UIType', 'Vtiger_RelationListView_Model',
 			'Inventory_TaxRegion_Model', 'EmailTemplates_Module_Model', 'Project_Record_Model', 'Settings_SMSNotifier_ProviderField_Model',);
 
 		if ($inSettings) {

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -218,6 +218,8 @@
 										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'reference'}
 											{$LISTVIEW_ENTRY->getTitle($LISTVIEW_HEADER)}
 										{else if $LISTVIEW_HEADER->get('uitype') eq '360'}
+										{else if $LISTVIEW_HEADER->getFieldDataType() eq 'string' || $LISTVIEW_HEADER->getFieldDataType() eq 'text'}
+											{Vtiger_Text_UIType::linkifyUrlsForList(vtranslate($LISTVIEW_ENTRY_VALUE, $MODULE))}
 										{else}
 											{vtranslate($LISTVIEW_ENTRY_VALUE, $MODULE)}
 										{/if}

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -988,7 +988,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							}
 						} else if (!in_array($fieldName, array('date_start', 'due_date'))) {
 							if ($fieldModel) {
-								if ($fieldDataType != 'picklist'){
+								if (!in_array($fieldDataType, array('picklist', 'string', 'text'))){
 									$recordData[$fieldName] = $fieldModel->getDisplayValue($fieldValue);
 								}
 							}

--- a/modules/Vtiger/helpers/PDF.php
+++ b/modules/Vtiger/helpers/PDF.php
@@ -50,7 +50,7 @@ class PDF_helper {
 			
 			$recordModel = PDFTemplates_Record_Model::getInstanceById($templateId);
 			$pdffilename = Vtiger_InventoryPDFController::getMergedDescription($recordModel->get("pdffilename"), $recordIdData, $moduleName);
-			$filename = ($pdffilename ? $pdffilename : $templateName);
+			$filename = strip_tags($pdffilename ? $pdffilename : $templateName);
 			header("Pragma: public");
 			header("Expires: 0");
 			header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
@@ -137,7 +137,7 @@ class PDF_helper {
 				
 				$pdffilename = Vtiger_InventoryPDFController::getMergedDescription($recordModel->get("pdffilename"), $recordId, $moduleName);
 				$pdffilename = Vtiger_InventoryPDFController::applyingFunctions($pdffilename, $recordId, $moduleName);
-				$filename = ($pdffilename ? $pdffilename : $templateName);
+				$filename = strip_tags($pdffilename ? $pdffilename : $templateName);
 				$hostfilepath = $hostfiledirectory.$uniquekey;
 				$dockerfilepath = $dokerfiledirectory.$uniquekey;
 		

--- a/modules/Vtiger/uitypes/String.php
+++ b/modules/Vtiger/uitypes/String.php
@@ -1,0 +1,21 @@
+<?php
+/*+***********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.0
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is:  vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ *************************************************************************************/
+
+class Vtiger_String_UIType extends Vtiger_Base_UIType {
+
+	/**
+	 * Function to get the Display Value, for the current field type with given DB Insert Value
+	 * @param <Object> $value
+	 * @return <Object>
+	 */
+	public function getDisplayValue($value, $record=false, $recordInstance=false) {
+		return Vtiger_Text_UIType::linkifyUrls($value);
+	}
+}

--- a/modules/Vtiger/uitypes/Text.php
+++ b/modules/Vtiger/uitypes/Text.php
@@ -21,8 +21,28 @@ class Vtiger_Text_UIType extends Vtiger_Base_UIType {
 		}
                 if($removeTags){
                     $value = strip_tags($value,'<br>');
+                    return nl2br(purifyHtmlEventAttributes($value, true));
                 }
-		return nl2br(purifyHtmlEventAttributes($value, true));
+		return self::linkifyUrls(nl2br(purifyHtmlEventAttributes($value, true)));
+	}
+
+	/**
+	 * テキスト中のURLをリンク表示に変換する（既存タグ内は対象外、全角文字・閉じ括弧はURLに含めない） #1773
+	 * @param <String> $value
+	 * @return <String>
+	 */
+	public static function linkifyUrls($value) {
+		$pattern = '/<[^>]*>|(https?:\/\/[^\s<>"\'\x{3000}-\x{30FF}\x{4E00}-\x{9FFF}\x{FF00}-\x{FFEF})\]]+)/u';
+		$result = preg_replace_callback($pattern, function($matches) {
+			if(empty($matches[1])) {
+				return $matches[0];
+			}
+			$url = rtrim($matches[1], '.,');
+			$trail = substr($matches[1], strlen($url));
+			return '<a class="urlField cursorPointer" href="'.$url.'" target="_blank">'.$url.'</a>'.$trail;
+		}, $value);
+		// 不正なUTF-8バイト列を含む値ではnullが返るため、元の値をそのまま表示する
+		return $result === null ? $value : $result;
 	}
     
     /**

--- a/modules/Vtiger/uitypes/Text.php
+++ b/modules/Vtiger/uitypes/Text.php
@@ -27,7 +27,7 @@ class Vtiger_Text_UIType extends Vtiger_Base_UIType {
 	}
 
 	/**
-	 * テキスト中のURLをリンク表示に変換する（既存タグ内は対象外、全角文字・閉じ括弧はURLに含めない） #1773
+	 * テキスト中のURLをリンク表示に変換する
 	 * @param <String> $value
 	 * @return <String>
 	 */
@@ -41,7 +41,7 @@ class Vtiger_Text_UIType extends Vtiger_Base_UIType {
 			$trail = substr($matches[1], strlen($url));
 			return '<a class="urlField cursorPointer" href="'.$url.'" target="_blank">'.$url.'</a>'.$trail;
 		}, $value);
-		// 不正なUTF-8バイト列を含む値ではnullが返るため、元の値をそのまま表示する
+		// 不正なUTF-8バイト列ではnullが返るため元の値を表示する
 		return $result === null ? $value : $result;
 	}
     

--- a/modules/Vtiger/uitypes/Text.php
+++ b/modules/Vtiger/uitypes/Text.php
@@ -16,13 +16,76 @@ class Vtiger_Text_UIType extends Vtiger_Base_UIType {
 	 * @return <Object>
 	 */
 	public function getDisplayValue($value, $record=false, $recordInstance = false,$removeTags = false) {
+		// nullでPHP8.1以降の非推奨警告が出ないよう文字列に揃える
+		$value = (string)$value;
 		if(in_array($this->get('field')->getFieldName(),array('signature','commentcontent'))) {
 			return $value;
 		}
                 if($removeTags){
                     $value = strip_tags($value,'<br>');
                 }
-		return nl2br(purifyHtmlEventAttributes($value, true));
+		$value = nl2br(purifyHtmlEventAttributes($value, true));
+		if(!$removeTags) {
+			$value = self::linkifyUrls($value);
+		}
+		return $value;
+	}
+
+	/**
+	 * テキスト中のURLをリンク表示に変換する
+	 * @param <String> $value
+	 * @return <String>
+	 */
+	public static function linkifyUrls($value) {
+		// 文字列以外が渡された場合は変換せずそのまま返す
+		if(!is_string($value)) {
+			return $value;
+		}
+		// URLに含めない和文文字の範囲
+		$cjk = '\x{3000}-\x{30FF}\x{3400}-\x{4DBF}\x{4E00}-\x{9FFF}\x{F900}-\x{FAFF}\x{FF00}-\x{FFEF}\x{20000}-\x{3FFFF}';
+		// URLに使える文字。空白・タグ文字・引用符・和文文字は含めない
+		$urlChar = '[^\s<>"\''.$cjk.']';
+		// 既存のリンク要素とタグを先にマッチさせて読み飛ばし、裸のURLのみリンク化する
+		$pattern = '/<a\b[^>]*>.*?<\/a>'.
+			'|<[^>]*>'.
+			'|(https?:\/\/'.$urlChar.'+)/uis';
+		$result = preg_replace_callback($pattern, function($matches) {
+			if(empty($matches[1])) {
+				return $matches[0];
+			}
+			$url = $matches[1];
+			$tail = '';
+			// 文末記号と対応しない閉じ括弧・角括弧はURLから外して本文側に残す
+			while($url !== '') {
+				$last = substr($url, -1);
+				$unpaired = ($last === ')' && substr_count($url, '(') < substr_count($url, ')'));
+				if(strpos('.,;:!?]', $last) === false && !$unpaired) {
+					break;
+				}
+				$tail = $last.$tail;
+				$url = substr($url, 0, -1);
+			}
+			// 削り込みでスキームだけになった場合はリンク化しない
+			if(!preg_match('/^https?:\/\/./ui', $url)) {
+				return $matches[0];
+			}
+			return '<a class="urlField cursorPointer" href="'.$url.'" target="_blank" rel="noopener noreferrer">'.$url.'</a>'.$tail;
+		}, $value);
+		// 不正なUTF-8バイト列ではnullが返るため元の値を表示する
+		return $result === null ? $value : $result;
+	}
+
+	/**
+	 * 一覧画面の表示値をリンク表示に変換する
+	 * @param <String> $value
+	 * @return <String>
+	 */
+	public static function linkifyUrlsForList($value) {
+		// 文字数制限で切り詰められた値はURLも切れている可能性があるためリンク化しない
+		if(is_string($value) && substr($value, -3) === '...') {
+			return $value;
+		}
+		return self::linkifyUrls($value);
 	}
     
     /**

--- a/public/layouts/v7/modules/Vtiger/resources/Detail.js
+++ b/public/layouts/v7/modules/Vtiger/resources/Detail.js
@@ -1167,7 +1167,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			fieldName = multiPicklistFieldName[0];
 		}
 
-		var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','currencyList','text', 'documentsFolder'];
+		var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','currencyList','text', 'documentsFolder', 'string'];
 		if(jQuery.inArray(fieldType, customHandlingFields) !== -1){
 			value = rawValue;
 		}
@@ -1310,7 +1310,7 @@ Vtiger.Class("Vtiger_Detail_Js",{
 			}
 
 			// prev Value should be taken based on field Type
-			var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','boolean']; 
+			var customHandlingFields = ['owner','ownergroup','picklist','multipicklist','reference','boolean','string']; 
 			if(jQuery.inArray(fieldType, customHandlingFields) !== -1){
 				previousValue = fieldBasicData.data('value');
 			}


### PR DESCRIPTION
本文：
## 関連Issue / Related Issue
- fix #1773

## 要望の内容 / Request
入力されたテキスト(単数行・複数行)の中にURLが含まれる場合は自動でリンク表示されるようにしてほしい。

## 変更内容 / Details of Change
1. テキスト項目（単数行・複数行）の表示時、文中の URL 部分のみ自動でリンク化
2. 既にリンクの箇所・全角文字・末尾の句読点は URL に含めない

## スクリーンショット / Screenshot
テキスト項目（単数行)
<img width="839" height="553" alt="image" src="https://github.com/user-attachments/assets/1c8aabae-24df-46e4-b961-e69f206bcf5c" />
テキスト項目（複数行)
<img width="886" height="740" alt="image" src="https://github.com/user-attachments/assets/2af9b6cb-f80c-4508-a7a6-8869d55f8bf8" />

## 影響範囲 / Affected Area
- テキスト（複数行）: 詳細画面・概要・クイックプレビュー・インライン編集後再表示・メール差込本文
- テキスト（単数行）: 詳細画面・概要・クイックプレビュー・インライン編集後再表示・メール差込本文
## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った