### PR TITLE
[修正] #1796 インポート 参照項目の値がカンマで分割され参照が解決できない

### DIFF
--- a/include/utils/InventoryUtils.php
+++ b/include/utils/InventoryUtils.php
@@ -1433,34 +1433,25 @@ function isRecordExistInDB($fieldData, $moduleMeta, $user, $cache) {
 		$fieldInstance = $moduleFields[$fieldName];
 		if ($fieldInstance->getFieldDataType() == 'reference') {
 			$entityId = false;
+			$referenceModuleName = null;
 			if (!empty($fieldValue)) {
-				if(strpos($fieldValue, '::::') > 0) {
-					$fieldValueDetails = explode('::::', $fieldValue);
-				} else if (strpos($fieldValue, ':::') > 0) {
-					$fieldValueDetails = explode(':::', $fieldValue);
-				} else {
-					$fieldValueDetails = array($fieldValue);
-				}
-				$fieldDetails = array();
-				foreach($fieldValueDetails as $fieldValueDetail){
-					if (strpos($fieldValueDetail, '====') > 0) {
-						$fieldDetail = explode('====', $fieldValueDetail);
-						$fieldDetails[$fieldDetail[0]] = $fieldDetail[1];
+				$parsed = Import_Reference_Model::parse($fieldValue);
+
+				if (!empty($parsed['columns'])) {
+					$referenceModuleName = $parsed['module'];
+					$entityId = getEntityIdByColumns($referenceModuleName, $parsed['columns'], $cache);
+				} else if ($parsed['label'] !== null) {
+					if ($parsed['module'] !== null) {
+						$referencedModules = array($parsed['module']);
+					} else {
+						$referencedModules = $fieldInstance->getReferenceList();
 					}
-				}
-				if (php7_count($fieldValueDetails) > 1 && !empty($fieldDetails)) {
-					$referenceModuleName = trim($fieldValueDetails[0]);
-					$referenceValueList = $fieldDetails;
-					$entityId = getEntityIdByColumns($referenceModuleName, $referenceValueList, $cache);
-				} else {
-					$referencedModules = $fieldInstance->getReferenceList();
-					$entityLabel = $fieldValue;
 					foreach ($referencedModules as $referenceModule) {
-						$referenceModuleName = $referenceModule;
 						try {
-							$referenceEntityId = getEntityIdByColumns($referenceModule, $entityLabel,$cache);
+							$referenceEntityId = getEntityIdByColumns($referenceModule, $parsed['label'], $cache);
 							if ($referenceEntityId != 0) {
 								$entityId = $referenceEntityId;
+								$referenceModuleName = $referenceModule;
 								break;
 							}
 						} catch (ImportException $e) {

--- a/include/utils/InventoryUtils.php
+++ b/include/utils/InventoryUtils.php
@@ -1436,28 +1436,14 @@ function isRecordExistInDB($fieldData, $moduleMeta, $user, $cache) {
 			$referenceModuleName = null;
 			if (!empty($fieldValue)) {
 				$parsed = Import_Reference_Model::parse($fieldValue);
-
-				if (!empty($parsed['columns'])) {
-					$referenceModuleName = $parsed['module'];
-					$entityId = getEntityIdByColumns($referenceModuleName, $parsed['columns'], $cache);
-				} else if ($parsed['label'] !== null) {
-					if ($parsed['module'] !== null) {
-						$referencedModules = array($parsed['module']);
-					} else {
-						$referencedModules = $fieldInstance->getReferenceList();
-					}
-					foreach ($referencedModules as $referenceModule) {
-						try {
-							$referenceEntityId = getEntityIdByColumns($referenceModule, $parsed['label'], $cache);
-							if ($referenceEntityId != 0) {
-								$entityId = $referenceEntityId;
-								$referenceModuleName = $referenceModule;
-								break;
-							}
-						} catch (ImportException $e) {
-							continue;
-						}
-					}
+				try {
+					$entityId = Import_Reference_Model::resolve($parsed, $fieldInstance, $cache, $user, $moduleMeta->getEntityName());
+				} catch (ImportException $e) {
+					$entityId = false;
+				}
+				if (!empty($entityId)) {
+					// 解決に使われたモジュールを権限判定のために特定する
+					$referenceModuleName = ($parsed['module'] !== null) ? $parsed['module'] : getSalesEntityType($entityId);
 				}
 				if (!empty($entityId) && $entityId != 0) {
 					$types = vtws_listtypes(null, $user);

--- a/include/utils/ListViewUtils.php
+++ b/include/utils/ListViewUtils.php
@@ -632,81 +632,41 @@ function getRelatedTableHeaderNavigation($navigation_array, $url_qry, $module, $
 /* Function to get the Entity Id of a given Entity Name */
 
 function getEntityId($module, $entityName) {
-	global $log, $adb;
+	global $log;
 	$log->info("in getEntityId " . $entityName);
 
-	$query = "select fieldname,tablename,entityidfield from vtiger_entityname where modulename = ?";
-	$result = $adb->pquery($query, array($module));
-	$fieldsname = $adb->query_result($result, 0, 'fieldname');
-	$tablename = $adb->query_result($result, 0, 'tablename');
-	$entityidfield = $adb->query_result($result, 0, 'entityidfield');
-	if (!(strpos($fieldsname, ',') === false)) {
-		$fieldlists = explode(',', $fieldsname);
-		$fieldsname = "trim(concat(";
-		$fieldsname = $fieldsname . implode(",' ',", $fieldlists);
-		$fieldsname = $fieldsname . "))";
-		$entityName = trim($entityName);
+	// 実装は Import_Reference_Model に集約されている。
+	// 顧客カスタマイズからの呼び出しに備え、未解決で例外を送出する現行契約を維持する
+	if (trim((string) $entityName) === '') {
+		return 0;
 	}
 
-	if ($entityName != '') {
-		$sql = "select $entityidfield from $tablename INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = $tablename.$entityidfield " .
-				" WHERE vtiger_crmentity.deleted = 0 and $fieldsname=?";
-		$result = $adb->pquery($sql, array($entityName));
-		if ($adb->num_rows($result) == 0) {
-			throw new ImportException("No reference exists");
-		}
-		if ($adb->num_rows($result) > 0) {
-			$entityId = $adb->query_result($result, 0, $entityidfield);
-		}
+	$entityId = Import_Reference_Model::resolveByLabel($module, $entityName, array());
+	if ($entityId === false) {
+		throw new ImportException("No reference exists");
 	}
-	if (!empty($entityId))
-		return $entityId;
-	else
-		return 0;
+
+	return $entityId;
 }
 
 // カラム名から関連項目を取得
 function getEntityIdByColumns($module, $referenceValueList, $cache) {
-	global $log, $adb;
-	$log->info("in getEntityIdByColumns " . $referenceValueList);
+	global $log;
+	$log->info("in getEntityIdByColumns " . (is_array($referenceValueList) ? json_encode($referenceValueList) : $referenceValueList));
 
-	if (empty($cache[$module])||empty($referenceValueList)){
+	// 実装は Import_Reference_Model に集約されている。
+	// 顧客カスタマイズからの呼び出しに備え、未解決で例外を送出する現行契約を維持する
+	if (is_array($referenceValueList)) {
+		$entityId = Import_Reference_Model::resolveByColumns($module, $referenceValueList, $cache);
+	} else {
+		$entityId = Import_Reference_Model::resolveByLabel($module, $referenceValueList, $cache);
+	}
+
+	if ($entityId === false) {
 		throw new ImportException("No reference exists");
 	}
 
-    $matchedIds = [];
-    if (is_array($referenceValueList)) {
-        foreach ($cache[$module] as $recordModel) {
-            $filterCache = array_intersect_key($recordModel, $referenceValueList);
-            ksort($referenceValueList);
-            ksort($filterCache);
-            if ($filterCache === $referenceValueList) {
-                $cacheValues = array_values($recordModel);
-                $matchedIds[] = $cacheValues[0];
-            }
-        }
-    } else {
-        $entityNameInfo = getEntityFieldNames($module);
-        $fieldNames = $entityNameInfo['fieldname'];
-        if (!is_array($fieldNames)) {
-            $fieldNames = array($fieldNames);
-        }
-        foreach ($cache[$module] as $recordModel) {
-            foreach ($fieldNames as $fieldName) {
-                if ((trim($recordModel[$fieldName] ?? '') === trim($referenceValueList))) {
-                    $cacheValues = array_values($recordModel);
-                    $matchedIds[] = $cacheValues[0];
-                    break;
-                }
-            }
-        	}
-    }
-
-	if (count($matchedIds) !== 1) {
-	    throw new ImportException("No reference exists");
-	}
-
-	return $matchedIds[0];
+	return $entityId;
 }
 
 function decode_emptyspace_html($str){

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -301,6 +301,18 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							case 'reference':	$parsedMergeValue = Import_Reference_Model::parse($comparisonValue);
 												if ($parsedMergeValue['label'] !== null) {
 													$comparisonValue = $parsedMergeValue['label'];
+												} elseif (!empty($parsedMergeValue['columns'])) {
+													// カラム指定形式は値にラベルを含まないため、レコードを特定してその
+													// ラベルを比較値にする。従来は 'field====value' をそのまま比較して
+													// いたため、この形式では重複が永久に見つからなかった
+													try {
+														$mergeEntityId = Import_Reference_Model::resolve(
+															$parsedMergeValue, $fieldInstance, $cache, $this->user, $moduleName);
+													} catch (ImportException $e) {
+														$mergeEntityId = false;
+													}
+													$comparisonValue = $mergeEntityId
+														? Vtiger_Functions::getCRMRecordLabel($mergeEntityId) : '';
 												}
 												break;
 							case 'currency'	:	if (!empty($comparisonValue)) {
@@ -570,50 +582,10 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				$implodeValue = implode(' |##| ', $explodedValue);
 				$fieldData[$fieldName] = $implodeValue;
 			} elseif ($fieldDataType == 'reference') {
-				$entityId = false;
 				if (!empty($fieldValue)) {
 					$parsed = Import_Reference_Model::parse($fieldValue);
-
-					if (!empty($parsed['columns'])) {
-						// Module::::field====value 形式：指定カラムのAND条件でレコードを特定する
-						$columns = array();
-						foreach ($parsed['columns'] as $columnName => $columnValue) {
-							$columns[$columnName] = decode_html($columnValue);
-						}
-						$entityId = getEntityIdByColumns($parsed['module'], $columns, $cache);
-					} else if ($parsed['label'] !== null) {
-						$entityLabel = $parsed['label'];
-						if ($parsed['module'] !== null) {
-							// Module::::Label / Module:::Label 形式：モジュールを限定する
-							$referencedModules = array($parsed['module']);
-						} else {
-							// Label のみ：項目の参照先モジュールを順に試す
-							$referencedModules = $fieldInstance->getReferenceList();
-						}
-
-						foreach ($referencedModules as $referenceModule) {
-							if ($referenceModule == 'Users') {
-								$referenceEntityId = getUserId_Ol($entityLabel);
-								if (empty($referenceEntityId) ||
-										!Import_Utils_Helper::hasAssignPrivilege($moduleName, $referenceEntityId)) {
-									$referenceEntityId = $this->user->id;
-								}
-							} elseif ($referenceModule == 'Currency') {
-								$referenceEntityId = getCurrencyId($entityLabel);
-							} else {
-								try {
-									$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
-								} catch (ImportException $e) {
-									$referenceEntityId = 0;
-								}
-							}
-							if ($referenceEntityId != 0) {
-								$entityId = $referenceEntityId;
-								break;
-							}
-						}
-					}
-					$fieldData[$fieldName] = $entityId;
+					$fieldData[$fieldName] = Import_Reference_Model::resolve(
+							$parsed, $fieldInstance, $cache, $this->user, $moduleName);
 				} else {
 					$referencedModules = $fieldInstance->getReferenceList();
 					if ($referencedModules[0] == 'Users') {
@@ -1334,42 +1306,23 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			foreach($referenceColumns as $referenceColumn) {
 				$referencevalue = $row[$referenceColumn];
 				if (!empty($referencevalue)){
+					$fieldInstance = null;
+					foreach ($allModuleFields as $mFields) {
+						if (isset($mFields[$referenceColumn])) {
+							$fieldInstance = $mFields[$referenceColumn];
+							break;
+						}
+					}
+					// 解決側と同じ宣言から必要な列を導くことで、両者の解釈がずれないようにする
 					$parsed = Import_Reference_Model::parse($referencevalue);
-
-					if (!empty($parsed['columns'])) {
-						// Module::::field====value 形式：指定されたカラムをキャッシュ対象にする
-						if (!isset($columnsForCache[$parsed['module']])){
-							$columnsForCache[$parsed['module']] = array();
+					$neededColumns = Import_Reference_Model::getCacheColumns($parsed, $fieldInstance);
+					foreach ($neededColumns as $refModule => $columns) {
+						if (!isset($columnsForCache[$refModule])) {
+							$columnsForCache[$refModule] = array();
 						}
-						foreach (array_keys($parsed['columns']) as $columnName) {
-							if (!in_array($columnName, $columnsForCache[$parsed['module']])){
-								array_push($columnsForCache[$parsed['module']], $columnName);
-							}
-						}
-					} else if ($parsed['label'] !== null) {
-						// ラベル形式：候補モジュールのエンティティ名項目をキャッシュ対象にする
-						if ($parsed['module'] !== null) {
-							$referencedModules = array($parsed['module']);
-						} else {
-							$fieldInstance = null;
-							foreach ($allModuleFields as $mFields) {
-								if (isset($mFields[$referenceColumn])) {
-									$fieldInstance = $mFields[$referenceColumn];
-									break;
-								}
-							}
-							$referencedModules = $fieldInstance ? $fieldInstance->getReferenceList() : array();
-						}
-						foreach ($referencedModules as $refModule) {
-							$entityNameInfo = getEntityFieldNames($refModule);
-							if (!$entityNameInfo) continue;
-							$fieldNames = $entityNameInfo['fieldname'];
-							if (!is_array($fieldNames)) $fieldNames = array($fieldNames);
-							if (!isset($columnsForCache[$refModule])) $columnsForCache[$refModule] = array();
-							foreach ($fieldNames as $fn) {
-								if (!in_array($fn, $columnsForCache[$refModule])) {
-									array_push($columnsForCache[$refModule], $fn);
-								}
+						foreach ($columns as $column) {
+							if (!in_array($column, $columnsForCache[$refModule])) {
+								array_push($columnsForCache[$refModule], $column);
 							}
 						}
 					}

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -301,19 +301,11 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							case 'reference':	$parsedMergeValue = Import_Reference_Model::parse($comparisonValue);
 												if ($parsedMergeValue['label'] !== null) {
 													$comparisonValue = $parsedMergeValue['label'];
-												} elseif (!empty($parsedMergeValue['columns'])) {
-													// カラム指定形式は値にラベルを含まないため、レコードを特定してその
-													// ラベルを比較値にする。従来は 'field====value' をそのまま比較して
-													// いたため、この形式では重複が永久に見つからなかった
-													try {
-														$mergeEntityId = Import_Reference_Model::resolve(
-															$parsedMergeValue, $fieldInstance, $cache, $this->user, $moduleName);
-													} catch (ImportException $e) {
-														$mergeEntityId = false;
-													}
-													$comparisonValue = $mergeEntityId
-														? Vtiger_Functions::getCRMRecordLabel($mergeEntityId) : '';
 												}
+												// Module::::field====value 形式は値にラベルを含まないため、比較値を
+												// 作れずこの形式では重複が検出されない。従来からの挙動であり、
+												// 重複マージは既存レコードを上書き・マージする処理のため、
+												// 挙動を変える場合は影響の確認を分けて行う。
 												break;
 							case 'currency'	:	if (!empty($comparisonValue)) {
 													$comparisonValue = CurrencyField::convertToUserFormat($comparisonValue, $this->user, TRUE, FALSE);

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -805,59 +805,6 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		return $fieldData;
 	}
 
-	public function createEntityRecord($moduleName, $entityLabel) {
-		$moduleHandler = vtws_getModuleHandlerFromName($moduleName, $this->user);
-		$moduleMeta = $moduleHandler->getMeta();
-		$moduleFields = $moduleMeta->getModuleFields();
-		$mandatoryFields = $moduleMeta->getMandatoryFields();
-		$entityNameFieldsString = $moduleMeta->getNameFields();
-		$entityNameFields = explode(',', $entityNameFieldsString);
-		$fieldData = array();
-		foreach ($entityNameFields as $entityNameField) {
-			$entityNameField = trim($entityNameField);
-			if (in_array($entityNameField, $mandatoryFields)) {
-				$fieldData[$entityNameField] = $entityLabel;
-			}
-		}
-		foreach ($mandatoryFields as $mandatoryField) {
-			if (empty($fieldData[$mandatoryField])) {
-				$fieldInstance = $moduleFields[$mandatoryField];
-				if ($fieldInstance->getFieldDataType() == 'owner') {
-					$fieldData[$mandatoryField] = $this->user->id;
-				} else if (!in_array($mandatoryField, $entityNameFields) && $fieldInstance->getFieldDataType() != 'reference') {
-					$fieldData[$mandatoryField] = '????';
-				}
-			}
-		}
-
-		$fieldData = DataTransform::sanitizeData($fieldData, $moduleMeta);
-		$entityIdInfo = vtws_create($moduleName, $fieldData, $this->user);
-		$adb = PearDatabase::getInstance();
-		$entityIdComponents = vtws_getIdComponents($entityIdInfo['id']);
-		$recordId = $entityIdComponents[1];
-		$entityfields = getEntityFieldNames($moduleName);
-		$label = '';
-		if (is_array($entityfields['fieldname'])) {
-			foreach ($entityfields['fieldname'] as $field) {
-				$label .= $fieldData[$field]." ";
-			}
-		} else {
-			$label = $fieldData[$entityfields['fieldname']];
-		}
-
-		$label = trim($label);
-		$adb->pquery('UPDATE vtiger_crmentity SET label=? WHERE crmid=?', array($label, $recordId));
-		CRMEntity::updateBasicInformation($moduleName, $recordId);
-
-		$recordModel = Vtiger_Record_Model::getCleanInstance($moduleName);
-		$focus = $recordModel->getEntity();
-		$focus->id = $recordId;
-		$focus->column_fields = $fieldData;
-		$this->entitydata[] = VTEntityData::fromCRMEntity($focus);
-		$focus->updateMissingSeqNumber($moduleName);
-		return $entityIdInfo;
-	}
-
 	public function getImportStatusCount() {
 		$adb = PearDatabase::getInstance();
 		$tableName = Import_Utils_Helper::getDbTableName($this->user, $this->id);
@@ -1225,32 +1172,6 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		}
 
 		return $entityInfo;
-	}
-
-	public function getEntityIdsList($referenceModuleName, $fieldValueDetails) {
-		$entityIdsList = array();
-		if ($referenceModuleName && $fieldValueDetails) {
-			foreach ($fieldValueDetails as $value) {
-				$entityLabel = str_replace($referenceModuleName, '', $value);
-				$entityLabel = trim(trim($entityLabel), ',');
-				$entityId = getEntityId($referenceModuleName, decode_html($entityLabel));
-				if (!$entityId) {
-					if (isPermitted($referenceModuleName, 'CreateView') == 'yes') {
-						try {
-							$wsEntityIdInfo = $this->createEntityRecord($referenceModuleName, $entityLabel);
-							$wsEntityId = $wsEntityIdInfo['id'];
-							$entityIdComponents = vtws_getIdComponents($wsEntityId);
-							$entityId = $entityIdComponents[1];
-						} catch (Exception $e) {
-						}
-					}
-				}
-				if ($entityId) {
-					$entityIdsList[] = $entityId;
-				}
-			}
-		}
-		return $entityIdsList;
 	}
 
 	public function createCacheForReference($moduleFields) {

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -575,68 +575,69 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				$fieldData[$fieldName] = $implodeValue;
 			} elseif ($fieldDataType == 'reference') {
 				$entityId = false;
-				$fieldDetails = false;
+				$fieldDetails = array();
 				if (!empty($fieldValue)) {
-					$referenceEntries = preg_split('/\s*,\s*/', trim($fieldValue));
-					$entityIds = array();
-					foreach ($referenceEntries as $referenceEntry) {
-						if ($referenceEntry === '') {
-							continue;
-						}
-						$entityId = false;
-						$fieldDetails = false;
-						if (strpos($referenceEntry, '::::') > 0) {
-							$fieldValueDetails = explode('::::', $referenceEntry);
-						} else if (strpos($referenceEntry, ':::') > 0) {
-							$fieldValueDetails = explode(':::', $referenceEntry);
-						} else {
-							$fieldValueDetails = $referenceEntry;
-						}
+					// 参照項目は常に単一レコードを指すため、セル値を区切り文字で分割しない。
+					// ラベルや値そのものがカンマを含むことがあるため。
+					// 複数レコードの指定は multireference 型の責務とする。
+					$referenceEntry = trim($fieldValue);
+					if (strpos($referenceEntry, '::::') > 0) {
+						$fieldValueDetails = explode('::::', $referenceEntry);
+					} else if (strpos($referenceEntry, ':::') > 0) {
+						$fieldValueDetails = explode(':::', $referenceEntry);
+					} else {
+						$fieldValueDetails = $referenceEntry;
+					}
 
-						foreach($fieldValueDetails as $fieldValueDetail){
+					if (is_array($fieldValueDetails)) {
+						foreach ($fieldValueDetails as $fieldValueDetail) {
 							if (strpos($fieldValueDetail, '====') > 0) {
 								$fieldDetail = explode('====', $fieldValueDetail);
 								$fieldDetails[$fieldDetail[0]] = decode_html(trim($fieldDetail[1]));
 							}
 						}
+					}
 
-						if (php7_count($fieldValueDetails) > 1) {
-							$referenceModuleName = trim($fieldValueDetails[0]);
-							$referenceValueList = $fieldDetails;
-							$entityId = getEntityIdByColumns($referenceModuleName, $referenceValueList, $cache);
+					$referencedModules = array();
+					$entityLabel = '';
+					if (php7_count($fieldValueDetails) > 1) {
+						$referenceModuleName = trim($fieldValueDetails[0]);
+						if (!empty($fieldDetails)) {
+							// Module::::field====value 形式：指定カラムのAND条件でレコードを特定する
+							$entityId = getEntityIdByColumns($referenceModuleName, $fieldDetails, $cache);
 						} else {
-							$referencedModules = $fieldInstance->getReferenceList();
-							$entityLabel = $referenceEntry;
-							foreach ($referencedModules as $referenceModule) {
-								$referenceModuleName = $referenceModule;
-								if ($referenceModule == 'Users') {
-									$referenceEntityId = getUserId_Ol($entityLabel);
-									if (empty($referenceEntityId) ||
-											!Import_Utils_Helper::hasAssignPrivilege($moduleName, $referenceEntityId)) {
-										$referenceEntityId = $this->user->id;
-									}
-								} elseif ($referenceModule == 'Currency') {
-									$referenceEntityId = getCurrencyId($entityLabel);
-								} else {
-									try {
-										$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
-									} catch (ImportException $e) {
-										$referenceEntityId = 0;
-									}
-								}
-								if ($referenceEntityId != 0) {
-									$entityId = $referenceEntityId;
-									break;
-								}
+							// Module::::Label / Module:::Label 形式：モジュールを限定してラベルで特定する
+							// （旧・複数レコード形式 Module:::L1:::L2 は単一参照では扱わないため先頭のみ採用）
+							$referencedModules = array($referenceModuleName);
+							$entityLabel = trim($fieldValueDetails[1]);
+						}
+					} else {
+						// Label のみ：項目の参照先モジュールを順に試す
+						$referencedModules = $fieldInstance->getReferenceList();
+						$entityLabel = $referenceEntry;
+					}
+
+					foreach ($referencedModules as $referenceModule) {
+						$referenceModuleName = $referenceModule;
+						if ($referenceModule == 'Users') {
+							$referenceEntityId = getUserId_Ol($entityLabel);
+							if (empty($referenceEntityId) ||
+									!Import_Utils_Helper::hasAssignPrivilege($moduleName, $referenceEntityId)) {
+								$referenceEntityId = $this->user->id;
+							}
+						} elseif ($referenceModule == 'Currency') {
+							$referenceEntityId = getCurrencyId($entityLabel);
+						} else {
+							try {
+								$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
+							} catch (ImportException $e) {
+								$referenceEntityId = 0;
 							}
 						}
-						if (!empty($entityId)) {
-							$entityIds[] = $entityId;
+						if ($referenceEntityId != 0) {
+							$entityId = $referenceEntityId;
+							break;
 						}
-					}
-				
-					if ($entityIds) {
-						$entityId = implode(', ', $entityIds);
 					}
 					$fieldData[$fieldName] = $entityId;
 				} else {

--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -298,13 +298,9 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 							case 'owner'	:	$userId = getUserId_Ol($comparisonValue);
 												$comparisonValue = getUserFullName($userId);
 												break;
-							case 'reference':	if (strpos($comparisonValue, '::::') > 0) {
-													$referenceFileValueComponents = explode('::::', $comparisonValue);
-												} else {
-													$referenceFileValueComponents = explode(':::', $comparisonValue);
-												}
-												if (php7_count($referenceFileValueComponents) > 1) {
-													$comparisonValue = trim($referenceFileValueComponents[1]);
+							case 'reference':	$parsedMergeValue = Import_Reference_Model::parse($comparisonValue);
+												if ($parsedMergeValue['label'] !== null) {
+													$comparisonValue = $parsedMergeValue['label'];
 												}
 												break;
 							case 'currency'	:	if (!empty($comparisonValue)) {
@@ -575,68 +571,46 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				$fieldData[$fieldName] = $implodeValue;
 			} elseif ($fieldDataType == 'reference') {
 				$entityId = false;
-				$fieldDetails = array();
 				if (!empty($fieldValue)) {
-					// 参照項目は常に単一レコードを指すため、セル値を区切り文字で分割しない。
-					// ラベルや値そのものがカンマを含むことがあるため。
-					// 複数レコードの指定は multireference 型の責務とする。
-					$referenceEntry = trim($fieldValue);
-					if (strpos($referenceEntry, '::::') > 0) {
-						$fieldValueDetails = explode('::::', $referenceEntry);
-					} else if (strpos($referenceEntry, ':::') > 0) {
-						$fieldValueDetails = explode(':::', $referenceEntry);
-					} else {
-						$fieldValueDetails = $referenceEntry;
-					}
+					$parsed = Import_Reference_Model::parse($fieldValue);
 
-					if (is_array($fieldValueDetails)) {
-						foreach ($fieldValueDetails as $fieldValueDetail) {
-							if (strpos($fieldValueDetail, '====') > 0) {
-								$fieldDetail = explode('====', $fieldValueDetail);
-								$fieldDetails[$fieldDetail[0]] = decode_html(trim($fieldDetail[1]));
-							}
+					if (!empty($parsed['columns'])) {
+						// Module::::field====value 形式：指定カラムのAND条件でレコードを特定する
+						$columns = array();
+						foreach ($parsed['columns'] as $columnName => $columnValue) {
+							$columns[$columnName] = decode_html($columnValue);
 						}
-					}
-
-					$referencedModules = array();
-					$entityLabel = '';
-					if (php7_count($fieldValueDetails) > 1) {
-						$referenceModuleName = trim($fieldValueDetails[0]);
-						if (!empty($fieldDetails)) {
-							// Module::::field====value 形式：指定カラムのAND条件でレコードを特定する
-							$entityId = getEntityIdByColumns($referenceModuleName, $fieldDetails, $cache);
+						$entityId = getEntityIdByColumns($parsed['module'], $columns, $cache);
+					} else if ($parsed['label'] !== null) {
+						$entityLabel = $parsed['label'];
+						if ($parsed['module'] !== null) {
+							// Module::::Label / Module:::Label 形式：モジュールを限定する
+							$referencedModules = array($parsed['module']);
 						} else {
-							// Module::::Label / Module:::Label 形式：モジュールを限定してラベルで特定する
-							// （旧・複数レコード形式 Module:::L1:::L2 は単一参照では扱わないため先頭のみ採用）
-							$referencedModules = array($referenceModuleName);
-							$entityLabel = trim($fieldValueDetails[1]);
+							// Label のみ：項目の参照先モジュールを順に試す
+							$referencedModules = $fieldInstance->getReferenceList();
 						}
-					} else {
-						// Label のみ：項目の参照先モジュールを順に試す
-						$referencedModules = $fieldInstance->getReferenceList();
-						$entityLabel = $referenceEntry;
-					}
 
-					foreach ($referencedModules as $referenceModule) {
-						$referenceModuleName = $referenceModule;
-						if ($referenceModule == 'Users') {
-							$referenceEntityId = getUserId_Ol($entityLabel);
-							if (empty($referenceEntityId) ||
-									!Import_Utils_Helper::hasAssignPrivilege($moduleName, $referenceEntityId)) {
-								$referenceEntityId = $this->user->id;
+						foreach ($referencedModules as $referenceModule) {
+							if ($referenceModule == 'Users') {
+								$referenceEntityId = getUserId_Ol($entityLabel);
+								if (empty($referenceEntityId) ||
+										!Import_Utils_Helper::hasAssignPrivilege($moduleName, $referenceEntityId)) {
+									$referenceEntityId = $this->user->id;
+								}
+							} elseif ($referenceModule == 'Currency') {
+								$referenceEntityId = getCurrencyId($entityLabel);
+							} else {
+								try {
+									$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
+								} catch (ImportException $e) {
+									$referenceEntityId = 0;
+								}
 							}
-						} elseif ($referenceModule == 'Currency') {
-							$referenceEntityId = getCurrencyId($entityLabel);
-						} else {
-							try {
-								$referenceEntityId = getEntityId($referenceModule, decode_html($entityLabel));
-							} catch (ImportException $e) {
-								$referenceEntityId = 0;
+							if ($referenceEntityId != 0) {
+								$entityId = $referenceEntityId;
+								break;
 							}
-						}
-						if ($referenceEntityId != 0) {
-							$entityId = $referenceEntityId;
-							break;
 						}
 					}
 					$fieldData[$fieldName] = $entityId;
@@ -1360,24 +1334,23 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 			foreach($referenceColumns as $referenceColumn) {
 				$referencevalue = $row[$referenceColumn];
 				if (!empty($referencevalue)){
-					if (strpos($referencevalue, '::::') > 0) {
-						$fieldValueDetails = explode('::::', $referencevalue);
-					} else if (strpos($referencevalue, ':::') > 0) {
-						$fieldValueDetails = explode(':::', $referencevalue);
-					} else {
-						$fieldValueDetails = array($referencevalue);
-					}
+					$parsed = Import_Reference_Model::parse($referencevalue);
 
-					foreach($fieldValueDetails as $fieldValueDetail){
-						if (strpos($fieldValueDetail, '====') > 0) {
-							$fieldDetail = explode('====', $fieldValueDetail);
-							if (!isset($columnsForCache[$fieldValueDetails[0]])){
-								$columnsForCache[$fieldValueDetails[0]] = array();
+					if (!empty($parsed['columns'])) {
+						// Module::::field====value 形式：指定されたカラムをキャッシュ対象にする
+						if (!isset($columnsForCache[$parsed['module']])){
+							$columnsForCache[$parsed['module']] = array();
+						}
+						foreach (array_keys($parsed['columns']) as $columnName) {
+							if (!in_array($columnName, $columnsForCache[$parsed['module']])){
+								array_push($columnsForCache[$parsed['module']], $columnName);
 							}
-							if (!in_array($fieldDetail[0],$columnsForCache[$fieldValueDetails[0]])){
-								array_push($columnsForCache[$fieldValueDetails[0]],$fieldDetail[0]);
-							}
-						} else if (php7_count($fieldValueDetails) == 1) {
+						}
+					} else if ($parsed['label'] !== null) {
+						// ラベル形式：候補モジュールのエンティティ名項目をキャッシュ対象にする
+						if ($parsed['module'] !== null) {
+							$referencedModules = array($parsed['module']);
+						} else {
 							$fieldInstance = null;
 							foreach ($allModuleFields as $mFields) {
 								if (isset($mFields[$referenceColumn])) {
@@ -1385,19 +1358,17 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 									break;
 								}
 							}
-							if ($fieldInstance) {
-								$referencedModules = $fieldInstance->getReferenceList();
-								foreach ($referencedModules as $refModule) {
-									$entityNameInfo = getEntityFieldNames($refModule);
-									if (!$entityNameInfo) continue;
-									$fieldNames = $entityNameInfo['fieldname'];
-									if (!is_array($fieldNames)) $fieldNames = array($fieldNames);
-									if (!isset($columnsForCache[$refModule])) $columnsForCache[$refModule] = array();
-									foreach ($fieldNames as $fn) {
-										if (!in_array($fn, $columnsForCache[$refModule])) {
-											array_push($columnsForCache[$refModule], $fn);
-										}
-									}
+							$referencedModules = $fieldInstance ? $fieldInstance->getReferenceList() : array();
+						}
+						foreach ($referencedModules as $refModule) {
+							$entityNameInfo = getEntityFieldNames($refModule);
+							if (!$entityNameInfo) continue;
+							$fieldNames = $entityNameInfo['fieldname'];
+							if (!is_array($fieldNames)) $fieldNames = array($fieldNames);
+							if (!isset($columnsForCache[$refModule])) $columnsForCache[$refModule] = array();
+							foreach ($fieldNames as $fn) {
+								if (!in_array($fn, $columnsForCache[$refModule])) {
+									array_push($columnsForCache[$refModule], $fn);
 								}
 							}
 						}

--- a/modules/Import/models/Reference.php
+++ b/modules/Import/models/Reference.php
@@ -108,9 +108,12 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 	/**
 	 * ラベルでレコードを特定する。
 	 *
-	 * 一致条件はエンティティ名項目をスペース連結した全体一致。Contacts なら
-	 * 「山田 太郎」で一致し、「山田」単独では一致しない。画面表示および
-	 * エクスポート出力のラベルと揃えるため。
+	 * 2段階で照合する。Contacts（lastname,firstname）の例:
+	 *   1段目: 連結した全体一致 …… 「山田 太郎」で一致
+	 *   2段目: 構成項目の個別一致 … 1段目で見つからなければ「山田」「太郎」でも一致
+	 *
+	 * 1段目を優先するのは、画面表示およびエクスポート出力のラベルと同じ形だから。
+	 * 2段目を残すのは、姓だけ・名だけを書いた既存のCSVを解決できるようにするため。
 	 *
 	 * @param string $module モジュール名
 	 * @param string $label  ラベル
@@ -134,13 +137,48 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 		$fieldNames = is_array($entityInfo['fieldname'])
 				? $entityInfo['fieldname'] : array($entityInfo['fieldname']);
 
-		$matchedIds = self::matchLabelInCache($module, $label, $cache, $fieldNames, $entityInfo['entityidfield']);
-		if ($matchedIds === null) {
-			// キャッシュが無い、または照合に必要な列が揃っていない
-			$matchedIds = self::matchLabelInDb($label, $fieldNames, $entityInfo);
+		// 1段目：エンティティ名項目を連結した全体一致。
+		// 画面表示およびエクスポート出力のラベルと同じ形なので、これを優先する
+		$matchedIds = self::matchLabel($module, $label, $cache, array($fieldNames), $entityInfo);
+
+		// 2段目：見つからなければ構成項目の個別一致も試す。
+		// 「山田」のように姓だけ・名だけを書いた既存のCSVを解決できるようにするため。
+		// 複数項目でラベルを構成するモジュール（Contacts / Leads / Users）のみ対象
+		if (empty($matchedIds) && count($fieldNames) > 1) {
+			$singleFieldGroups = array();
+			foreach ($fieldNames as $fieldName) {
+				$singleFieldGroups[] = array($fieldName);
+			}
+			$matchedIds = self::matchLabel($module, $label, $cache, $singleFieldGroups, $entityInfo);
 		}
 
 		return self::single($matchedIds, $module, $label);
+	}
+
+	/**
+	 * ラベルを照合する。キャッシュが使えればキャッシュ、そうでなければ DB を引く。
+	 *
+	 * @param array $fieldGroups 照合単位の配列。各要素は連結して1つのラベルを構成する
+	 *                           項目名の配列。例: array(array('lastname','firstname')) なら
+	 *                           「姓 名」の全体一致、array(array('lastname'),array('firstname'))
+	 *                           なら姓または名の個別一致
+	 * @return array 一致した crmid の配列
+	 */
+	private static function matchLabel($module, $label, $cache, $fieldGroups, $entityInfo) {
+		$allFieldNames = array();
+		foreach ($fieldGroups as $group) {
+			foreach ($group as $fieldName) {
+				$allFieldNames[] = $fieldName;
+			}
+		}
+
+		$matchedIds = self::matchLabelInCache($module, $label, $cache, $fieldGroups, $allFieldNames, $entityInfo['entityidfield']);
+		if ($matchedIds === null) {
+			// キャッシュが無い、または照合に必要な列が揃っていない
+			$matchedIds = self::matchLabelInDb($label, $fieldGroups, $entityInfo);
+		}
+
+		return $matchedIds;
 	}
 
 	/**
@@ -243,9 +281,11 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 	/**
 	 * キャッシュ上でラベルを照合する。
 	 *
+	 * @param array $fieldGroups 照合単位。各要素は連結して1ラベルを構成する項目名の配列
+	 * @param array $allFieldNames $fieldGroups に現れる全項目名（列の有無判定に使う）
 	 * @return array|null 一致した crmid の配列。キャッシュが使えない場合は null
 	 */
-	private static function matchLabelInCache($module, $label, $cache, $fieldNames, $entityIdField) {
+	private static function matchLabelInCache($module, $label, $cache, $fieldGroups, $allFieldNames, $entityIdField) {
 		if (empty($cache[$module])) {
 			return null;
 		}
@@ -256,7 +296,7 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 		if (!is_array($firstRow) || !array_key_exists($entityIdField, $firstRow)) {
 			return null;
 		}
-		foreach ($fieldNames as $fieldName) {
+		foreach ($allFieldNames as $fieldName) {
 			if (!array_key_exists($fieldName, $firstRow)) {
 				return null;
 			}
@@ -264,21 +304,24 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 
 		$matchedIds = array();
 		foreach ($cache[$module] as $recordModel) {
-			$values = array();
-			$hasNull = false;
-			foreach ($fieldNames as $fieldName) {
-				if (!array_key_exists($fieldName, $recordModel) || $recordModel[$fieldName] === null) {
-					// SQL の concat() は引数に NULL があると NULL を返して一致しない。挙動を揃える
-					$hasNull = true;
-					break;
+			foreach ($fieldGroups as $group) {
+				$values = array();
+				$hasNull = false;
+				foreach ($group as $fieldName) {
+					if (!array_key_exists($fieldName, $recordModel) || $recordModel[$fieldName] === null) {
+						// SQL の concat() は引数に NULL があると NULL を返して一致しない。挙動を揃える
+						$hasNull = true;
+						break;
+					}
+					$values[] = $recordModel[$fieldName];
 				}
-				$values[] = $recordModel[$fieldName];
-			}
-			if ($hasNull) {
-				continue;
-			}
-			if (trim(implode(' ', $values)) === $label) {
-				$matchedIds[] = $recordModel[$entityIdField];
+				if ($hasNull) {
+					continue;
+				}
+				if (trim(implode(' ', $values)) === $label) {
+					$matchedIds[] = $recordModel[$entityIdField];
+					break;   // 同一レコードを複数回数えない
+				}
 			}
 		}
 
@@ -288,9 +331,10 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 	/**
 	 * DB 上でラベルを照合する。
 	 *
+	 * @param array $fieldGroups 照合単位。各要素は連結して1ラベルを構成する項目名の配列
 	 * @return array 一致した crmid の配列
 	 */
-	private static function matchLabelInDb($label, $fieldNames, $entityInfo) {
+	private static function matchLabelInDb($label, $fieldGroups, $entityInfo) {
 		$adb = PearDatabase::getInstance();
 
 		$tableName = $entityInfo['tablename'];
@@ -299,16 +343,25 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 			return array();
 		}
 
-		if (count($fieldNames) > 1) {
-			$labelExpression = 'trim(concat(' . implode(",' ',", $fieldNames) . '))';
-		} else {
-			$labelExpression = $fieldNames[0];
+		$conditions = array();
+		$params = array();
+		foreach ($fieldGroups as $group) {
+			if (count($group) > 1) {
+				$labelExpression = 'trim(concat(' . implode(",' ',", $group) . '))';
+			} else {
+				$labelExpression = $group[0];
+			}
+			$conditions[] = $labelExpression . ' = ?';
+			$params[] = $label;
+		}
+		if (empty($conditions)) {
+			return array();
 		}
 
 		$sql = "SELECT $tableName.$entityIdField FROM $tableName"
 				. " INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = $tableName.$entityIdField"
-				. " WHERE vtiger_crmentity.deleted = 0 AND $labelExpression = ?";
-		$result = $adb->pquery($sql, array($label));
+				. " WHERE vtiger_crmentity.deleted = 0 AND (" . implode(' OR ', $conditions) . ")";
+		$result = $adb->pquery($sql, $params);
 		if (!$result) {
 			return array();
 		}

--- a/modules/Import/models/Reference.php
+++ b/modules/Import/models/Reference.php
@@ -1,0 +1,75 @@
+<?php
+/* ***********************************************************************************
+ * 参照項目（uitype 10）のインポート書式を解釈・解決する。
+ *
+ * 受理する書式（優先順）:
+ *   1. Module::::field====value::::field====value  指定カラムのAND条件でレコードを特定
+ *   2. Module::::Label / Module:::Label            モジュールを限定してラベルで特定
+ *   3. Label                                       項目の参照先モジュールを順に試して特定
+ *
+ * この書式の解釈はこのクラスに集約する。呼び出し元で独自にパースしてはならない。
+ * 解釈規則が箇所ごとにずれることが Issue #1796 の根本原因だった。
+ * ***********************************************************************************/
+
+class Import_Reference_Model extends Vtiger_Base_Model {
+
+	const MODULE_DELIMITER_LONG  = '::::';
+	const MODULE_DELIMITER_SHORT = ':::';
+	const COLUMN_DELIMITER       = '====';
+
+	/**
+	 * セル値を構造へ変換する。
+	 *
+	 * 純粋関数として保つ（PHP 組込関数のみを使い、DB・キャッシュ・グローバルに触れない）。
+	 * decode_html() は適用しない。呼び出し元および resolve() の責務とする。
+	 *
+	 * @param string $value セル値
+	 * @return array array('module' => string|null, 'columns' => array, 'label' => string|null)
+	 *               columns と label は排他
+	 */
+	public static function parse($value) {
+		$parsed = array('module' => null, 'columns' => array(), 'label' => null);
+
+		$entry = trim((string) $value);
+		if ($entry === '') {
+			return $parsed;
+		}
+
+		// 参照項目は常に単一レコードを指すため、セル値を区切り文字で分割しない。
+		// ラベルや値そのものがカンマを含むことがあるため（Issue #1796）。
+		if (strpos($entry, self::MODULE_DELIMITER_LONG) > 0) {
+			$parts = explode(self::MODULE_DELIMITER_LONG, $entry);
+		} else if (strpos($entry, self::MODULE_DELIMITER_SHORT) > 0) {
+			$parts = explode(self::MODULE_DELIMITER_SHORT, $entry);
+		} else {
+			// モジュール指定なし。値全体がラベル
+			$parsed['label'] = $entry;
+			return $parsed;
+		}
+
+		$parsed['module'] = trim($parts[0]);
+
+		$columns = array();
+		for ($i = 1; $i < count($parts); $i++) {
+			if (strpos($parts[$i], self::COLUMN_DELIMITER) > 0) {
+				// 値そのものが ==== を含む場合に値を失わないよう分割数を2に制限する
+				$column = explode(self::COLUMN_DELIMITER, $parts[$i], 2);
+				$columns[trim($column[0])] = trim($column[1]);
+			}
+		}
+
+		if (!empty($columns)) {
+			$parsed['columns'] = $columns;
+			return $parsed;
+		}
+
+		// Module::::Label / Module:::Label 形式。
+		// 旧・複数レコード形式 Module:::L1:::L2 は単一参照では扱わないため先頭のみ採用する
+		if (isset($parts[1])) {
+			$label = trim($parts[1]);
+			$parsed['label'] = ($label === '') ? null : $label;
+		}
+
+		return $parsed;
+	}
+}

--- a/modules/Import/models/Reference.php
+++ b/modules/Import/models/Reference.php
@@ -11,6 +11,10 @@
  * 解釈規則が箇所ごとにずれることが Issue #1796 の根本原因だった。
  * ***********************************************************************************/
 
+// ImportException と Import_Utils_Helper はどちらもこのファイルで定義されている。
+// オートロードは Import_Utils_Helper 経由でしか効かないため、明示的に読み込む
+vimport('modules.Import.helpers.Utils');
+
 class Import_Reference_Model extends Vtiger_Base_Model {
 
 	const MODULE_DELIMITER_LONG  = '::::';
@@ -71,5 +75,274 @@ class Import_Reference_Model extends Vtiger_Base_Model {
 		}
 
 		return $parsed;
+	}
+
+	/**
+	 * カラム条件（Module::::field====value 形式）でレコードを特定する。
+	 *
+	 * @param string $module モジュール名
+	 * @param array  $columns カラム名 => 値
+	 * @param array  $cache createCacheForReference() が作ったキャッシュ
+	 * @return int|false 特定できた crmid。該当なしは false
+	 * @throws ImportException 複数レコードに一致した場合
+	 */
+	public static function resolveByColumns($module, $columns, $cache) {
+		if (empty($module) || empty($columns) || empty($cache[$module])) {
+			return false;
+		}
+
+		$matchedIds = array();
+		ksort($columns);
+		foreach ($cache[$module] as $recordModel) {
+			$filtered = array_intersect_key($recordModel, $columns);
+			ksort($filtered);
+			if ($filtered === $columns) {
+				$values = array_values($recordModel);
+				$matchedIds[] = $values[0];
+			}
+		}
+
+		return self::single($matchedIds, $module, $columns);
+	}
+
+	/**
+	 * ラベルでレコードを特定する。
+	 *
+	 * 一致条件はエンティティ名項目をスペース連結した全体一致。Contacts なら
+	 * 「山田 太郎」で一致し、「山田」単独では一致しない。画面表示および
+	 * エクスポート出力のラベルと揃えるため。
+	 *
+	 * @param string $module モジュール名
+	 * @param string $label  ラベル
+	 * @param array  $cache  createCacheForReference() が作ったキャッシュ
+	 * @return int|false 特定できた crmid。該当なしは false
+	 * @throws ImportException 複数レコードに一致した場合
+	 */
+	public static function resolveByLabel($module, $label, $cache) {
+		if (empty($module)) {
+			return false;
+		}
+		$label = trim((string) $label);
+		if ($label === '') {
+			return false;
+		}
+
+		$entityInfo = getEntityFieldNames($module);
+		if (empty($entityInfo) || empty($entityInfo['fieldname'])) {
+			return false;
+		}
+		$fieldNames = is_array($entityInfo['fieldname'])
+				? $entityInfo['fieldname'] : array($entityInfo['fieldname']);
+
+		$matchedIds = self::matchLabelInCache($module, $label, $cache, $fieldNames, $entityInfo['entityidfield']);
+		if ($matchedIds === null) {
+			// キャッシュが無い、または照合に必要な列が揃っていない
+			$matchedIds = self::matchLabelInDb($label, $fieldNames, $entityInfo);
+		}
+
+		return self::single($matchedIds, $module, $label);
+	}
+
+	/**
+	 * パース結果を解決する。
+	 *
+	 * @param array $parsed parse() の戻り値
+	 * @param Vtiger_Field_Model $fieldInstance 対象の参照項目
+	 * @param array $cache createCacheForReference() が作ったキャッシュ
+	 * @param Users $user インポート実行ユーザ
+	 * @param string $moduleName インポート対象モジュール名（Users の権限判定に使う）
+	 * @return int|false 特定できた crmid。該当なしは false
+	 * @throws ImportException 複数レコードに一致した場合
+	 */
+	public static function resolve($parsed, $fieldInstance, $cache, $user, $moduleName) {
+		if (!empty($parsed['columns'])) {
+			$columns = array();
+			foreach ($parsed['columns'] as $columnName => $columnValue) {
+				$columns[$columnName] = decode_html($columnValue);
+			}
+			return self::resolveByColumns($parsed['module'], $columns, $cache);
+		}
+
+		if ($parsed['label'] === null) {
+			return false;
+		}
+		$label = decode_html($parsed['label']);
+
+		if ($parsed['module'] !== null) {
+			$referencedModules = array($parsed['module']);
+		} else {
+			$referencedModules = $fieldInstance->getReferenceList();
+		}
+
+		foreach ($referencedModules as $referenceModule) {
+			// Users / Currency は専用の検索関数を使う。連結一致・曖昧一致の規則は適用しない
+			if ($referenceModule == 'Users') {
+				$entityId = getUserId_Ol($label);
+				if (empty($entityId) || !Import_Utils_Helper::hasAssignPrivilege($moduleName, $entityId)) {
+					$entityId = $user->id;
+				}
+			} elseif ($referenceModule == 'Currency') {
+				$entityId = getCurrencyId($label);
+			} else {
+				$entityId = self::resolveByLabel($referenceModule, $label, $cache);
+			}
+			if (!empty($entityId)) {
+				return $entityId;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * 解決に必要なキャッシュ列を申告する。
+	 *
+	 * createCacheForReference() はこの申告に従って列を揃える。構築側と解決側が
+	 * 同じ宣言から導かれることで、両者の解釈がずれなくなる（Issue #1796 の根本原因）。
+	 *
+	 * @param array $parsed parse() の戻り値
+	 * @param Vtiger_Field_Model $fieldInstance 対象の参照項目
+	 * @return array モジュール名 => 必要な列名の配列
+	 */
+	public static function getCacheColumns($parsed, $fieldInstance) {
+		$needed = array();
+
+		if (!empty($parsed['columns'])) {
+			if ($parsed['module'] !== null) {
+				$needed[$parsed['module']] = array_keys($parsed['columns']);
+			}
+			return $needed;
+		}
+
+		if ($parsed['label'] === null) {
+			return $needed;
+		}
+
+		if ($parsed['module'] !== null) {
+			$referencedModules = array($parsed['module']);
+		} else {
+			$referencedModules = $fieldInstance ? $fieldInstance->getReferenceList() : array();
+		}
+
+		foreach ($referencedModules as $referenceModule) {
+			if ($referenceModule == 'Users' || $referenceModule == 'Currency') {
+				continue;   // 専用の検索関数を使うためキャッシュ不要
+			}
+			$entityInfo = getEntityFieldNames($referenceModule);
+			if (empty($entityInfo) || empty($entityInfo['fieldname'])) {
+				continue;
+			}
+			$fieldNames = is_array($entityInfo['fieldname'])
+					? $entityInfo['fieldname'] : array($entityInfo['fieldname']);
+			$needed[$referenceModule] = $fieldNames;
+		}
+
+		return $needed;
+	}
+
+	/**
+	 * キャッシュ上でラベルを照合する。
+	 *
+	 * @return array|null 一致した crmid の配列。キャッシュが使えない場合は null
+	 */
+	private static function matchLabelInCache($module, $label, $cache, $fieldNames, $entityIdField) {
+		if (empty($cache[$module])) {
+			return null;
+		}
+
+		// 照合に必要な列が揃っていなければキャッシュを使ってはならない。
+		// 列が欠けたまま照合すると「0件」と誤判定し、解決できたはずの参照が空になる
+		$firstRow = reset($cache[$module]);
+		if (!is_array($firstRow) || !array_key_exists($entityIdField, $firstRow)) {
+			return null;
+		}
+		foreach ($fieldNames as $fieldName) {
+			if (!array_key_exists($fieldName, $firstRow)) {
+				return null;
+			}
+		}
+
+		$matchedIds = array();
+		foreach ($cache[$module] as $recordModel) {
+			$values = array();
+			$hasNull = false;
+			foreach ($fieldNames as $fieldName) {
+				if (!array_key_exists($fieldName, $recordModel) || $recordModel[$fieldName] === null) {
+					// SQL の concat() は引数に NULL があると NULL を返して一致しない。挙動を揃える
+					$hasNull = true;
+					break;
+				}
+				$values[] = $recordModel[$fieldName];
+			}
+			if ($hasNull) {
+				continue;
+			}
+			if (trim(implode(' ', $values)) === $label) {
+				$matchedIds[] = $recordModel[$entityIdField];
+			}
+		}
+
+		return $matchedIds;
+	}
+
+	/**
+	 * DB 上でラベルを照合する。
+	 *
+	 * @return array 一致した crmid の配列
+	 */
+	private static function matchLabelInDb($label, $fieldNames, $entityInfo) {
+		$adb = PearDatabase::getInstance();
+
+		$tableName = $entityInfo['tablename'];
+		$entityIdField = $entityInfo['entityidfield'];
+		if (empty($tableName) || empty($entityIdField)) {
+			return array();
+		}
+
+		if (count($fieldNames) > 1) {
+			$labelExpression = 'trim(concat(' . implode(",' ',", $fieldNames) . '))';
+		} else {
+			$labelExpression = $fieldNames[0];
+		}
+
+		$sql = "SELECT $tableName.$entityIdField FROM $tableName"
+				. " INNER JOIN vtiger_crmentity ON vtiger_crmentity.crmid = $tableName.$entityIdField"
+				. " WHERE vtiger_crmentity.deleted = 0 AND $labelExpression = ?";
+		$result = $adb->pquery($sql, array($label));
+		if (!$result) {
+			return array();
+		}
+
+		$matchedIds = array();
+		$noOfRows = $adb->num_rows($result);
+		for ($i = 0; $i < $noOfRows; ++$i) {
+			$matchedIds[] = $adb->query_result($result, $i, $entityIdField);
+		}
+
+		return $matchedIds;
+	}
+
+	/**
+	 * 一致結果を1件に絞る。
+	 *
+	 * 複数件に一致した場合は例外とする。従来 getEntityId() は先頭を黙って採用して
+	 * いたが、誤ったレコードに紐づいたことに気づけないため廃止する（Issue #1796）。
+	 *
+	 * @return int|false
+	 * @throws ImportException
+	 */
+	private static function single($matchedIds, $module, $condition) {
+		$count = count($matchedIds);
+		if ($count === 1) {
+			return $matchedIds[0];
+		}
+		if ($count > 1) {
+			global $log;
+			$log->error(sprintf(
+					'Import reference: %d records matched in %s for %s. Skipping the row.',
+					$count, $module, is_array($condition) ? json_encode($condition) : $condition));
+			throw new ImportException('Reference matched multiple records');
+		}
+		return false;
 	}
 }

--- a/modules/PriceBooks/PriceBooks.php
+++ b/modules/PriceBooks/PriceBooks.php
@@ -484,12 +484,18 @@ class PriceBooks extends CRMEntity {
 				if(!$product['relatedto'])
 					continue;
 				$parsed = Import_Reference_Model::parse($product['relatedto']);
-				if (!empty($parsed['columns'])) {
-					$productId = getEntityIdByColumns($parsed['module'], $parsed['columns'], $cache);
-				} else if ($parsed['label'] !== null) {
-					$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
-					$productId = getEntityIdByColumns($productModule, $parsed['label'], $cache);
-				} else {
+				$productId = false;
+				try {
+					if (!empty($parsed['columns'])) {
+						$productId = Import_Reference_Model::resolveByColumns($parsed['module'], $parsed['columns'], $cache);
+					} else if ($parsed['label'] !== null) {
+						$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
+						$productId = Import_Reference_Model::resolveByLabel($productModule, $parsed['label'], $cache);
+					}
+				} catch (ImportException $e) {
+					$productId = false;
+				}
+				if (!$productId) {
 					continue;
 				}
                 $presence = isRecordExists($productId);
@@ -510,12 +516,18 @@ class PriceBooks extends CRMEntity {
 		$entityIds = array();
 		foreach($productList as $product){
 			$parsed = Import_Reference_Model::parse($product['relatedto']);
-			if (!empty($parsed['columns'])) {
-				$productId = getEntityIdByColumns($parsed['module'], $parsed['columns'], $cache);
-			} else if ($parsed['label'] !== null) {
-				$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
-				$productId = getEntityIdByColumns($productModule, $parsed['label'], $cache);
-			} else {
+			$productId = 0;
+			try {
+				if (!empty($parsed['columns'])) {
+					$productId = Import_Reference_Model::resolveByColumns($parsed['module'], $parsed['columns'], $cache);
+				} else if ($parsed['label'] !== null) {
+					$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
+					$productId = Import_Reference_Model::resolveByLabel($productModule, $parsed['label'], $cache);
+				}
+			} catch (ImportException $e) {
+				$productId = 0;
+			}
+			if (!$productId) {
 				$productId = 0;
 			}
 			array_push($entityIds, $productId);

--- a/modules/PriceBooks/PriceBooks.php
+++ b/modules/PriceBooks/PriceBooks.php
@@ -483,16 +483,15 @@ class PriceBooks extends CRMEntity {
 			foreach($productList as $product){
 				if(!$product['relatedto'])
 					continue;
-				$productDetails = $product['relatedto'];
-				$productDetails = explode('::::', $productDetails);
-				$productValueDetails = false;
-				foreach($productDetails as $productDetail){
-					if (strpos($productDetail, '====') > 0) {
-						$productValueDetail = explode('====', $productDetail);
-						$productValueDetails[$productValueDetail[0]] = $productValueDetail[1];
-					}
+				$parsed = Import_Reference_Model::parse($product['relatedto']);
+				if (!empty($parsed['columns'])) {
+					$productId = getEntityIdByColumns($parsed['module'], $parsed['columns'], $cache);
+				} else if ($parsed['label'] !== null) {
+					$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
+					$productId = getEntityIdByColumns($productModule, $parsed['label'], $cache);
+				} else {
+					continue;
 				}
-				$productId = getEntityIdByColumns($productDetails[0], $productValueDetails, $cache);
                 $presence = isRecordExists($productId);
                 if($presence){
                     $productInstance = Vtiger_Record_Model::getInstanceById($productId);
@@ -510,16 +509,15 @@ class PriceBooks extends CRMEntity {
 		$isProductsExist = false;
 		$entityIds = array();
 		foreach($productList as $product){
-			$productDetails = $product['relatedto'];
-			$productDetails = explode('::::', $productDetails);
-			$productValueDetails = false;
-			foreach($productDetails as $productDetail){
-				if (strpos($productDetail, '====') > 0) {
-					$productValueDetail = explode('====', $productDetail);
-					$productValueDetails[$productValueDetail[0]] = $productValueDetail[1];
-				}
+			$parsed = Import_Reference_Model::parse($product['relatedto']);
+			if (!empty($parsed['columns'])) {
+				$productId = getEntityIdByColumns($parsed['module'], $parsed['columns'], $cache);
+			} else if ($parsed['label'] !== null) {
+				$productModule = ($parsed['module'] !== null) ? $parsed['module'] : 'Products';
+				$productId = getEntityIdByColumns($productModule, $parsed['label'], $cache);
+			} else {
+				$productId = 0;
 			}
-			$productId = getEntityIdByColumns($productDetails[0], $productValueDetails, $cache);
 			array_push($entityIds, $productId);
 		}
 


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1796

##  不具合の内容 / Bug
1. インポート時、参照項目（reference / uitype 10）のセル値が無条件にカンマで分割されるため、`ACME CO., LTD.` のようにカンマを含むラベルで参照が解決できない。分割結果によって、①参照が空のまま取り込まれる ②`ACME CO.` など別レコードへ誤って紐づく ③`123, 456` のような複数IDが単一参照項目へ書き込まれる、の3通りに壊れる。
2. 併発しているリグレッションとして、`Module:::Label` / `Module::::Label` 形式の値が必ず `ImportException` となり、**当該行がスキップされる**。
3. 上記の根本原因である「書式を解釈するコードが複数箇所に独立実装され、解釈規則が互いにずれる構造」がそのまま残っている。この構造に起因して、さらに以下の不具合が存在する。
   - 価格表（PriceBooks）のインポートで、関連商品に**裸の商品名を指定すると例外になり行がスキップ**される（`Module::::field====value` 形式しか受理しない）
   - 取引先担当者（Contacts）など複数項目でラベルを構成するモジュールで、**解決経路によってラベルの一致条件が違う**。キャッシュ経由では `山田 太郎` が一致せず、`山田` 単独で一致する
   - ラベルが複数レコードに一致したとき、**解決経路によって「先頭を黙って採用」と「例外」に分かれる**。前者は誤紐づけに気づけない

##  原因 / Cause
1. `modules/Import/actions/Data.php` の `transformForImport()` にて、`::::` / `:::` の判定より前に `preg_split('/\s*,\s*/', trim($fieldValue))` が実行されている。カンマ分割は `:::` 区切りと重複する2つ目の区切り規則であり、値そのものに含まれるカンマと区別できない。キャッシュを構築する `createCacheForReference()` はカンマ分割を行わないため、値の解釈規則が両者で食い違っていた。
2. `====` を含まない値でも `php7_count($fieldValueDetails) > 1` で無条件に `getEntityIdByColumns()` へ流れていた。`====` が無い場合 `$fieldDetails` は `false` のままであり、`getEntityIdByColumns()` は冒頭の `empty($referenceValueList)` で例外を送出する（`include/utils/ListViewUtils.php`）。この例外は呼び出し元で捕捉され `IMPORT_RECORD_SKIPPED` となる。
3. いずれも PR #1303（`37a3161d7`）でエクスポートをID基準へ変更した際に、カンマ分割が追加され、旧来のラベル解決分岐（`php7_count($fieldValueDetails) == 2` → `getEntityId()`）が削除されたことによる。
4. 書式リテラル（`::::` / `:::` / `====`）を扱う箇所を調査したところ、パース側に6箇所（うち1箇所はデッドコード）、生成側に3箇所（うち1箇所はデッドコード）あった。パース側6箇所は受理する書式も解決方法も揃っておらず、同じセル値が箇所によって別の意味に解釈されていた。

##  変更内容 / Details of Change
### 1. カンマ分割の廃止（Issue #1796 本体）

参照項目は常に単一レコードを指すものとし、**セル値を区切り文字で分割しない**方針に変更しました。複数レコードの指定は `multireference` 型の責務として分離します。受理する書式は以下の優先順です。

| 順 | 書式 | 解決方法 |
|---|---|---|
| 1 | `Module::::field====value::::field====value` | 指定カラムのAND条件でレコードを特定 |
| 2 | `Module::::Label` / `Module:::Label` | モジュールを限定してラベルで特定 |
| 3 | `Label` | 項目の参照先モジュールを順に試してラベルで特定 |

### 2. 書式の解釈・解決を `Import_Reference_Model` へ集約

`modules/Import/models/Reference.php` を新設し、書式リテラルを扱う箇所を1つに畳みました。

```
Import_Reference_Model::parse($value)                    … 純粋パース。DB・キャッシュに触れない
Import_Reference_Model::resolve($parsed, $fieldInstance, $cache, $user, $moduleName)
Import_Reference_Model::getCacheColumns($parsed, $fieldInstance)
```

3つ目が本PRの要点です。#1796 の根本原因は「キャッシュ構築側と解決側が別々に書式を解釈していた」ことでした。構築に必要な列を解決側と同じ宣言から導くことで、両者の食い違いが構造的に起きなくなります。

置き換えた6箇所:

- `Data.php transformForImport()`
- `Data.php createCacheForReference()`
- `Data.php createRecords()`（重複マージの比較値生成）
- `include/utils/InventoryUtils.php isRecordExistInDB()`
- `modules/PriceBooks/PriceBooks.php relatePriceBookWithProduct()`
- `modules/PriceBooks/PriceBooks.php isProductsExistInDB()`

これにより書式リテラルは `Import_Reference_Model` の定数定義のみとなりました。

### 3. ラベルの一致条件を統一（2段階照合）

複数項目でラベルを構成するモジュール（Contacts / Leads / Users）で、従来は解決経路によって一致条件が違っていました。

| | 従来の一致条件 | `山田 太郎` | `山田` |
|---|---|---|---|
| `getEntityId()` | `trim(concat(lastname,' ',firstname))` の全体一致 | 一致する | 一致しない |
| `getEntityIdByColumns()` | `lastname` **または** `firstname` の個別一致 | 一致しない | 一致する |

どちらの経路でも**2段階で照合**するよう統一しました。

1. **連結した全体一致** …… `山田 太郎` で一致。画面表示およびエクスポート出力のラベルと同じ形なので優先します
2. **構成項目の個別一致** … 1段目で見つからない場合のみ `山田` / `太郎` でも一致

2段目を残したのは、姓だけ・名だけを書いた既存のCSVを解決できるようにするためです。1段目が優先されるため、連結の全体一致が個別一致に負けることはありません。個別一致で複数レコードに当たった場合（同姓が複数など）は従来のキャッシュ経由の解決と同様に行をスキップします。

`concat()` は引数に NULL があると NULL を返して一致しないため、キャッシュ照合でも構成項目に NULL があるレコードは一致させず、DB 側と挙動を揃えています。

### 4. 曖昧一致を行スキップに統一

複数レコードに一致した場合、従来は `getEntityId()` が先頭を黙って採用し、`getEntityIdByColumns()` は例外を送出していました。誤ったレコードに紐づいたことに気づけない前者を廃止し、**`ImportException`（行スキップ）に統一**しました。

### 5. デッドコードの削除

参照先レコードの自動作成は仕様として廃止済みであり、その処理を担っていた `getEntityIdsList()` は呼び出し元が存在せず、唯一の呼び出し先だった `createEntityRecord()` も連鎖して未使用でした。両者を削除しました。

### 後方互換

`getEntityId()` / `getEntityIdByColumns()` は削除せず、`Import_Reference_Model` へ委譲する薄いラッパとして残しました。`include/utils/` の自由関数の削除はアップグレード時に顧客カスタマイズを壊しうるためです。**未解決で `ImportException` を送出する現行契約も維持**しています（`resolve()` は未解決を `false` で返しますが、ラッパ内で例外に変換します）。

### コミット構成

挙動が変わるのは4番目と6番目です。他は新規追加または呼び出しの置き換えです。

1. `[追加] 参照項目の書式パーサ Import_Reference_Model を追加` — 新ファイルのみ。挙動変更なし
2. `[リファクタ] 参照書式のパースを Import_Reference_Model に集約` — 6箇所を `parse()` 経由に
3. `[追加] 参照項目の解決処理を Import_Reference_Model に追加` — 呼び出さないため挙動変更なし
4. `[修正] 参照ラベルの解決を連結一致・曖昧一致スキップに統一` — **挙動変更を含む**
5. `[削除] 参照先レコード自動作成のデッドコードを削除`
6. `[修正] 参照ラベルの照合に構成項目の個別一致を残す` — 後方互換のため2段階照合に
7. `[取り消し] 重複マージの比較値の変更を取り消す`

## スクリーンショット / Screenshot
該当なし（サーバサイドの処理のため）。Docker 環境の実 DB に対して `Import_Data_Action::import()` を実際に走らせ、`createCacheForReference()` / `transformForImport()` / `vtws_create()` すべて本物を通して確認しました（PHP 8.3 / MySQL 8.0）。

**ServiceContracts（`sc_related_to`、参照先 Contacts・Accounts）**

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `ACME CO., LTD.` | **別の取引先へ誤紐づけ**（CREATED なので気づけない） | 正しい取引先 |
| `Accounts::::accountid====<id>` | 正しい取引先 | 正しい取引先 |
| `Accounts:::ACME` | **行スキップ** | 正しい取引先 |
| `Accounts::::ACME` | **行スキップ** | 正しい取引先 |
| `Accounts::::accountname====ACME CO., LTD.::::phone====0123` | **行スキップ** | 正しい取引先 |
| `ACME` | 正しい取引先 | 正しい取引先 |

取込結果は修正前 `CREATED 3 / SKIPPED 3` → 修正後 `CREATED 6 / SKIPPED 0`。

**Contacts（複数項目ラベル）**

`山田 太郎` / `山田 花子` / `佐藤 次郎` / `鈴木 一郎`×2 を用意して確認しました。

| 入力 | 結果 |
|---|---|
| `山田 太郎` | 該当レコードに紐づく（CREATED） |
| `佐藤`（姓のみ・一意） | 該当レコードに紐づく（CREATED） |
| `次郎`（名のみ・一意） | 該当レコードに紐づく（CREATED） |
| `山田`（姓が重複） | **行スキップ**（SKIPPED） |
| `Contacts:::山田 太郎` | 該当レコードに紐づく（CREATED） |
| `鈴木 一郎`（同姓同名が2件） | **行スキップ**（SKIPPED） |

**インベントリ系（`isRecordExistInDB`）と PriceBooks**

商品名にカンマを含む `WIDGET, LARGE` を用意して確認しました。

| 検証 | 修正前 | 修正後 |
|---|---|---|
| Quotes明細: 裸ラベルで商品を認識 | OK | OK |
| Quotes明細: `Products:::裸ラベル` で認識 | **false（認識せず）** | OK |
| Quotes明細: カラム形式で認識 | OK | OK |
| PriceBooks: 裸ラベルを受理 | **ImportException** | OK |
| PriceBooks: `Products:::裸ラベル` を受理 | **ImportException** | OK |
| PriceBooks: 裸ラベルで価格表に商品が関連付く | **例外で到達せず** | 関連付く |

パース単体（13ケース）・解決単体（23ケース）・実機インポート（21ケース）の計57ケースがすべて通っています。

## 影響範囲  / Affected Area
- 対象は参照項目（uitype 10）を含むインポート全般。`modules/Import/`、`include/utils/InventoryUtils.php`、`include/utils/ListViewUtils.php`、`modules/PriceBooks/PriceBooks.php`。
- **既存運用への影響が最も大きい2点**
  - **複数項目ラベル（Contacts / Leads / Users）で、DB 直引き経路の一致条件が広がります。** 従来 `getEntityId()` 経由では連結した全体一致のみでしたが、姓だけ・名だけでも一致するようになります。従来解決できていた値が解決しなくなることはありません。逆に、従来は参照が空のまま取り込まれていた行が、今後はレコードに紐づく場合があります。
  - **ラベルが複数レコードに一致する行はスキップされます。** 従来 `getEntityId()` 経由では先頭が黙って採用されていたため、同名レコードを複数持つ環境では取り込み件数が減ります。誤ったレコードに紐づくより安全と判断しましたが、運用によっては影響が出ます。スキップはインポート結果画面に表示されるため利用者が気づけます。加えて `$log->error()` に値・モジュール・候補件数を出力していますが、`log4php.rootLogger=FATAL` のため**既定では出力されません**（調査時に log level を下げた場合に追えます）。
- **意図的に復活・修正した経路**
  - `Module:::Label` / `Module::::Label` 形式。PR #1303 以前にエクスポートしたCSVと、当該形式を用いた既存のインポート手順が再び利用可能になります。
  - PriceBooks の関連商品に裸の商品名・`:::` 形式を指定できるようになります（従来は行スキップ）。
- 単一参照項目に複数IDを書き込む経路が無くなるため、`crmid` 以外の文字列が保存されることはありません。
- `getEntityId()` / `getEntityIdByColumns()` のシグネチャと例外契約は変えていないため、これらを呼ぶ顧客カスタマイズは動作します。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った（言語ファイルの追加・変更なし）

## 備考 / Remarks
本PRの対応範囲外とした点です。方針についてご指示いただければ別途対応します。

- **生成（エクスポート）側の集約は行っていません。** 書式を生成している箇所は `modules/Vtiger/actions/ExportData.php` と `modules/PriceBooks/actions/ExportData.php` の2箇所（いずれも `Module::::entityidfield====crmid` 形式で一致）ですが、前者がコア（アップグレードで上書き）のため改変できません。片側だけ集約しても意味が薄いと判断しました。生成側も `Import_Reference_Model` に寄せるには、コア側の扱いについてご判断が必要です。
- **書式パーサの増殖を CI で防ぐ仕組みは入れていません。** GitHub 側に PHP のテスト基盤（`php -l` すら）が無く、器から作ることになるため別途検討とします。
- **重複マージ（自動マージ）で `Module::::field====value` 形式の重複が検出されない問題は残しています。** この形式は値にラベルを含まないため比較値を作れず、従来から重複が見つからない状態です。修正は可能ですが、重複マージは既存レコードを上書き・マージする処理であり、「従来は常に新規作成されていた行が既存レコードを書き換えるようになる」という変化を伴います。参照項目の書式解釈の集約とは影響範囲の性質が異なるため本PRには含めず、コードにコメントとして明記しました。
- **他に見つかったデッドコード2件は触っていません。**
  - `data/CRMEntity.php add_related_to()` と、それだけが呼んでいる `include/utils/ListViewUtils.php getFirstModule()`。どちらも呼び出し元がありません。`data/CRMEntity.php` は全モジュールの基底クラスであり、顧客カスタマイズが呼んでいるリスクが他より高いため見送りました。
  - `include/utils/export.php`。どこからも include されていないファイルです。旧式の `Module::::Label` を生成するコードを含みます。

また、`Module:::Label` 形式で対象レコードが存在しない場合は、`#1639` の `try`/`catch` により例外ではなく参照が空のまま取り込まれます。ラベル解決全体の挙動と揃える意図ですが、モジュールを明示している以上は解決失敗をエラーとすべき、というご判断であれば合わせます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
