### PR TITLE
[修正] Header.tplのJSコンテキストXSS（_META / _EXTENSIONMETA / _USERMETA）

### DIFF
--- a/layouts/v7/modules/Install/Header.tpl
+++ b/layouts/v7/modules/Install/Header.tpl
@@ -43,13 +43,13 @@
 
 			<script src="{vresource_url('layouts/v7/lib/jquery/jquery.min.js')}"></script>
 			<script type="text/javascript">
-				var _META = { 'module': "{$MODULE}", view: "{$VIEW}", 'parent': "{$PARENT_MODULE}" };
+				var _META = { 'module': "{$MODULE|escape:'javascript'}", view: "{$VIEW|escape:'javascript'}", 'parent': "{$PARENT_MODULE|escape:'javascript'}" };
 				{if $EXTENSION_MODULE}
-					var _EXTENSIONMETA = { 'module': "{$EXTENSION_MODULE}", view: "{$EXTENSION_VIEW}"};
+					var _EXTENSIONMETA = { 'module': "{$EXTENSION_MODULE|escape:'javascript'}", view: "{$EXTENSION_VIEW|escape:'javascript'}"};
 				{/if}
 				var _USERMETA;
 				{if $CURRENT_USER_MODEL}
-					_USERMETA =  { 'id' : "{$CURRENT_USER_MODEL->get('id')}", 'menustatus' : "{$CURRENT_USER_MODEL->get('leftpanelhide')}" };
+					_USERMETA =  { 'id' : "{$CURRENT_USER_MODEL->get('id')|escape:'javascript'}", 'menustatus' : "{$CURRENT_USER_MODEL->get('leftpanelhide')|escape:'javascript'}" };
 				{/if}
 			</script>
 		</head>

--- a/layouts/v7/modules/Vtiger/Header.tpl
+++ b/layouts/v7/modules/Vtiger/Header.tpl
@@ -53,9 +53,9 @@
 		<script src="{vresource_url('layouts/v7/lib/jquery/jquery.min.js')}"></script>
 		<script src="{vresource_url('layouts/v7/lib/jquery/jquery-migrate-1.4.1.js')}"></script>
 		<script type="text/javascript">
-			var _META = { 'module': "{$MODULE}", view: "{$VIEW}", 'parent': "{$PARENT_MODULE}", 'notifier':"{$NOTIFIER_URL}", 'app':"{$SELECTED_MENU_CATEGORY}" };
+			var _META = { 'module': "{$MODULE|escape:'javascript'}", view: "{$VIEW|escape:'javascript'}", 'parent': "{$PARENT_MODULE|escape:'javascript'}", 'notifier':"{$NOTIFIER_URL|escape:'javascript'}", 'app':"{$SELECTED_MENU_CATEGORY|escape:'javascript'}" };
             {if $EXTENSION_MODULE}
-                var _EXTENSIONMETA = { 'module': "{$EXTENSION_MODULE}", view: "{$EXTENSION_VIEW}"};
+                var _EXTENSIONMETA = { 'module': "{$EXTENSION_MODULE|escape:'javascript'}", view: "{$EXTENSION_VIEW|escape:'javascript'}"};
             {/if}
             var _USERMETA;
             {if $CURRENT_USER_MODEL}

--- a/layouts/v7/modules/Vtiger/Header.tpl
+++ b/layouts/v7/modules/Vtiger/Header.tpl
@@ -59,9 +59,9 @@
             {/if}
             var _USERMETA;
             {if $CURRENT_USER_MODEL}
-               _USERMETA =  { 'id' : "{$CURRENT_USER_MODEL->get('id')}", 'menustatus' : "{$CURRENT_USER_MODEL->get('leftpanelhide')}",
-                              'currency' : "{$USER_CURRENCY_SYMBOL}", 'currencySymbolPlacement' : "{$CURRENT_USER_MODEL->get('currency_symbol_placement')}",
-                          'currencyGroupingPattern' : "{$CURRENT_USER_MODEL->get('currency_grouping_pattern')}", 'truncateTrailingZeros' : "{$CURRENT_USER_MODEL->get('truncate_trailing_zeros')}"};
+               _USERMETA =  { 'id' : "{$CURRENT_USER_MODEL->get('id')|escape:'javascript'}", 'menustatus' : "{$CURRENT_USER_MODEL->get('leftpanelhide')|escape:'javascript'}",
+                              'currency' : "{$USER_CURRENCY_SYMBOL|escape:'javascript'}", 'currencySymbolPlacement' : "{$CURRENT_USER_MODEL->get('currency_symbol_placement')|escape:'javascript'}",
+                          'currencyGroupingPattern' : "{$CURRENT_USER_MODEL->get('currency_grouping_pattern')|escape:'javascript'}", 'truncateTrailingZeros' : "{$CURRENT_USER_MODEL->get('truncate_trailing_zeros')|escape:'javascript'}"};
             {/if}
             {* WebComponents版QuickCreateを無効にするモジュールリスト（ブラックリスト形式） *}
             {* 基本的にはWebComponents版を使用し、未対応モジュールのみ除外 *}


### PR DESCRIPTION
##  関連Issue / Related Issue
- なし（Issue未起票）

##  不具合の内容 / Bug
1. `layouts/v7/modules/Vtiger/Header.tpl` および `layouts/v7/modules/Install/Header.tpl` のインライン `<script>` 内で、`_META` / `_EXTENSIONMETA` / `_USERMETA` に埋め込む値がエスケープされずに出力されていた。
2. このためリクエストパラメータ由来の値（例: `parent`）に `"` を含めると JavaScript 文字列リテラルを脱出でき、任意の JavaScript が実行される（XSS）。

##  原因 / Cause
1. Smarty テンプレートで `{$PARENT_MODULE}` のように修飾子なしで値を出力していた。
2. 出力先が HTML ではなく `<script>` 内の JavaScript 文字列リテラルであるため、値に含まれる `"` `'` `\` `</` などがそのまま出力され、コンテキストを脱出できる状態だった。

##  変更内容 / Details of Change
1. `layouts/v7/modules/Vtiger/Header.tpl` の `_META`（`module` / `view` / `parent` / `notifier` / `app`）に `|escape:'javascript'` を付与。
2. 同ファイルの `_EXTENSIONMETA`（`module` / `view`）に `|escape:'javascript'` を付与。
3. 同ファイルの `_USERMETA`（`id` / `menustatus` / `currency` / `currencySymbolPlacement` / `currencyGroupingPattern` / `truncateTrailingZeros`）に `|escape:'javascript'` を付与。
4. `layouts/v7/modules/Install/Header.tpl` の `_META` / `_EXTENSIONMETA` / `_USERMETA` の各埋め込み値にも同様に `|escape:'javascript'` を付与。

## スクリーンショット / Screenshot
画面上の見た目に変化はないため、HTML 出力での確認結果を記載します。

修正後（`index.php?module=Contacts&view=List&parent=Settings"+alert(1)+"`）:

```js
var _META = { 'module': "Contacts", view: "List", 'parent': "Settings\"+alert(1)+\"", 'notifier':"", 'app':"MARKETING" };
```

`"` が `\"` にエスケープされ、JavaScript 文字列リテラルを脱出できないことを確認しました。

## 影響範囲  / Affected Area
- `layouts/v7/modules/Vtiger/Header.tpl` … v7 レイアウトを使用する全画面のヘッダ。
- `layouts/v7/modules/Install/Header.tpl` … インストーラ画面のヘッダ。
- グローバル変数 `_META` / `_EXTENSIONMETA` / `_USERMETA` を参照する JavaScript 全般。ただし出力が変化するのは値に `\` `'` `"` 改行 `</` `<!--` が含まれる場合のみで、モジュール名・ビュー名・ユーザーID・通貨記号などの正常な値では出力が変わらないため、既存動作への影響はありません。
- `layouts/` 配下のレイアウトは `v7` のみであり、`var _META` を出力しているのは本 PR で修正した 2 ファイルで全てです。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- 動作確認の内容
  - ログイン画面、およびログイン後の一覧画面（Contacts）でヘッダの `_META` / `_USERMETA` が従来どおり出力され、画面が正常に表示されることを確認しました。
  - `parent` パラメータに `Settings"+alert(1)+"` を指定し、出力が `"Settings\"+alert(1)+\""` にエスケープされることを確認しました。
- `escape:'javascript'` は `\` `'` `"` `\r` `\n` `</` `<!--` をエスケープします（`vendor/smarty/smarty/libs/plugins/modifier.escape.php`）。JavaScript 文字列リテラルの脱出と `</script>` による早期終了の双方を防止できます。
- 言語対応について: 本修正はテンプレートのエスケープ追加のみで `languages/` 配下の変更が無いため、日・英の言語ファイル対応は該当なしと判断しました。
- 関連 Issue は未起票のため「なし」としています。
