### PR TITLE
[修正] #1799 メールアドレス項目が非表示のときメールタブが開けない

### DIFF
--- a/modules/Emails/models/Module.php
+++ b/modules/Emails/models/Module.php
@@ -40,6 +40,7 @@ class Emails_Module_Model extends Vtiger_Module_Model{
 		
 		$relatedModules = vtws_listtypes(array('email'), Users_Record_Model::getCurrentUserModel());
 		$relatedModules = $relatedModules['types'];
+		$emailRelatedModules = array();
 
 		foreach ($relatedModules as $key => $moduleName) {
 			if ($moduleName === 'Users') {
@@ -66,6 +67,9 @@ class Emails_Module_Model extends Vtiger_Module_Model{
 		$emailsResult = array();
         $params = array();
 		$db = PearDatabase::getInstance();
+		//メールアドレス項目が1つも参照できないモジュールでも動作するよう初期化する
+		$activeModules = array();
+		$fieldIds = array();
 
 		$EmailsModuleModel = Vtiger_Module_Model::getInstance('Emails');
 		$emailSupportedModulesList = $EmailsModuleModel->getEmailRelatedModules();
@@ -85,37 +89,40 @@ class Emails_Module_Model extends Vtiger_Module_Model{
 			if ($moduleName) {
                 $activeModules = array($moduleName);
             }
-            
-            $query = "SELECT vtiger_emailslookup.crmid, vtiger_emailslookup.setype, vtiger_emailslookup.value, 
-                          vtiger_crmentity.label FROM vtiger_emailslookup INNER JOIN vtiger_crmentity on 
-                          vtiger_crmentity.crmid = vtiger_emailslookup.crmid AND vtiger_crmentity.deleted=0 WHERE 
-						  vtiger_emailslookup.fieldid in (".generateQuestionMarks($fieldIds).") and 
-						  vtiger_emailslookup.setype in (".generateQuestionMarks($activeModules).") 
-                          and (vtiger_emailslookup.value LIKE ? OR vtiger_crmentity.label LIKE ?)";
-            $params = array_merge($params, $fieldIds);
-            $params = array_merge($params, $activeModules);
-            array_push($params, "%$searchValue%");
-            array_push($params, "%$searchValue%");
-			$emailOptOutIds = $this->getEmailOptOutRecordIds();
-			if (!empty($emailOptOutIds)) {
-				$query .= " AND vtiger_emailslookup.crmid NOT IN (". generateQuestionMarks($emailOptOutIds).")";
-                $params = array_merge($params, $emailOptOutIds);
-			}
 
-			$result = $db->pquery($query, $params);
-            $isAdmin = is_admin($current_user);
-			while ($row = $db->fetchByAssoc($result)) {
-				if (!$isAdmin) {
-					$recordPermission = Users_Privileges_Model::isPermitted($row['setype'], 'DetailView', $row['crmid']);
-					if (!$recordPermission) {
-						continue;
-					}
-				}
-			$emailsResult[vtranslate($row['setype'], $row['setype'])][$row['crmid']][] = array('value' => $row['value'],
-																								'label' => decode_html($row['label']).' ('.$row['value'].')',
-																								'name' => decode_html($row['label']),);
+            //参照可能なメールアドレス項目が1つも無い場合はCRMレコードの検索を行わない
+            if (!empty($fieldIds) && !empty($activeModules)) {
+                $query = "SELECT vtiger_emailslookup.crmid, vtiger_emailslookup.setype, vtiger_emailslookup.value,
+                              vtiger_crmentity.label FROM vtiger_emailslookup INNER JOIN vtiger_crmentity on
+                              vtiger_crmentity.crmid = vtiger_emailslookup.crmid AND vtiger_crmentity.deleted=0 WHERE
+                              vtiger_emailslookup.fieldid in (".generateQuestionMarks($fieldIds).") and
+                              vtiger_emailslookup.setype in (".generateQuestionMarks($activeModules).")
+                              and (vtiger_emailslookup.value LIKE ? OR vtiger_crmentity.label LIKE ?)";
+                $params = array_merge($params, $fieldIds);
+                $params = array_merge($params, $activeModules);
+                array_push($params, "%$searchValue%");
+                array_push($params, "%$searchValue%");
+                $emailOptOutIds = $this->getEmailOptOutRecordIds();
+                if (!empty($emailOptOutIds)) {
+                    $query .= " AND vtiger_emailslookup.crmid NOT IN (". generateQuestionMarks($emailOptOutIds).")";
+                    $params = array_merge($params, $emailOptOutIds);
+                }
+
+                $result = $db->pquery($query, $params);
+                $isAdmin = is_admin($current_user);
+                while ($row = $db->fetchByAssoc($result)) {
+                    if (!$isAdmin) {
+                        $recordPermission = Users_Privileges_Model::isPermitted($row['setype'], 'DetailView', $row['crmid']);
+                        if (!$recordPermission) {
+                            continue;
+                        }
+                    }
+                    $emailsResult[vtranslate($row['setype'], $row['setype'])][$row['crmid']][] = array('value' => $row['value'],
+                                                                                    'label' => decode_html($row['label']).' ('.$row['value'].')',
+                                                                                    'name' => decode_html($row['label']),);
+                }
             }
-            
+
             // For Users we should only search in users table
             $additionalModule = array('Users');
             if(!$moduleName || in_array($moduleName, $additionalModule)){

--- a/modules/Emails/models/Record.php
+++ b/modules/Emails/models/Record.php
@@ -673,11 +673,11 @@ class Emails_Record_Model extends Vtiger_Record_Model {
 				$moduleModel = $this->getModule();
 				$emails = $moduleModel->searchEmails($fromEmail);
 				if ($emails) {
-					if ($emails[$relatedModule][$relatedRecordId]) {
+					if (!empty($emails[$relatedModule][$relatedRecordId])) {
 						return $emails[$relatedModule][$relatedRecordId][0]['name'];
 					}
 
-					if ($emails['Users']) {
+					if (!empty($emails['Users'])) {
 						$emailInfo = array_values($emails['Users']);
 					} else {
 						$emailsInfo = array_values($emails);


### PR DESCRIPTION
## 概要

close #1799

参照可能なメールアドレス項目が1つも無い状態で、詳細画面のメールタブがエラーで開けなくなる不具合を修正しました。あわせて、同じ原因で壊れていたメール作成画面の**宛先検索（オートコンプリート）**も修正されます。

## 原因

`Emails_Module_Model::searchEmails()` で、参照可能なメールアドレス項目が1件も集まらなかった場合に `$fieldIds` / `$activeModules` が未初期化のままSQL組み立てへ渡され、`array_merge(): Argument #2 must be of type array, null given` の TypeError となっていました。

メールタブでの発生経路:

```
EmailRelatedList.tpl:92  getSenderName()          ← 「送信者名」列の描画
→ Emails_Record_Model::getSenderName()   Record.php:674
→ Emails_Module_Model::searchEmails()    Module.php:95  ← TypeError
```

メールタブ自体は表示処理に入れるものの、メールレコードが1件でも表示されると送信者名の描画で落ちるため、結果として「タブが開かない」という症状になります。宛先検索（`modules/Emails/actions/BasicAjax.php`）も同じ `searchEmails()` を呼ぶため、検索語に関わらず全滅していました。

なお Issue の再現手順どおり「顧客企業のメールアドレス項目だけ」を非表示にしても、単体では再現しません。`searchEmails()` はメール送信対象となる全モジュールの項目IDをまとめて集めるためです。ただしユーザーの権限やモジュール構成により対象モジュールが絞られている場合は、1モジュールの非表示だけで発生します。本修正はどちらのケースもカバーします。

## 修正内容

- `modules/Emails/models/Module.php`
  - `searchEmails()` で `$activeModules` / `$fieldIds` を初期化し、参照可能なメールアドレス項目が無い場合はCRMレコード側の検索クエリをスキップ（ユーザー側の検索は従来どおり実行）
  - `getEmailRelatedModules()` の `$emailRelatedModules` を初期化
- `modules/Emails/models/Record.php`
  - `getSenderName()` の未定義キー参照を `!empty()` に変更。送信者名を解決できない場合は送信元メールアドレスを表示するフォールバックとする

## 動作確認

ローカルDBに実データ（メールレコード・`vtiger_emailslookup`）を投入し、項目のpresenceを切り替えて検証しました。

### メールタブ

| ケース | 修正前 | 修正後 |
|---|---|---|
| 全モジュールでメールアドレス項目が表示 | OK | OK（送信者名がレコード名で解決される＝退行なし） |
| 顧客企業のみ非表示 | OK | OK（送信者名はメールアドレスにフォールバック） |
| 全モジュールで非表示 | **TypeError** | OK |
| メールアドレス項目が元から無いモジュール（商談・サポート依頼） | **TypeError** | OK |

顧客企業・顧客担当者・リード・仕入先・商談・サポート依頼の6モジュールで確認しました。

### 宛先検索（`Emails_BasicAjax_Action`）

修正前後で同一スクリプトの出力を diff で比較しています。

| 項目の状態 | 修正前 | 修正後 |
|---|---|---|
| 全モジュール表示（通常運用） | 正常 | **出力が完全に一致（差分なし）** |
| 顧客企業のみ非表示 | 正常 | **出力が完全に一致（差分なし）** |
| 全モジュール非表示 | **TypeError で全滅** | 正常応答 |

修正後の検索結果:

| 検索語 | 全項目表示 | 顧客企業のみ非表示 | 全モジュール非表示 |
|---|---|---|---|
| `example`（部分一致） | 顧客企業2 / 顧客担当者2 / ユーザー9 | 顧客担当者2 / ユーザー9 | ユーザー9 |
| メールアドレス | 顧客企業1 | 0件 | 0件 |
| レコード名 | 顧客企業1 | 0件 | 0件 |
| 担当者名 | 顧客担当者1 | 顧客担当者1 | 0件 |
| ユーザー名 | ユーザー1 | ユーザー1 | ユーザー1 |

非表示にしたモジュールのレコードが宛先候補から除外されるのは、項目を非表示にした意図どおりの動作です。

## 補足

Issue の「その他情報」にある**メール追加ボタン**は、調査した限りエラーになりません。アドレス選択ダイアログが空になるためJS側（`showComposeEmailPopup`）が選択をスキップし、宛先が空のままメール作成画面が開きます（手入力で送信可能）。

`modules/Vtiger/views/MassActionAjax.php` に未定義変数 `$recordIds` 参照の警告が出ますが、`php7_count()` が null を許容するため無害であること、およびコア（`modules/Vtiger/`）であることから本PRでは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)