### PR TITLE
[修正] #1806 クイック作成の複製モード判定が属性パースの暗黙挙動に依存している潜在バグの修正

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from "../../hooks/useTranslation";
 import { transformCalendarDateTime } from "../../utils/datetime";
 import { validateFieldByUIType } from "../../utils/validation";
 import { syncJoditEditorFormData } from "../../utils/joditEditor";
+import { toBooleanProp } from "../../utils/webComponentProps";
 import { isFutureEventHeldInvalid } from "./utils/calendarValidation";
 
 /**
@@ -40,8 +41,11 @@ export interface ExtendedQuickCreateProps extends QuickCreateProps {
   variant?: "default" | "calendar";
   /** Record ID for edit mode */
   recordId?: string;
-  /** Duplicate mode flag (when true, treat as new record even with recordId) */
-  isDuplicate?: boolean;
+  /**
+   * Duplicate mode flag (when true, treat as new record even with recordId).
+   * カスタム要素の属性経由では文字列で渡るため boolean と文字列の双方を受け付ける。
+   */
+  isDuplicate?: boolean | string;
 }
 
 /**
@@ -117,7 +121,8 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
     explicitVariant ?? (isCalendarModule ? "calendar" : "default");
   const isCalendarVariant = variant === "calendar";
   // 複製モード時はrecordIdが存在しても編集モードではなく新規作成として扱う
-  const isDuplicateMode = isDuplicate === true;
+  // カスタム要素の is-duplicate 属性は文字列で渡るため、真偽値へ正規化してから判定する
+  const isDuplicateMode = toBooleanProp(isDuplicate);
   const isEditMode = !!recordId && !isDuplicateMode;
 
   // Modal state

--- a/assets/react-web-components/src/types/quickcreate.ts
+++ b/assets/react-web-components/src/types/quickcreate.ts
@@ -14,8 +14,11 @@ export interface QuickCreateProps {
   isOpen?: boolean;
   /** 初期値（関連レコードからの値等） */
   initialData?: Record<string, any>;
-  /** 複製モードフラグ（trueの場合、recordIdが存在しても新規作成として扱う） */
-  isDuplicate?: boolean;
+  /**
+   * 複製モードフラグ（trueの場合、recordIdが存在しても新規作成として扱う）
+   * カスタム要素の属性経由では文字列で渡るため boolean と文字列の双方を受け付ける
+   */
+  isDuplicate?: boolean | string;
   /** 保存成功時コールバック */
   onSave?: (result: QuickCreateSaveResult) => void;
   /** キャンセル時コールバック */

--- a/assets/react-web-components/src/utils/webComponentProps.test.ts
+++ b/assets/react-web-components/src/utils/webComponentProps.test.ts
@@ -1,0 +1,43 @@
+/*+**********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.1
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is:  vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ ************************************************************************************/
+
+import { describe, it, expect } from "vitest";
+import { toBooleanProp } from "./webComponentProps";
+
+describe("toBooleanProp", () => {
+  it("boolean の true をそのまま true として扱う", () => {
+    expect(toBooleanProp(true)).toBe(true);
+  });
+
+  it('文字列の "true" を true として扱う（カスタム要素の属性は文字列で渡るため）', () => {
+    expect(toBooleanProp("true")).toBe(true);
+  });
+
+  it('大文字小文字や前後の空白を無視して "true" を判定する', () => {
+    expect(toBooleanProp("TRUE")).toBe(true);
+    expect(toBooleanProp(" true ")).toBe(true);
+  });
+
+  it("値なし（空文字）の属性を true として扱う", () => {
+    expect(toBooleanProp("")).toBe(true);
+  });
+
+  it("boolean の false は false のまま扱う", () => {
+    expect(toBooleanProp(false)).toBe(false);
+  });
+
+  it('文字列の "false" と "0" は false として扱う', () => {
+    expect(toBooleanProp("false")).toBe(false);
+    expect(toBooleanProp("0")).toBe(false);
+  });
+
+  it("undefined は false として扱う", () => {
+    expect(toBooleanProp(undefined)).toBe(false);
+  });
+});

--- a/assets/react-web-components/src/utils/webComponentProps.ts
+++ b/assets/react-web-components/src/utils/webComponentProps.ts
@@ -1,0 +1,34 @@
+/*+**********************************************************************************
+ * The contents of this file are subject to the vtiger CRM Public License Version 1.1
+ * ("License"); You may not use this file except in compliance with the License
+ * The Original Code is:  vtiger CRM Open Source
+ * The Initial Developer of the Original Code is vtiger.
+ * Portions created by vtiger are Copyright (C) vtiger.
+ * All Rights Reserved.
+ ************************************************************************************/
+
+/**
+ * カスタム要素（Web Components）経由で渡る真偽値 props を正規化する。
+ *
+ * HTML の属性値は常に文字列のため、`<calendar-quick-create is-duplicate="true">`
+ * のように指定された値は本来 `"true"` という文字列として props に届く。
+ * 受け側が `value === true` のような厳密比較をしていると、この文字列は偽と判定され、
+ * 複製モードが編集モードとして扱われるといった不具合につながる。
+ *
+ * 現状は createWebComponent の属性パースが JSON.parse のフォールバックを持つため
+ * 結果的に boolean へ変換されているが、その暗黙の挙動に依存しないよう、
+ * boolean と文字列の双方をここで受け付ける。
+ *
+ * HTML の真偽値属性の慣習に合わせ、属性が存在すれば true とみなす。
+ * ただし `"false"` / `"0"` のような明示的な否定は false として扱う。
+ */
+export function toBooleanProp(value: boolean | string | undefined): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized !== "false" && normalized !== "0";
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1806

##  不具合の内容 / Bug
1. Web Components 版クイック作成（`calendar-quick-create`）の複製モード判定が、属性パーサの実装に依存した状態になっています。現状の標準構成では顕在化しませんが、属性の渡り方が変わった時点で複製が編集として扱われ、新規作成のつもりが既存の活動を上書きしてしまう潜在的な不具合です。

##  原因 / Cause
1. `QuickCreate.tsx` は複製モードを `const isDuplicateMode = isDuplicate === true;` と厳密比較で判定しています。
1. 一方 `isDuplicate` はカスタム要素の属性 `is-duplicate` に由来し、HTML の属性値は常に文字列であるため、本来 props には `"true"` という文字列が渡ります。
1. 現状は `createWebComponent.tsx` の属性パースが `try { JSON.parse(attrValue) } catch { attrValue }` となっており、`JSON.parse("true")` が boolean を返すことで偶然成立しています。つまり複製機能が JSON.parse のフォールバックという暗黙の副作用に依存しています。
1. このため、属性パースを「文字列はそのまま渡す」仕様に変更した場合（`record-id="01234"` が数値 `1234` に化ける問題を修正する際に必要になります）や、`is-duplicate` を値なし・`"TRUE"` 等で指定した場合に、`isDuplicate === true` が偽となり編集モードで開いてしまいます。

##  変更内容 / Details of Change
1. `assets/react-web-components/src/utils/webComponentProps.ts` を新規追加し、カスタム要素経由の真偽値 props を正規化する `toBooleanProp()` を実装しました。HTML の真偽値属性の慣習に合わせ、属性が存在すれば `true`、`"false"` / `"0"` のみ `false` として扱います。
1. `QuickCreate.tsx` の複製モード判定を `toBooleanProp(isDuplicate)` に変更し、boolean・文字列のいずれで渡っても正しく判定されるようにしました。
1. `ExtendedQuickCreateProps` および `QuickCreateProps` の `isDuplicate` の型を `boolean | string` に変更し、属性由来の値が文字列であり得ることを型でも明示しました。
1. `assets/react-web-components/src/utils/webComponentProps.test.ts` を新規追加し、boolean / `"true"` / `"TRUE"` / 空文字 / `"false"` / `"0"` / `undefined` の各ケースを検証しています。

## スクリーンショット / Screenshot
該当なし（画面表示の変更はありません）

## 影響範囲  / Affected Area
- クイック作成モーダル（Web Components 版）の複製モード判定
  - カレンダー（個人カレンダー／共有カレンダー）のポップオーバーからの「複製」
  - `calendar-quick-create` / `quick-create` に `is-duplicate` を渡す全経路
- 既存の呼び出し側（`Calendar.js` は `is-duplicate="true"` を設定）では、変更前後で判定結果は変わりません（`true` のまま）。既存挙動を維持したまま、属性の渡り方が変わっても壊れないようにする修正です。
- 画面表示・API・DB スキーマへの変更はありません。

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- テスト結果:
  - 新規テスト `webComponentProps.test.ts`（7 件）は、実装前に失敗することを確認したうえで実装し、全件パスしています。
  - `npx vitest run`: 18 ファイル / 276 テスト すべてパス
  - `npx tsc --noEmit`: エラーなし
  - `npx eslint`（変更ファイル）: エラーなし（既存の `no-explicit-any` 警告のみ）
- 言語対応について: 本修正は `languages/` 配下のファイルを変更しないため、日本語・英語の言語対応は該当なしです。
- 併せて `createWebComponent.tsx` の属性パースそのものを見直す（属性ごとにパース方法を明示する）改善も考えられますが、影響範囲が全カスタム要素に及ぶため本 PR では扱わず、複製モード判定側の依存解消のみに絞っています。