### PR TITLE
#1794 カレンダーの色選択をプリセットパレット＋カスタム指定に統一

### DIFF
--- a/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.test.tsx
+++ b/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CalendarColorPicker } from "./CalendarColorPicker";
+import { CALENDAR_COLOR_PALETTE, isPresetColor, normalizeHex } from "./colors";
+
+/**
+ * CalendarColorPicker を <form> 内にレンダリングし、
+ * 周辺処理が参照する hidden input(.selectedColor) を併設するヘルパー。
+ */
+function renderInForm(props: {
+  value?: string;
+  onChange?: (hex: string) => void;
+}) {
+  const utils = render(
+    <form>
+      <input type="hidden" className="selectedColor" defaultValue="" />
+      <CalendarColorPicker {...props} />
+    </form>,
+  );
+  const hiddenInput = utils.container.querySelector(
+    "input.selectedColor",
+  ) as HTMLInputElement;
+  return { ...utils, hiddenInput };
+}
+
+describe("normalizeHex", () => {
+  it("#付き6桁をそのまま小文字化する", () => {
+    expect(normalizeHex("#EF4444")).toBe("#ef4444");
+  });
+
+  it("#無しでも補完する", () => {
+    expect(normalizeHex("ef4444")).toBe("#ef4444");
+  });
+
+  it("3桁形式を6桁に展開する", () => {
+    expect(normalizeHex("#f00")).toBe("#ff0000");
+  });
+
+  it("不正値は null を返す", () => {
+    expect(normalizeHex("")).toBeNull();
+    expect(normalizeHex("red")).toBeNull();
+    expect(normalizeHex("#12345")).toBeNull();
+    expect(normalizeHex(undefined)).toBeNull();
+  });
+});
+
+describe("isPresetColor", () => {
+  it("パレット内の色を判定する", () => {
+    expect(isPresetColor(CALENDAR_COLOR_PALETTE[0].hex)).toBe(true);
+    expect(isPresetColor("#EF4444")).toBe(true); // 大文字でも一致
+  });
+
+  it("パレット外の色は false", () => {
+    expect(isPresetColor("#123456")).toBe(false);
+  });
+});
+
+describe("CalendarColorPicker", () => {
+  it("全プリセット色のスウォッチが描画される", () => {
+    renderInForm({});
+    CALENDAR_COLOR_PALETTE.forEach((swatch) => {
+      expect(screen.getByLabelText(swatch.name)).toBeInTheDocument();
+    });
+  });
+
+  it("プリセット選択で hidden input に #rrggbb が書き込まれ、onChange が発火する", () => {
+    const onChange = vi.fn();
+    const { hiddenInput } = renderInForm({ onChange });
+
+    const target = CALENDAR_COLOR_PALETTE[3];
+    fireEvent.click(screen.getByLabelText(target.name));
+
+    expect(hiddenInput.value).toBe(target.hex);
+    expect(onChange).toHaveBeenCalledWith(target.hex);
+  });
+
+  it("value 属性の初期値が hidden input に反映される", () => {
+    const { hiddenInput } = renderInForm({ value: "#ABCDEF" });
+    expect(hiddenInput.value).toBe("#abcdef");
+  });
+
+  it("カスタムHEX入力で任意のRGB色を指定できる", () => {
+    const onChange = vi.fn();
+    const { hiddenInput } = renderInForm({ onChange });
+
+    const hexInput = screen.getByLabelText(
+      "カラーコード（16進数）",
+    ) as HTMLInputElement;
+    fireEvent.change(hexInput, { target: { value: "#123abc" } });
+
+    expect(hiddenInput.value).toBe("#123abc");
+    expect(onChange).toHaveBeenCalledWith("#123abc");
+  });
+
+  it("不正なHEX入力ではコミットされない", () => {
+    const onChange = vi.fn();
+    const { hiddenInput } = renderInForm({ onChange });
+
+    const hexInput = screen.getByLabelText(
+      "カラーコード（16進数）",
+    ) as HTMLInputElement;
+    fireEvent.change(hexInput, { target: { value: "#12" } });
+
+    expect(hiddenInput.value).toBe("");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.test.tsx
+++ b/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.test.tsx
@@ -1,7 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CalendarColorPicker } from "./CalendarColorPicker";
-import { CALENDAR_COLOR_PALETTE, isPresetColor, normalizeHex } from "./colors";
+import {
+  CALENDAR_COLOR_BLOCKS,
+  CALENDAR_COLOR_COLUMNS,
+  CALENDAR_COLOR_HUE_GROUPS,
+  CALENDAR_COLOR_PALETTE,
+  CALENDAR_COLOR_TIERS,
+  getCalendarColorHexes,
+  isPresetColor,
+  normalizeHex,
+} from "./colors";
 
 /**
  * CalendarColorPicker を <form> 内にレンダリングし、
@@ -44,6 +53,90 @@ describe("normalizeHex", () => {
   });
 });
 
+describe("CALENDAR_COLOR_PALETTE の並び順", () => {
+  it("色相 × 階調のマトリクスとして色数が決まる", () => {
+    const hueCount = CALENDAR_COLOR_HUE_GROUPS.flat().length;
+    expect(CALENDAR_COLOR_PALETTE).toHaveLength(
+      hueCount * CALENDAR_COLOR_TIERS.length,
+    );
+  });
+
+  it("すべての色相グループが列数と同じ色相数を持つ", () => {
+    CALENDAR_COLOR_HUE_GROUPS.forEach((group) => {
+      expect(group).toHaveLength(CALENDAR_COLOR_COLUMNS);
+    });
+  });
+
+  it("各ブロックが対応する色相グループの並び順になる", () => {
+    expect(CALENDAR_COLOR_BLOCKS).toHaveLength(
+      CALENDAR_COLOR_HUE_GROUPS.length,
+    );
+
+    CALENDAR_COLOR_HUE_GROUPS.forEach((group, index) => {
+      expect([
+        ...new Set(CALENDAR_COLOR_BLOCKS[index].map((swatch) => swatch.hue)),
+      ]).toEqual(group.map((hue) => hue.key));
+    });
+  });
+
+  it("各ブロックは1行=1階調で並ぶ", () => {
+    CALENDAR_COLOR_BLOCKS.forEach((block) => {
+      expect(block).toHaveLength(
+        CALENDAR_COLOR_COLUMNS * CALENDAR_COLOR_TIERS.length,
+      );
+
+      CALENDAR_COLOR_TIERS.forEach((tier, rowIndex) => {
+        const row = block.slice(
+          rowIndex * CALENDAR_COLOR_COLUMNS,
+          (rowIndex + 1) * CALENDAR_COLOR_COLUMNS,
+        );
+        expect(row.map((swatch) => swatch.tier)).toEqual(row.map(() => tier));
+      });
+    });
+  });
+
+  it("各ブロックは1列=1色相の濃淡になる", () => {
+    CALENDAR_COLOR_BLOCKS.forEach((block) => {
+      for (let column = 0; column < CALENDAR_COLOR_COLUMNS; column++) {
+        const hues = CALENDAR_COLOR_TIERS.map(
+          (_, rowIndex) =>
+            block[rowIndex * CALENDAR_COLOR_COLUMNS + column].hue,
+        );
+        expect(new Set(hues).size).toBe(1);
+      }
+    });
+  });
+
+  it("パレットはブロックを順に連結した並びになる", () => {
+    expect(CALENDAR_COLOR_PALETTE).toEqual(CALENDAR_COLOR_BLOCKS.flat());
+  });
+
+  it("同じ色が重複しない", () => {
+    const hexes = CALENDAR_COLOR_PALETTE.map((swatch) => swatch.hex);
+    expect(new Set(hexes).size).toBe(hexes.length);
+  });
+
+  it("表示ラベルに Tailwind の内部名（red-500 等）を使わない", () => {
+    CALENDAR_COLOR_PALETTE.forEach((swatch) => {
+      expect(swatch.label).not.toMatch(/[a-z]+-\d{3}/);
+    });
+  });
+});
+
+describe("getCalendarColorHexes", () => {
+  it("プリセット全色のHEXを並び順どおりに返す", () => {
+    expect(getCalendarColorHexes()).toEqual(
+      CALENDAR_COLOR_PALETTE.map((swatch) => swatch.hex),
+    );
+  });
+
+  it("返す色はすべてプリセットとして判定できる", () => {
+    getCalendarColorHexes().forEach((hex) => {
+      expect(isPresetColor(hex)).toBe(true);
+    });
+  });
+});
+
 describe("isPresetColor", () => {
   it("パレット内の色を判定する", () => {
     expect(isPresetColor(CALENDAR_COLOR_PALETTE[0].hex)).toBe(true);
@@ -59,7 +152,7 @@ describe("CalendarColorPicker", () => {
   it("全プリセット色のスウォッチが描画される", () => {
     renderInForm({});
     CALENDAR_COLOR_PALETTE.forEach((swatch) => {
-      expect(screen.getByLabelText(swatch.name)).toBeInTheDocument();
+      expect(screen.getByLabelText(swatch.label)).toBeInTheDocument();
     });
   });
 
@@ -68,10 +161,28 @@ describe("CalendarColorPicker", () => {
     const { hiddenInput } = renderInForm({ onChange });
 
     const target = CALENDAR_COLOR_PALETTE[3];
-    fireEvent.click(screen.getByLabelText(target.name));
+    fireEvent.click(screen.getByLabelText(target.label));
 
     expect(hiddenInput.value).toBe(target.hex);
     expect(onChange).toHaveBeenCalledWith(target.hex);
+  });
+
+  it("プリセット選択でHEX入力欄に選択色が反映される", () => {
+    renderInForm({});
+
+    const target = CALENDAR_COLOR_PALETTE[5];
+    fireEvent.click(screen.getByLabelText(target.label));
+
+    expect(screen.getByLabelText("カラーコード（16進数）")).toHaveValue(
+      target.hex,
+    );
+  });
+
+  it("カスタム色の指定UIが「色を選ぶ」と表示され、カラー入力に紐づく", () => {
+    renderInForm({});
+
+    expect(screen.getByText("色を選ぶ")).toBeInTheDocument();
+    expect(screen.getByLabelText("色を選ぶ")).toHaveAttribute("type", "color");
   });
 
   it("value 属性の初期値が hidden input に反映される", () => {

--- a/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.tsx
+++ b/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Check } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { CALENDAR_COLOR_PALETTE, isPresetColor, normalizeHex } from "./colors";
+import { CALENDAR_COLOR_BLOCKS, isPresetColor, normalizeHex } from "./colors";
 
 /** カスタム(RGB)入力の初期表示に使うフォールバック色 */
 const FALLBACK_COLOR = "#3b82f6";
@@ -117,70 +117,98 @@ export const CalendarColorPicker: React.FC<CalendarColorPickerProps> = ({
   const colorInputValue = normalizeHex(current) ?? FALLBACK_COLOR;
 
   return (
-    <div ref={rootRef} className="inline-flex flex-col gap-3 align-top">
-      {/* プリセット色（Tailwind パレット） */}
+    <div ref={rootRef} className="inline-flex w-fit flex-col gap-3 align-top">
+      {/*
+        プリセット色。横=色相 / 縦=明るさ（1列がその色相の濃淡）のグリッド。
+        全色相は横幅に収まらないため、色相を上下2グループに分けている
+        （各 3行 × 7列）。列数は CALENDAR_COLOR_COLUMNS と grid-cols-7 を
+        一致させること。
+        グループ間の間隔は行間と同じにして、全体が 6行 × 7列 の一枚の表として
+        見えるようにする。
+
+        サイズは rem ではなく px で指定する。CRM 本体が html に font-size:10px を
+        設定しているため、rem ベースの指定（h-7 等）は 62.5% に縮んでしまう。
+      */}
       <div
-        className="flex max-w-[320px] flex-wrap gap-1.5"
+        className="flex flex-col gap-[6px]"
         role="listbox"
         aria-label="プリセットカラー"
       >
-        {CALENDAR_COLOR_PALETTE.map((swatch) => {
-          const selected = normalizeHex(current) === swatch.hex;
-          return (
-            <button
-              key={swatch.name}
-              type="button"
-              role="option"
-              aria-selected={selected}
-              aria-label={swatch.name}
-              title={swatch.name}
-              onClick={() => commit(swatch.hex)}
-              style={{ backgroundColor: swatch.hex }}
-              className={cn(
-                "flex h-6 w-6 items-center justify-center rounded-md border border-black/10 transition-transform",
-                "hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-700 focus-visible:ring-offset-1",
-                selected && "ring-2 ring-gray-800 ring-offset-1",
-              )}
-            >
-              {selected && (
-                <Check
-                  className="h-4 w-4"
-                  style={{ color: getReadableTextColor(swatch.hex) }}
-                  aria-hidden="true"
-                />
-              )}
-            </button>
-          );
-        })}
+        {CALENDAR_COLOR_BLOCKS.map((block) => (
+          <div key={block[0].hue} className="grid grid-cols-7 gap-[6px]">
+            {block.map((swatch) => {
+              const selected = normalizeHex(current) === swatch.hex;
+              return (
+                <button
+                  key={swatch.name}
+                  type="button"
+                  role="option"
+                  aria-selected={selected}
+                  aria-label={swatch.label}
+                  title={swatch.label}
+                  onClick={() => commit(swatch.hex)}
+                  style={{ backgroundColor: swatch.hex }}
+                  className={cn(
+                    "flex h-[28px] w-[44px] items-center justify-center rounded-[5px] border border-black/10 transition",
+                    "hover:ring-2 hover:ring-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-700 focus-visible:ring-offset-1",
+                    selected &&
+                      "ring-2 ring-gray-800 ring-offset-1 hover:ring-gray-800",
+                  )}
+                >
+                  {selected && (
+                    <Check
+                      className="h-[16px] w-[16px]"
+                      style={{ color: getReadableTextColor(swatch.hex) }}
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        ))}
       </div>
 
       {/* カスタム(RGB)指定 */}
-      <div className="flex items-center gap-2">
-        <span className="text-md text-gray-700">カスタム</span>
+      <div className="flex items-center gap-[8px]">
+        <span className="text-base text-gray-700">カスタム</span>
+
+        {/*
+          ネイティブのカラーピッカーを開くボタン。input[type=color] 自体は
+          見た目を制御できないため透明にして重ね、枠線・ホバー・アイコンで
+          「押せる」ことが分かる見た目をラベル側で作る。
+          m-0 は CRM 本体の Bootstrap が持つ label{margin-bottom:5px} の打ち消し。
+          これが無いと隣の入力欄と縦位置が 2.5px ずれる。
+        */}
         <label
           className={cn(
-            "relative flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-black/10",
+            "relative m-0 flex h-[32px] flex-shrink-0 cursor-pointer items-center gap-[8px] rounded-[6px] border border-input bg-white px-[10px]",
+            "shadow-sm transition hover:bg-gray-50 focus-within:ring-2 focus-within:ring-gray-700 focus-within:ring-offset-1",
             usingCustomColor && "ring-2 ring-gray-800 ring-offset-1",
           )}
-          style={{ backgroundColor: colorInputValue }}
-          title="カスタムカラーを選択"
+          title="クリックしてカラーピッカーを開く"
         >
-          {/* ネイティブのカラーピッカー（RGB指定）。見た目はラベルの背景色で表現 */}
+          <span
+            className="h-[20px] w-[20px] flex-shrink-0 rounded-[4px] border border-black/10"
+            style={{ backgroundColor: colorInputValue }}
+            aria-hidden="true"
+          />
+          <span className="text-base whitespace-nowrap text-gray-700">
+            色を選ぶ
+          </span>
+          <ChevronDown
+            className="h-[16px] w-[16px] flex-shrink-0 text-gray-500"
+            aria-hidden="true"
+          />
           <input
             type="color"
             value={colorInputValue}
             onChange={(e) => commit(e.target.value)}
             className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
-            aria-label="カスタムカラー（RGB）"
           />
-          {usingCustomColor && (
-            <Check
-              className="pointer-events-none h-4 w-4"
-              style={{ color: getReadableTextColor(colorInputValue) }}
-              aria-hidden="true"
-            />
-          )}
         </label>
+
+        {/* 現在の色（HEX）。#込みの7文字が省略されない幅・等幅フォントで表示する */}
         <input
           type="text"
           value={hexDraft}
@@ -188,28 +216,15 @@ export const CalendarColorPicker: React.FC<CalendarColorPickerProps> = ({
           onBlur={handleHexInputBlur}
           placeholder="#RRGGBB"
           maxLength={7}
+          size={8}
           spellCheck={false}
           autoComplete="off"
           aria-label="カラーコード（16進数）"
           className={cn(
-            "h-6 w-24 rounded-sm border border-input bg-transparent px-2 text-md uppercase outline-none",
+            "m-0 h-[32px] w-[104px] flex-shrink-0 rounded-[6px] border border-input bg-transparent px-[8px] font-mono text-[14px] uppercase outline-none",
             "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]",
           )}
         />
-      </div>
-
-      {/* 現在の選択プレビュー */}
-      <div className="flex items-center gap-2">
-        <span
-          className="h-4 w-4 flex-shrink-0 rounded-sm border border-black/10"
-          style={{
-            backgroundColor: hasSelection ? colorInputValue : "transparent",
-          }}
-          aria-hidden="true"
-        />
-        <span className="text-md text-gray-600">
-          {hasSelection ? current.toUpperCase() : "未選択"}
-        </span>
       </div>
     </div>
   );

--- a/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.tsx
+++ b/assets/react-web-components/src/components/CalendarColorPicker/CalendarColorPicker.tsx
@@ -1,0 +1,218 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CALENDAR_COLOR_PALETTE, isPresetColor, normalizeHex } from "./colors";
+
+/** カスタム(RGB)入力の初期表示に使うフォールバック色 */
+const FALLBACK_COLOR = "#3b82f6";
+
+export interface CalendarColorPickerProps {
+  /** 現在の色（#rrggbb）。外部から属性で渡され、フィールド/ユーザー変更時の自動設定にも使われる */
+  value?: string;
+  /** 色確定時に発火するコールバック（Web Component では "change" イベントとして発火） */
+  onChange?: (hex: string) => void;
+}
+
+/**
+ * 選択中の色に対して視認できる文字色（白 or 黒）を返す。
+ * チェックマークの色決定に使用する。
+ */
+function getReadableTextColor(hex: string): string {
+  const normalized = normalizeHex(hex);
+  if (!normalized) {
+    return "#000000";
+  }
+  const r = parseInt(normalized.slice(1, 3), 16);
+  const g = parseInt(normalized.slice(3, 5), 16);
+  const b = parseInt(normalized.slice(5, 7), 16);
+  // 知覚輝度（YIQ 近似）で明暗を判定
+  const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+  return luminance > 150 ? "#000000" : "#ffffff";
+}
+
+/**
+ * CalendarColorPicker
+ *
+ * カレンダーの色選択UI。Tailwind のプリセット色から選ぶか、
+ * カスタム(RGB)で自由に指定できる。
+ *
+ * このコンポーネントは UI のみを担い、選択結果は同一 <form> 内の
+ * hidden input（input.selectedColor）へ #rrggbb 形式で書き込む。
+ * 保存・送信などの周辺処理は既存の実装をそのまま利用する。
+ */
+export const CalendarColorPicker: React.FC<CalendarColorPickerProps> = ({
+  value,
+  onChange,
+}) => {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [current, setCurrent] = useState<string>(
+    () => normalizeHex(value) ?? "",
+  );
+  // カスタムHEXテキスト入力の下書き（確定前の自由入力を保持）
+  const [hexDraft, setHexDraft] = useState<string>(
+    () => normalizeHex(value) ?? "",
+  );
+
+  /**
+   * 同一フォーム内の hidden input（.selectedColor）へ色を書き込み、
+   * 既存の保存処理が読み取れるようにする。
+   */
+  const writeToSelectedColorInput = useCallback((hex: string) => {
+    const input = rootRef.current
+      ?.closest("form")
+      ?.querySelector<HTMLInputElement>("input.selectedColor");
+    if (input) {
+      input.value = hex;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  }, []);
+
+  /**
+   * 外部（value 属性）からの色指定に追従する。
+   * 例: 対象フィールド／ユーザーを切り替えたときの色の自動設定。
+   */
+  useEffect(() => {
+    const normalized = normalizeHex(value);
+    if (normalized) {
+      setCurrent(normalized);
+      setHexDraft(normalized);
+      writeToSelectedColorInput(normalized);
+    }
+  }, [value, writeToSelectedColorInput]);
+
+  /** 色を確定し、状態・hidden input・コールバックへ反映する */
+  const commit = useCallback(
+    (hex: string) => {
+      const normalized = normalizeHex(hex);
+      if (!normalized) {
+        return;
+      }
+      setCurrent(normalized);
+      setHexDraft(normalized);
+      writeToSelectedColorInput(normalized);
+      onChange?.(normalized);
+    },
+    [onChange, writeToSelectedColorInput],
+  );
+
+  /** HEXテキスト入力の変更（有効な値なら即時確定） */
+  const handleHexInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    setHexDraft(raw);
+    if (normalizeHex(raw)) {
+      commit(raw);
+    }
+  };
+
+  /** HEXテキストからフォーカスが外れたとき、不正な下書きは現在値に戻す */
+  const handleHexInputBlur = () => {
+    if (!normalizeHex(hexDraft)) {
+      setHexDraft(current);
+    }
+  };
+
+  const hasSelection = current !== "";
+  const usingCustomColor = hasSelection && !isPresetColor(current);
+  const colorInputValue = normalizeHex(current) ?? FALLBACK_COLOR;
+
+  return (
+    <div ref={rootRef} className="inline-flex flex-col gap-3 align-top">
+      {/* プリセット色（Tailwind パレット） */}
+      <div
+        className="flex max-w-[320px] flex-wrap gap-1.5"
+        role="listbox"
+        aria-label="プリセットカラー"
+      >
+        {CALENDAR_COLOR_PALETTE.map((swatch) => {
+          const selected = normalizeHex(current) === swatch.hex;
+          return (
+            <button
+              key={swatch.name}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              aria-label={swatch.name}
+              title={swatch.name}
+              onClick={() => commit(swatch.hex)}
+              style={{ backgroundColor: swatch.hex }}
+              className={cn(
+                "flex h-6 w-6 items-center justify-center rounded-md border border-black/10 transition-transform",
+                "hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-700 focus-visible:ring-offset-1",
+                selected && "ring-2 ring-gray-800 ring-offset-1",
+              )}
+            >
+              {selected && (
+                <Check
+                  className="h-4 w-4"
+                  style={{ color: getReadableTextColor(swatch.hex) }}
+                  aria-hidden="true"
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* カスタム(RGB)指定 */}
+      <div className="flex items-center gap-2">
+        <span className="text-md text-gray-700">カスタム</span>
+        <label
+          className={cn(
+            "relative flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-black/10",
+            usingCustomColor && "ring-2 ring-gray-800 ring-offset-1",
+          )}
+          style={{ backgroundColor: colorInputValue }}
+          title="カスタムカラーを選択"
+        >
+          {/* ネイティブのカラーピッカー（RGB指定）。見た目はラベルの背景色で表現 */}
+          <input
+            type="color"
+            value={colorInputValue}
+            onChange={(e) => commit(e.target.value)}
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label="カスタムカラー（RGB）"
+          />
+          {usingCustomColor && (
+            <Check
+              className="pointer-events-none h-4 w-4"
+              style={{ color: getReadableTextColor(colorInputValue) }}
+              aria-hidden="true"
+            />
+          )}
+        </label>
+        <input
+          type="text"
+          value={hexDraft}
+          onChange={handleHexInputChange}
+          onBlur={handleHexInputBlur}
+          placeholder="#RRGGBB"
+          maxLength={7}
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="カラーコード（16進数）"
+          className={cn(
+            "h-6 w-24 rounded-sm border border-input bg-transparent px-2 text-md uppercase outline-none",
+            "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[2px]",
+          )}
+        />
+      </div>
+
+      {/* 現在の選択プレビュー */}
+      <div className="flex items-center gap-2">
+        <span
+          className="h-4 w-4 flex-shrink-0 rounded-sm border border-black/10"
+          style={{
+            backgroundColor: hasSelection ? colorInputValue : "transparent",
+          }}
+          aria-hidden="true"
+        />
+        <span className="text-md text-gray-600">
+          {hasSelection ? current.toUpperCase() : "未選択"}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default CalendarColorPicker;

--- a/assets/react-web-components/src/components/CalendarColorPicker/colors.ts
+++ b/assets/react-web-components/src/components/CalendarColorPicker/colors.ts
@@ -1,0 +1,98 @@
+/**
+ * カレンダー色選択用のプリセットパレット
+ *
+ * Tailwind CSS のカラー定義から、カレンダー上で視認しやすく区別しやすい
+ * 色を厳選している。各色相について標準（500）と濃色（600）の2階調を用意し、
+ * 「ちょうどいい色をそれなりの種類」から選べるようにしている。
+ * ここに無い色はカスタム（RGB）指定で自由に選択できる。
+ */
+
+/** プリセット1色分の定義 */
+export interface CalendarColorSwatch {
+  /** Tailwind の色名（例: "blue-500"）。ツールチップ／aria-label に使用 */
+  name: string;
+  /** #rrggbb 形式の16進数カラーコード */
+  hex: string;
+}
+
+/**
+ * プリセットパレット本体。
+ * Tailwind の各色相 × 標準/濃色の2階調を色相順に並べている。
+ */
+export const CALENDAR_COLOR_PALETTE: readonly CalendarColorSwatch[] = [
+  { name: "red-500", hex: "#ef4444" },
+  { name: "red-600", hex: "#dc2626" },
+  { name: "orange-500", hex: "#f97316" },
+  { name: "orange-600", hex: "#ea580c" },
+  { name: "amber-500", hex: "#f59e0b" },
+  { name: "amber-600", hex: "#d97706" },
+  { name: "yellow-500", hex: "#eab308" },
+  { name: "yellow-600", hex: "#ca8a04" },
+  { name: "lime-500", hex: "#84cc16" },
+  { name: "lime-600", hex: "#65a30d" },
+  { name: "green-500", hex: "#22c55e" },
+  { name: "green-600", hex: "#16a34a" },
+  { name: "emerald-500", hex: "#10b981" },
+  { name: "emerald-600", hex: "#059669" },
+  { name: "teal-500", hex: "#14b8a6" },
+  { name: "teal-600", hex: "#0d9488" },
+  { name: "cyan-500", hex: "#06b6d4" },
+  { name: "cyan-600", hex: "#0891b2" },
+  { name: "sky-500", hex: "#0ea5e9" },
+  { name: "sky-600", hex: "#0284c7" },
+  { name: "blue-500", hex: "#3b82f6" },
+  { name: "blue-600", hex: "#2563eb" },
+  { name: "indigo-500", hex: "#6366f1" },
+  { name: "indigo-600", hex: "#4f46e5" },
+  { name: "violet-500", hex: "#8b5cf6" },
+  { name: "violet-600", hex: "#7c3aed" },
+  { name: "purple-500", hex: "#a855f7" },
+  { name: "purple-600", hex: "#9333ea" },
+  { name: "fuchsia-500", hex: "#d946ef" },
+  { name: "fuchsia-600", hex: "#c026d3" },
+  { name: "pink-500", hex: "#ec4899" },
+  { name: "pink-600", hex: "#db2777" },
+  { name: "rose-500", hex: "#f43f5e" },
+  { name: "rose-600", hex: "#e11d48" },
+  { name: "slate-500", hex: "#64748b" },
+  { name: "slate-600", hex: "#475569" },
+  { name: "gray-500", hex: "#6b7280" },
+  { name: "gray-700", hex: "#374151" },
+];
+
+/** 16進数カラーコード（#rrggbb / #rgb）にマッチする正規表現 */
+const HEX_COLOR_REGEX = /^#?([0-9a-f]{6}|[0-9a-f]{3})$/i;
+
+/**
+ * 入力された色文字列を #rrggbb（小文字）形式に正規化する。
+ * 不正な値の場合は null を返す。
+ */
+export function normalizeHex(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!HEX_COLOR_REGEX.test(trimmed)) {
+    return null;
+  }
+  let hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  // #rgb 形式は #rrggbb に展開する
+  if (hex.length === 3) {
+    hex = hex
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  return "#" + hex.toLowerCase();
+}
+
+/**
+ * 与えられた色がパレット内のプリセットと一致するか（大文字小文字を無視）を判定する。
+ */
+export function isPresetColor(value: string | null | undefined): boolean {
+  const normalized = normalizeHex(value);
+  if (!normalized) {
+    return false;
+  }
+  return CALENDAR_COLOR_PALETTE.some((swatch) => swatch.hex === normalized);
+}

--- a/assets/react-web-components/src/components/CalendarColorPicker/colors.ts
+++ b/assets/react-web-components/src/components/CalendarColorPicker/colors.ts
@@ -1,64 +1,173 @@
 /**
  * カレンダー色選択用のプリセットパレット
  *
- * Tailwind CSS のカラー定義から、カレンダー上で視認しやすく区別しやすい
- * 色を厳選している。各色相について標準（500）と濃色（600）の2階調を用意し、
- * 「ちょうどいい色をそれなりの種類」から選べるようにしている。
- * ここに無い色はカスタム（RGB）指定で自由に選択できる。
+ * 「1列 = 1色相の濃淡」「1行 = 同じ明るさ」のグリッドとして定義する。
+ * 全色相を1行に並べると横幅に収まらないため、色相を上下2グループに分け、
+ * それぞれを 3行 × 7列 のブロックとして描画する。
+ * どちらのグループも色相環の順（暖色 → 寒色 → ピンク／グレー）に並ぶので、
+ * 画面上に軸ラベルを出さなくても並びの基準が伝わる。
+ *
+ * 色値は Tailwind CSS のカラーパレットから、カレンダー上で
+ * 互いに判別しやすい色相を抜き出したもの。
+ * ここに無い色はカスタム指定（HEX／RGB）で自由に選択できる。
  */
+
+/** 明るさの段階。Tailwind の階調番号をそのまま識別子に使う（画面には出さない） */
+export type CalendarColorTier = 400 | 500 | 600;
+
+/** 明るさの段階を明るい順に並べたもの。ブロック内の行順になる */
+export const CALENDAR_COLOR_TIERS: readonly CalendarColorTier[] = [
+  400, 500, 600,
+];
+
+/** 明るさの段階に対応する表示名 */
+const TIER_LABELS: Record<CalendarColorTier, string> = {
+  400: "明るめ",
+  500: "標準",
+  600: "濃いめ",
+};
+
+/** 1色相分の定義 */
+export interface CalendarColorHue {
+  /** 内部識別子（例: "red"） */
+  key: string;
+  /** 表示名（例: "赤"）。Tailwind の内部名は画面に出さない */
+  label: string;
+  /** 明るさの段階ごとの #rrggbb */
+  shades: Record<CalendarColorTier, string>;
+}
+
+/**
+ * 色相の定義。1つの配列が1ブロック（= 3行 × 7列）の列構成になる。
+ * 上下どちらのブロックも色相環を一周するよう、色相環の順に交互に振り分けている。
+ */
+export const CALENDAR_COLOR_HUE_GROUPS: readonly (readonly CalendarColorHue[])[] =
+  [
+    [
+      {
+        key: "red",
+        label: "赤",
+        shades: { 400: "#f87171", 500: "#ef4444", 600: "#dc2626" },
+      },
+      {
+        key: "amber",
+        label: "アンバー",
+        shades: { 400: "#fbbf24", 500: "#f59e0b", 600: "#d97706" },
+      },
+      {
+        key: "lime",
+        label: "ライム",
+        shades: { 400: "#a3e635", 500: "#84cc16", 600: "#65a30d" },
+      },
+      {
+        key: "emerald",
+        label: "エメラルド",
+        shades: { 400: "#34d399", 500: "#10b981", 600: "#059669" },
+      },
+      {
+        key: "cyan",
+        label: "シアン",
+        shades: { 400: "#22d3ee", 500: "#06b6d4", 600: "#0891b2" },
+      },
+      {
+        key: "indigo",
+        label: "インディゴ",
+        shades: { 400: "#818cf8", 500: "#6366f1", 600: "#4f46e5" },
+      },
+      {
+        key: "pink",
+        label: "ピンク",
+        shades: { 400: "#f472b6", 500: "#ec4899", 600: "#db2777" },
+      },
+    ],
+    [
+      {
+        key: "orange",
+        label: "オレンジ",
+        shades: { 400: "#fb923c", 500: "#f97316", 600: "#ea580c" },
+      },
+      {
+        key: "yellow",
+        label: "黄",
+        shades: { 400: "#facc15", 500: "#eab308", 600: "#ca8a04" },
+      },
+      {
+        key: "green",
+        label: "緑",
+        shades: { 400: "#4ade80", 500: "#22c55e", 600: "#16a34a" },
+      },
+      {
+        key: "teal",
+        label: "ティール",
+        shades: { 400: "#2dd4bf", 500: "#14b8a6", 600: "#0d9488" },
+      },
+      {
+        key: "blue",
+        label: "青",
+        shades: { 400: "#60a5fa", 500: "#3b82f6", 600: "#2563eb" },
+      },
+      {
+        key: "violet",
+        label: "バイオレット",
+        shades: { 400: "#a78bfa", 500: "#8b5cf6", 600: "#7c3aed" },
+      },
+      {
+        key: "gray",
+        label: "グレー",
+        shades: { 400: "#9ca3af", 500: "#6b7280", 600: "#4b5563" },
+      },
+    ],
+  ];
+
+/**
+ * グリッドの列数。画面側の grid-cols-* と一致させる必要がある。
+ */
+export const CALENDAR_COLOR_COLUMNS = CALENDAR_COLOR_HUE_GROUPS[0].length;
 
 /** プリセット1色分の定義 */
 export interface CalendarColorSwatch {
-  /** Tailwind の色名（例: "blue-500"）。ツールチップ／aria-label に使用 */
+  /** 内部識別子（例: "red-500"）。React の key に使用 */
   name: string;
+  /** 表示名（例: "赤（標準）"）。tooltip／aria-label に使用 */
+  label: string;
+  /** 色相の識別子（例: "red"） */
+  hue: string;
+  /** 明るさの段階 */
+  tier: CalendarColorTier;
   /** #rrggbb 形式の16進数カラーコード */
   hex: string;
 }
 
 /**
- * プリセットパレット本体。
- * Tailwind の各色相 × 標準/濃色の2階調を色相順に並べている。
+ * 上下2つのブロック。grid は DOM 順に左上から埋まるため、
+ * 行（明るさ）を外側、列（色相）を内側にして並べる。
  */
-export const CALENDAR_COLOR_PALETTE: readonly CalendarColorSwatch[] = [
-  { name: "red-500", hex: "#ef4444" },
-  { name: "red-600", hex: "#dc2626" },
-  { name: "orange-500", hex: "#f97316" },
-  { name: "orange-600", hex: "#ea580c" },
-  { name: "amber-500", hex: "#f59e0b" },
-  { name: "amber-600", hex: "#d97706" },
-  { name: "yellow-500", hex: "#eab308" },
-  { name: "yellow-600", hex: "#ca8a04" },
-  { name: "lime-500", hex: "#84cc16" },
-  { name: "lime-600", hex: "#65a30d" },
-  { name: "green-500", hex: "#22c55e" },
-  { name: "green-600", hex: "#16a34a" },
-  { name: "emerald-500", hex: "#10b981" },
-  { name: "emerald-600", hex: "#059669" },
-  { name: "teal-500", hex: "#14b8a6" },
-  { name: "teal-600", hex: "#0d9488" },
-  { name: "cyan-500", hex: "#06b6d4" },
-  { name: "cyan-600", hex: "#0891b2" },
-  { name: "sky-500", hex: "#0ea5e9" },
-  { name: "sky-600", hex: "#0284c7" },
-  { name: "blue-500", hex: "#3b82f6" },
-  { name: "blue-600", hex: "#2563eb" },
-  { name: "indigo-500", hex: "#6366f1" },
-  { name: "indigo-600", hex: "#4f46e5" },
-  { name: "violet-500", hex: "#8b5cf6" },
-  { name: "violet-600", hex: "#7c3aed" },
-  { name: "purple-500", hex: "#a855f7" },
-  { name: "purple-600", hex: "#9333ea" },
-  { name: "fuchsia-500", hex: "#d946ef" },
-  { name: "fuchsia-600", hex: "#c026d3" },
-  { name: "pink-500", hex: "#ec4899" },
-  { name: "pink-600", hex: "#db2777" },
-  { name: "rose-500", hex: "#f43f5e" },
-  { name: "rose-600", hex: "#e11d48" },
-  { name: "slate-500", hex: "#64748b" },
-  { name: "slate-600", hex: "#475569" },
-  { name: "gray-500", hex: "#6b7280" },
-  { name: "gray-700", hex: "#374151" },
-];
+export const CALENDAR_COLOR_BLOCKS: readonly (readonly CalendarColorSwatch[])[] =
+  CALENDAR_COLOR_HUE_GROUPS.map((hues) =>
+    CALENDAR_COLOR_TIERS.flatMap((tier) =>
+      hues.map((hue) => ({
+        name: `${hue.key}-${tier}`,
+        label: `${hue.label}（${TIER_LABELS[tier]}）`,
+        hue: hue.key,
+        tier,
+        hex: hue.shades[tier],
+      })),
+    ),
+  );
+
+/** パレット本体。ブロックを上から順に連結した並び */
+export const CALENDAR_COLOR_PALETTE: readonly CalendarColorSwatch[] =
+  CALENDAR_COLOR_BLOCKS.flat();
+
+/**
+ * プリセット全色の #rrggbb を並び順どおりに返す。
+ *
+ * カレンダー側の JS（Calendar.js の getRandomColor）が色をランダムに選ぶ際に
+ * 参照する。色の定義をこのファイルに一元化し、JS 側に同じ色表を持たせない。
+ */
+export function getCalendarColorHexes(): string[] {
+  return CALENDAR_COLOR_PALETTE.map((swatch) => swatch.hex);
+}
 
 /** 16進数カラーコード（#rrggbb / #rgb）にマッチする正規表現 */
 const HEX_COLOR_REGEX = /^#?([0-9a-f]{6}|[0-9a-f]{3})$/i;

--- a/assets/react-web-components/src/components/CalendarColorPicker/index.ts
+++ b/assets/react-web-components/src/components/CalendarColorPicker/index.ts
@@ -1,0 +1,10 @@
+export {
+  CalendarColorPicker,
+  type CalendarColorPickerProps,
+} from "./CalendarColorPicker";
+export {
+  CALENDAR_COLOR_PALETTE,
+  isPresetColor,
+  normalizeHex,
+  type CalendarColorSwatch,
+} from "./colors";

--- a/assets/react-web-components/src/components/CalendarColorPicker/index.ts
+++ b/assets/react-web-components/src/components/CalendarColorPicker/index.ts
@@ -4,6 +4,7 @@ export {
 } from "./CalendarColorPicker";
 export {
   CALENDAR_COLOR_PALETTE,
+  getCalendarColorHexes,
   isPresetColor,
   normalizeHex,
   type CalendarColorSwatch,

--- a/assets/react-web-components/src/main.ts
+++ b/assets/react-web-components/src/main.ts
@@ -3,7 +3,17 @@ import "./index.css";
 import { QuickCreate, CalendarQuickCreate } from "@/components/QuickCreate";
 import { AppMenu } from "@/components/AppMenu";
 import { ActivityList } from "@/components/ActivityList";
-import { CalendarColorPicker } from "@/components/CalendarColorPicker";
+import {
+  CalendarColorPicker,
+  getCalendarColorHexes,
+} from "@/components/CalendarColorPicker";
+
+declare global {
+  interface Window {
+    /** カレンダー色のプリセット（#rrggbb の配列）。Calendar.js から参照する */
+    CalendarColorPalette?: string[];
+  }
+}
 
 // QuickCreate本体コンポーネントの登録
 // イベント: save, cancel, go-to-full-form, open-change (CustomEvent)
@@ -71,3 +81,7 @@ createWebComponent(
   ["value"],
   ["onChange"],
 );
+
+// カレンダー側の JS（Calendar.js の getRandomColor）が、色選択UIと同じプリセットから
+// 色を選べるようにパレットを公開する。色表を JS 側に複製しないための共有ポイント。
+window.CalendarColorPalette = getCalendarColorHexes();

--- a/assets/react-web-components/src/main.ts
+++ b/assets/react-web-components/src/main.ts
@@ -3,6 +3,7 @@ import "./index.css";
 import { QuickCreate, CalendarQuickCreate } from "@/components/QuickCreate";
 import { AppMenu } from "@/components/AppMenu";
 import { ActivityList } from "@/components/ActivityList";
+import { CalendarColorPicker } from "@/components/CalendarColorPicker";
 
 // QuickCreate本体コンポーネントの登録
 // イベント: save, cancel, go-to-full-form, open-change (CustomEvent)
@@ -54,3 +55,19 @@ createWebComponent(ActivityList, "activity-list", [
   "limit",
   "refresh-key",
 ]);
+
+// CalendarColorPicker コンポーネントの登録（カレンダーの色選択UI）
+// Tailwind のプリセット色から選ぶか、カスタム(RGB)で自由に指定できる。
+// 選択結果は同一 <form> 内の hidden input（input.selectedColor）へ書き込むため、
+// 保存・送信などの周辺処理は既存実装のまま変更不要。
+// value属性: 現在の色（#rrggbb）。フィールド/ユーザー変更時の自動設定にも使われる。
+// イベント: change (CustomEvent, detail = #rrggbb)
+//
+// 使用例（HTML）:
+// <calendar-color-picker value="#3b82f6"></calendar-color-picker>
+createWebComponent(
+  CalendarColorPicker,
+  "calendar-color-picker",
+  ["value"],
+  ["onChange"],
+);

--- a/layouts/v7/modules/Calendar/AddActivityType.tpl
+++ b/layouts/v7/modules/Calendar/AddActivityType.tpl
@@ -73,7 +73,7 @@
             <div class="form-group">
                 <label class="control-label fieldLabel col-sm-4">{vtranslate('LBL_SELECT_CALENDAR_COLOR', $MODULE)}</label>
                 <div class="controls fieldValue col-sm-8">
-                    <p class="calendarColorPicker"></p>
+                    <calendar-color-picker value=""></calendar-color-picker>
                 </div>
             </div>
         </form>

--- a/layouts/v7/modules/Calendar/AddUserCalendar.tpl
+++ b/layouts/v7/modules/Calendar/AddUserCalendar.tpl
@@ -39,7 +39,7 @@
             <div class="form-group">
                 <label class="control-label fieldLabel col-sm-4">{vtranslate('LBL_SELECT_CALENDAR_COLOR', $MODULE)}</label>
                 <div class="controls fieldValue col-sm-8">
-                    <p class="calendarColorPicker"></p>
+                    <calendar-color-picker value=""></calendar-color-picker>
                 </div>
             </div>
         </form>

--- a/layouts/v7/modules/Calendar/EditActivityType.tpl
+++ b/layouts/v7/modules/Calendar/EditActivityType.tpl
@@ -59,7 +59,7 @@
             <div class="form-group">
                 <label class="control-label fieldLabel col-sm-4">{vtranslate('LBL_SELECT_CALENDAR_COLOR', $MODULE)}</label>
                 <div class="controls fieldValue col-sm-8">
-                    <p class="calendarColorPicker"></p>
+                    <calendar-color-picker value=""></calendar-color-picker>
                 </div>
             </div>
         </form>

--- a/layouts/v7/modules/Calendar/EditUserCalendar.tpl
+++ b/layouts/v7/modules/Calendar/EditUserCalendar.tpl
@@ -40,7 +40,7 @@
             <div class="form-group">
                 <label class="control-label fieldLabel col-sm-4">{vtranslate('LBL_SELECT_CALENDAR_COLOR', $MODULE)}</label>
                 <div class="controls fieldValue col-sm-8">
-                    <p class="calendarColorPicker"></p>
+                    <calendar-color-picker value=""></calendar-color-picker>
                 </div>
             </div>
         </form>

--- a/modules/Calendar/views/Calendar.php
+++ b/modules/Calendar/views/Calendar.php
@@ -35,8 +35,7 @@ class Calendar_Calendar_View extends Vtiger_Index_View {
 			"~layouts/".Vtiger_Viewer::getDefaultLayoutName()."/lib/jquery/fullcalendar/lib/moment.min.js",
 			"~layouts/".Vtiger_Viewer::getDefaultLayoutName()."/lib/jquery/fullcalendar/fullcalendar.js",
 			"~layouts/".Vtiger_Viewer::getDefaultLayoutName()."/lib/jquery/webui-popover/dist/jquery.webui-popover.js",
-			"modules.Calendar.resources.CalendarView",
-			"~/libraries/jquery/colorpicker/js/colorpicker.js"
+			"modules.Calendar.resources.CalendarView"
 		);
 
 		$jsScriptInstances = $this->checkAndConvertJsScripts($jsFileNames);
@@ -50,8 +49,7 @@ class Calendar_Calendar_View extends Vtiger_Index_View {
 		$cssFileNames = array(
 			'~layouts/'.Vtiger_Viewer::getDefaultLayoutName().'/lib/jquery/fullcalendar/fullcalendar.css',
 			'~layouts/'.Vtiger_Viewer::getDefaultLayoutName().'/lib/jquery/fullcalendar/fullcalendar-bootstrap.css',
-			'~layouts/'.Vtiger_Viewer::getDefaultLayoutName().'/lib/jquery/webui-popover/dist/jquery.webui-popover.css',
-			'~/libraries/jquery/colorpicker/css/colorpicker.css'
+			'~layouts/'.Vtiger_Viewer::getDefaultLayoutName().'/lib/jquery/webui-popover/dist/jquery.webui-popover.css'
 		);
 		$cssInstances = $this->checkAndConvertCssStyles($cssFileNames);
 		$headerCssInstances = array_merge($headerCssInstances, $cssInstances);

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -714,16 +714,6 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			this.updateRangeFields(container, options);
 		}
 	},
-	initializeColorPicker: function (element, customParams, onChangeFunc) {
-		var params = {
-			flat: true,
-			onChange: onChangeFunc
-		};
-		if (typeof customParams !== 'undefined') {
-			params = jQuery.extend(params, customParams);
-		}
-		element.ColorPicker(params);
-	},
 	getRandomColor: function () {
 		return '#' + (0x1000000 + (Math.random()) * 0xffffff).toString(16).substr(1, 6);
 	},
@@ -752,7 +742,7 @@ Vtiger.Class("Calendar_Calendar_Js", {
 				currentColor = feedCheckbox.data('calendarFeedColor');
 			}
 			modalContainer.find('.selectedColor').val(currentColor);
-			modalContainer.find('.calendarColorPicker').ColorPickerSetColor(currentColor);
+			modalContainer.find('calendar-color-picker').attr('value', currentColor);
 		});
 		modalContainer.find('#calendarviewconditions').on('change', function () {
 			fieldsSelect.trigger('change');
@@ -903,13 +893,6 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	registerColorEditorEvents: function (modalContainer, feedIndicator) {
 		var thisInstance = this;
 		var feedCheckbox = feedIndicator.find('input[type="checkbox"].toggleCalendarFeed');
-
-		var colorPickerHost = modalContainer.find('.calendarColorPicker');
-		var selectedColor = modalContainer.find('.selectedColor');
-		thisInstance.initializeColorPicker(colorPickerHost, {}, function (hsb, hex, rgb) {
-			var selectedColorCode = '#' + hex;
-			selectedColor.val(selectedColorCode);
-		});
 
 		modalContainer.find('input[name="is_own"]').attr('checked', feedIndicator.find('.toggleCalendarFeed').data('calendarIs_own') === 1);
 		if(feedIndicator.find('.toggleCalendarFeed').data('calendarIsdefault') === 1) {
@@ -1073,12 +1056,6 @@ Vtiger.Class("Calendar_Calendar_Js", {
 	},
 	registerAddActivityTypeFeedActions: function (modalContainer) {
 		var thisInstance = this;
-		var colorPickerHost = modalContainer.find('.calendarColorPicker');
-		var selectedColor = modalContainer.find('.selectedColor');
-		thisInstance.initializeColorPicker(colorPickerHost, {}, function (hsb, hex, rgb) {
-			var selectedColorCode = '#' + hex;
-			selectedColor.val(selectedColorCode);
-		});
 
 		thisInstance.registerDateFieldChangeEvent(modalContainer);
 

--- a/public/layouts/v7/modules/Calendar/resources/Calendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/Calendar.js
@@ -714,7 +714,17 @@ Vtiger.Class("Calendar_Calendar_Js", {
 			this.updateRangeFields(container, options);
 		}
 	},
+	/**
+	 * カレンダーの色をプリセットパレットから1つ選ぶ。
+	 * パレットは色選択UI(<calendar-color-picker>)と同じ定義を
+	 * window.CalendarColorPalette 経由で共有し、色表を二重に持たない。
+	 */
 	getRandomColor: function () {
+		var palette = window.CalendarColorPalette;
+		if (Array.isArray(palette) && palette.length > 0) {
+			return palette[Math.floor(Math.random() * palette.length)];
+		}
+		// web-components が読み込まれていない場合のフォールバック
 		return '#' + (0x1000000 + (Math.random()) * 0xffffff).toString(16).substr(1, 6);
 	},
 	registerDateFieldChangeEvent: function (modalContainer) {

--- a/public/layouts/v7/modules/Calendar/resources/SharedCalendar.js
+++ b/public/layouts/v7/modules/Calendar/resources/SharedCalendar.js
@@ -147,7 +147,7 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 				currentColor = feedCheckbox.data('calendarFeedColor');
 			}
 			modalContainer.find('.selectedColor').val(currentColor);
-			modalContainer.find('.calendarColorPicker').ColorPickerSetColor(currentColor);
+			modalContainer.find('calendar-color-picker').attr('value', currentColor);
 		});
 	},
 
@@ -229,13 +229,6 @@ Calendar_Calendar_Js('Calendar_SharedCalendar_Js', {
 	registerColorEditorEvents : function(modalContainer,feedIndicator) {
 		var thisInstance = this;
 		var editorMode = modalContainer.find('.editorMode').val();
-
-		var colorPickerHost = modalContainer.find('.calendarColorPicker');
-		var selectedColor = modalContainer.find('.selectedColor');
-		thisInstance.initializeColorPicker(colorPickerHost, {}, function(hsb, hex, rgb) {
-			var selectedColorCode = '#'+hex;
-			selectedColor.val(selectedColorCode);
-		});
 
 		thisInstance.registerUserChangeEvent(modalContainer);
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1794

##  不具合の内容 / Bug
1. カレンダー設定（活動タイプ 追加/編集、カレンダー(マイ/共有) 追加/編集）の色選択が jQuery colorpicker による HSB グラデーションからの自由入力で、約1677万色から狙った色を出す操作コストが高い。
2. 微妙に違う色が乱立し、カレンダー上でどの活動タイプ／カレンダーの色か判別しづらい。同じ色を選び直すのも難しい。
3. 色を自動割り当てする処理（`Calendar_Js.getRandomColor`）も任意の色を生成するため、判別しづらい色が混ざる。

##  原因 / Cause
1. 色選択UIが「見分けやすい色を1つ決める」という実際のユースケースに対して自由度が過剰だった。
2. `getRandomColor` が `Math.random()` から16進数を直接生成しており、選択UIの色体系と無関係だった。

なお実装中に、Web Components 全般に関わる次の2点も判明したため併せて対処した。

3. CRM 本体が `html` に `font-size: 10px` を設定しているため、Tailwind の `rem` ベースのサイズ指定（`h-7` 等）が一律 **62.5%** に縮小される。指定 44×28px のスウォッチが実測 27.5×17.5px になっていた。
4. `<label>` に Bootstrap の `label { margin-bottom: 5px }` が効き、`items-center` の中で隣の入力欄と縦位置が 2.5px ずれる。

##  変更内容 / Details of Change
1. `assets/react-web-components` に `<calendar-color-picker>` を追加し、4つのモーダルの色選択部を置き換え。既存の hidden input `.selectedColor` へ `#rrggbb` を書き込む契約は維持し、保存・送信・DB周りは変更なし。
2. プリセットを「1列=1色相の濃淡 / 1行=同じ明るさ」のマトリクスとして定義（14色相 × 3階調 = 42色）。色相を上下2グループに分け、6行×7列の一枚の表として表示する。
3. 軸ラベルは表示せず、Tailwind の内部名（`red-500` 等）も画面に出さない。tooltip / aria-label は日本語表示（例: 赤（標準））。
4. カスタム指定を、枠線・影・ホバー・アイコン・「色を選ぶ」ラベル付きのボタン型に変更（クリックでOS標準のカラーピッカーを開く）。HEX入力欄は等幅フォント・14px で `#RRGGBB` の7文字が収まる幅に。
5. 上記 原因3 に対し、このコンポーネントのサイズ指定を px ベースへ変更。`--spacing` は他コンポーネントの見た目に波及するため変更していない。
6. 上記 原因4 に対し、`m-0` で `label` のマージンを打ち消し。
7. `getRandomColor` をプリセット42色から選ぶよう変更。色表を二重に持たないよう、パレットを `window.CalendarColorPalette` として web-components 側から公開し、Calendar.js はそれを参照する（未読込時のみ従来のランダム生成へフォールバック）。
8. 不要になった旧 colorpicker ライブラリの読み込みを除去。

## スクリーンショット / Screenshot
<!-- 画像は別途添付します -->
現在の描画（実ブラウザで計測・確認済み）:

- 上3行: 赤・アンバー・ライム・エメラルド・シアン・インディゴ・ピンク
- 下3行: オレンジ・黄・緑・ティール・青・バイオレット・グレー
- 各列が1色相の「明るめ → 標準 → 濃いめ」
- 下部に「カスタム」行（色を選ぶボタン ＋ HEX入力欄）

実測値:

| 項目 | 値 |
|---|---|
| スウォッチ | 44×28px |
| パレット全体 | 344×198px（色選択欄の実幅 約369px に収まる） |
| カスタムボタン / HEX入力欄の高さ | ともに 32px（縦位置差 0） |
| HEX入力欄のはみ出し | なし（`scrollWidth 102 == clientWidth 102`） |

## 影響範囲  / Affected Area
- 活動タイプ 追加／編集モーダル、カレンダー（マイ／共有）追加／編集モーダルの色選択UI
- `Calendar_Js.getRandomColor`（`SharedCalendar.js` の2箇所も同メソッドを継承利用しているため同時に変わる）
- 保存・送信処理、DB、既存データの読み出しは変更なし。プリセット外の色が保存されている既存カレンダーは「カスタム色」として表示され、値はそのまま保持される
- `window.CalendarColorPalette` をグローバルに追加

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
- **言語対応は未実施です。** UIの文言（「カスタム」「色を選ぶ」）と色名（「赤（標準）」等）を日本語でハードコードしています。多言語化が必要であれば別途対応します。
- テスト: `assets/react-web-components` の vitest で 292 tests / 18 files が green。色の並び順（1行=1階調 / 1列=1色相）とパレット公開APIは不変条件としてテスト済み。
- `npm run lint` は本PRの変更ファイルで指摘0。既存の warning（`any` 等）は #1691 の範囲のため未着手。
- 表示の検証は、CRM と同じCSS読み込み順・同じモーダルDOM構造を再現した計測ハーネスを実ブラウザ（Chromium）で描画し、`getBoundingClientRect` と算出スタイルを測って行いました。ハーネスは一時ファイルのためコミットには含めていません。E2Eテストとして残す価値があれば追加します。
- 原因3（`html{font-size:10px}` により rem ベースの指定が 62.5% になる）は他の Web Components でも同じ条件のため、共通の注意点として共有しておきます。
