### PR TITLE
[修正] #1808 クイック作成のToDoで保存できない・開始時刻の入力欄が表示されない

### DIFF
--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.calendar.test.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.calendar.test.tsx
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QuickCreate } from "./QuickCreate";
+
+/**
+ * ToDo（Calendarタブ）のフィールド定義
+ * ToDoの完了日（due_date）は日付のみ入力（時刻フィールドなし）
+ */
+const mockCalendarFields = [
+  {
+    name: "subject",
+    label: "件名",
+    uitype: "2",
+    mandatory: true,
+    readonly: false,
+  },
+  {
+    name: "date_start",
+    label: "開始日時",
+    uitype: "23",
+    mandatory: true,
+    readonly: false,
+  },
+  {
+    name: "due_date",
+    label: "終了日",
+    uitype: "23",
+    mandatory: true,
+    readonly: false,
+  },
+];
+
+/** 活動（Eventsタブ）のフィールド定義 */
+const mockEventsFields = [
+  {
+    name: "subject",
+    label: "件名",
+    uitype: "2",
+    mandatory: true,
+    readonly: false,
+  },
+  {
+    name: "date_start",
+    label: "開始日時",
+    uitype: "23",
+    mandatory: true,
+    readonly: false,
+  },
+  {
+    name: "due_date",
+    label: "終了日時",
+    uitype: "23",
+    mandatory: true,
+    readonly: false,
+  },
+];
+
+const mockSave = vi.fn();
+const mockClearError = vi.fn();
+
+const mockUseQuickCreateSave = vi.fn(() => ({
+  save: mockSave,
+  isSaving: false,
+  error: null,
+  clearError: mockClearError,
+}));
+
+const mockUseCalendarFields = vi.fn((activeTab: string) => ({
+  calendarFields: mockCalendarFields,
+  eventsFields: mockEventsFields,
+  currentFields:
+    activeTab === "Calendar" ? mockCalendarFields : mockEventsFields,
+  loading: false,
+  error: null,
+  editViewUrl: "index.php?module=Calendar&view=Edit",
+  availableUsers: [],
+  timeOptions: [
+    { value: "09:00", label: "09:00" },
+    { value: "14:30", label: "14:30" },
+    { value: "15:00", label: "15:00" },
+  ],
+  // 実装（useCalendarFields）と同じロジック
+  parseDateTimeValue: (value?: string) => {
+    if (!value) return { date: "", time: "" };
+    if (value.includes("T")) {
+      const [datePart, timePart] = value.split("T");
+      return { date: datePart, time: timePart || "" };
+    }
+    return { date: value, time: "" };
+  },
+  combineDateTimeValue: (date: string, time: string) => {
+    if (!date) return "";
+    if (!time) return date;
+    return `${date}T${time}`;
+  },
+  parseReminderValue: () => ({ days: 0, hours: 0, minutes: 0 }),
+  combineReminderValue: () => 0,
+  transformInitialDataForEdit: (data: Record<string, unknown>) => data,
+}));
+
+vi.mock("./hooks/useQuickCreateFields", () => ({
+  useQuickCreateFields: () => ({
+    fields: [],
+    loading: false,
+    error: null,
+    editViewUrl: null,
+    moduleLabel: null,
+    picklistDependency: undefined,
+  }),
+}));
+
+vi.mock("./hooks/useQuickCreateSave", () => ({
+  useQuickCreateSave: () => mockUseQuickCreateSave(),
+}));
+
+vi.mock("./hooks/useRecordData", () => ({
+  useRecordData: () => ({ data: null, loading: false, error: null }),
+}));
+
+vi.mock("./hooks/useCalendarFields", () => ({
+  useCalendarFields: (params: { activeTab: string }) =>
+    mockUseCalendarFields(params.activeTab),
+}));
+
+const END_DATE_ERROR = "終了日時は開始日時より後に設定してください";
+
+describe("QuickCreate (calendar variant) の日付範囲バリデーション", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSave.mockResolvedValue({
+      success: true,
+      recordId: "123",
+      recordLabel: "テストToDo",
+      module: "Calendar",
+    });
+  });
+
+  describe("ToDo（due_date が日付のみ）", () => {
+    it("開始日時と終了日が同一日・開始 14:30 でも保存できる", async () => {
+      // クイック作成メニュー（右上＋ボタン）や概要画面からの起動では
+      // due_date が日付のみ（YYYY-MM-DD）で初期化される。
+      // date-only 文字列を UTC 解釈すると JST では 9:00 扱いとなり、
+      // 開始時刻が 9:00 以降のとき誤って NG 判定されていた。
+      const user = userEvent.setup();
+
+      render(
+        <QuickCreate
+          module="Calendar"
+          isOpen={true}
+          initialData={{
+            subject: "テストToDo",
+            date_start: "2026-08-17T14:30",
+            due_date: "2026-08-17",
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /保存/i }));
+
+      await waitFor(() => {
+        expect(mockSave).toHaveBeenCalled();
+      });
+      expect(screen.queryByText(END_DATE_ERROR)).not.toBeInTheDocument();
+    });
+
+    it("開始日が終了日より後の場合はエラーになり保存されない", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <QuickCreate
+          module="Calendar"
+          isOpen={true}
+          initialData={{
+            subject: "テストToDo",
+            date_start: "2026-08-18T09:00",
+            due_date: "2026-08-17",
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /保存/i }));
+
+      expect(await screen.findByText(END_DATE_ERROR)).toBeInTheDocument();
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("活動（due_date が日時）", () => {
+    it("終了日時が開始日時より前の場合はエラーになり保存されない", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <QuickCreate
+          module="Events"
+          isOpen={true}
+          initialData={{
+            subject: "テスト活動",
+            date_start: "2026-08-17T15:00",
+            due_date: "2026-08-17T14:30",
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /保存/i }));
+
+      expect(await screen.findByText(END_DATE_ERROR)).toBeInTheDocument();
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it("終了日時が開始日時より後の場合は保存できる", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <QuickCreate
+          module="Events"
+          isOpen={true}
+          initialData={{
+            subject: "テスト活動",
+            date_start: "2026-08-17T14:30",
+            due_date: "2026-08-17T15:00",
+          }}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /保存/i }));
+
+      await waitFor(() => {
+        expect(mockSave).toHaveBeenCalled();
+      });
+      expect(screen.queryByText(END_DATE_ERROR)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("QuickCreate (calendar variant) の終日フラグとタブの関係", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSave.mockResolvedValue({ success: true, recordId: "123" });
+  });
+
+  it("終日エリアからの起動でも ToDo タブには開始時刻の入力欄が表示される", async () => {
+    // カレンダーの終日エリアクリックでは initialData に is_allday=true が入る。
+    // 終日は活動（Events）のみの概念で ToDo には終日チェックボックスも無いため、
+    // ToDo タブで時刻入力欄が消えると解除する手段が無くなる。
+    render(
+      <QuickCreate
+        module="Calendar"
+        isOpen={true}
+        initialData={{
+          subject: "終日エリアからのToDo",
+          date_start: "2026-08-17",
+          due_date: "2026-08-17",
+          is_allday: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("終日エリアからのToDo")).toBeVisible();
+    });
+
+    // ToDo の完了日は日付のみ入力のため、時刻入力欄は開始日時の1つだけ
+    expect(screen.getAllByPlaceholderText("--:--")).toHaveLength(1);
+  });
+
+  it("終日の活動から ToDo タブに切り替えると開始時刻の入力欄が表示される", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <QuickCreate
+        module="Events"
+        isOpen={true}
+        initialData={{
+          subject: "終日エリアからの起動",
+          date_start: "2026-08-17",
+          due_date: "2026-08-17",
+          is_allday: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("終日エリアからの起動")).toBeVisible();
+    });
+    expect(screen.queryAllByPlaceholderText("--:--")).toHaveLength(0);
+
+    await user.click(screen.getByRole("button", { name: /ToDo/i }));
+
+    expect(screen.getAllByPlaceholderText("--:--")).toHaveLength(1);
+  });
+
+  it("活動タブで終日の場合は時刻入力欄が表示されない", async () => {
+    render(
+      <QuickCreate
+        module="Events"
+        isOpen={true}
+        initialData={{
+          subject: "終日の活動",
+          date_start: "2026-08-17",
+          due_date: "2026-08-17",
+          is_allday: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("終日の活動")).toBeVisible();
+    });
+
+    expect(screen.queryAllByPlaceholderText("--:--")).toHaveLength(0);
+  });
+});

--- a/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreate.tsx
@@ -25,7 +25,10 @@ import { useTranslation } from "../../hooks/useTranslation";
 import { transformCalendarDateTime } from "../../utils/datetime";
 import { validateFieldByUIType } from "../../utils/validation";
 import { syncJoditEditorFormData } from "../../utils/joditEditor";
-import { isFutureEventHeldInvalid } from "./utils/calendarValidation";
+import {
+  isDateRangeInvalid,
+  isFutureEventHeldInvalid,
+} from "./utils/calendarValidation";
 
 /**
  * Activity type for Calendar variant
@@ -532,6 +535,11 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
 
     if (calendarFields.length > 0) {
       const calInitial: Record<string, any> = { ...initialData };
+      // 終日（is_allday）は活動（Events）のみの概念。
+      // カレンダーの終日エリアクリックでは initialData に is_allday が入るが、
+      // ToDo タブには終日チェックボックスが無く、持ち込むと開始時刻の入力欄が
+      // 消えたまま解除できなくなるため除外する
+      delete calInitial.is_allday;
       calendarFields.forEach((field) => {
         if (!(field.name in calInitial)) {
           const initialValue = getFieldInitialValue(field);
@@ -830,15 +838,8 @@ const QuickCreateInner: React.FC<ExtendedQuickCreateProps> = ({
     if (isCalendarVariant) {
       const dateStart = currentCalendarFormData["date_start"];
       const dueDate = currentCalendarFormData["due_date"];
-      if (
-        typeof dateStart === "string" &&
-        typeof dueDate === "string" &&
-        dateStart &&
-        dueDate
-      ) {
-        if (new Date(dateStart) > new Date(dueDate)) {
-          errors["due_date"] = t("LBL_END_DATE_AFTER_START");
-        }
+      if (isDateRangeInvalid(dateStart, dueDate)) {
+        errors["due_date"] = t("LBL_END_DATE_AFTER_START");
       }
       // 未来日付の活動はステータス「完了」(Held) で登録不可
       if (

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isFutureEventHeldInvalid } from "./calendarValidation";
+import {
+  isDateRangeInvalid,
+  isFutureEventHeldInvalid,
+} from "./calendarValidation";
 
 describe("isFutureEventHeldInvalid", () => {
   const now = new Date("2026-06-24T12:00:00");
@@ -89,5 +92,94 @@ describe("isFutureEventHeldInvalid", () => {
 
   it("eventstatus が null は OK (false)", () => {
     expect(isFutureEventHeldInvalid(null, "2026-07-15T10:00", now)).toBe(false);
+  });
+});
+
+describe("isDateRangeInvalid", () => {
+  describe("ToDo (due_date が日付のみ)", () => {
+    it("同一日 + 開始 14:30 は OK (false)", () => {
+      // 旧実装では new Date("2026-08-17") が UTC 0:00 (= JST 9:00) と解釈され、
+      // 開始時刻が 9:00 以降のとき誤って NG 判定されていた
+      expect(isDateRangeInvalid("2026-08-17T14:30", "2026-08-17")).toBe(false);
+    });
+
+    it("同一日 + 開始 08:30 は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-17T08:30", "2026-08-17")).toBe(false);
+    });
+
+    it("同一日 + 開始 23:59 は OK (false) — 終了日はその日の終わりまで", () => {
+      expect(isDateRangeInvalid("2026-08-17T23:59", "2026-08-17")).toBe(false);
+    });
+
+    it("開始日が終了日の翌日は NG (true)", () => {
+      expect(isDateRangeInvalid("2026-08-18T09:00", "2026-08-17")).toBe(true);
+    });
+
+    it("開始日が終了日より前は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-16T09:00", "2026-08-17")).toBe(false);
+    });
+  });
+
+  describe("Events (開始・終了とも日時)", () => {
+    it("終了が開始より後は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-17T14:30", "2026-08-17T15:00")).toBe(
+        false,
+      );
+    });
+
+    it("終了が開始より前は NG (true)", () => {
+      expect(isDateRangeInvalid("2026-08-17T15:00", "2026-08-17T14:30")).toBe(
+        true,
+      );
+    });
+
+    it("開始と終了が同時刻は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-17T14:30", "2026-08-17T14:30")).toBe(
+        false,
+      );
+    });
+
+    it("日跨ぎ (翌日終了) は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-17T23:30", "2026-08-18T00:30")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("終日 (開始・終了とも日付のみ)", () => {
+    it("同一日は OK (false)", () => {
+      expect(isDateRangeInvalid("2026-08-17", "2026-08-17")).toBe(false);
+    });
+
+    it("開始日が終了日より後は NG (true)", () => {
+      expect(isDateRangeInvalid("2026-08-18", "2026-08-17")).toBe(true);
+    });
+  });
+
+  describe("値が不足・不正な場合はチェックしない (false)", () => {
+    it("date_start が空文字", () => {
+      expect(isDateRangeInvalid("", "2026-08-17")).toBe(false);
+    });
+
+    it("due_date が空文字", () => {
+      expect(isDateRangeInvalid("2026-08-17T14:30", "")).toBe(false);
+    });
+
+    it("date_start が undefined", () => {
+      expect(isDateRangeInvalid(undefined, "2026-08-17")).toBe(false);
+    });
+
+    it("due_date が undefined", () => {
+      expect(isDateRangeInvalid("2026-08-17T14:30", undefined)).toBe(false);
+    });
+
+    it("文字列以外 (数値)", () => {
+      expect(isDateRangeInvalid(20260817, "2026-08-17")).toBe(false);
+    });
+
+    it("不正な日付文字列 — 必須チェック側で弾く", () => {
+      expect(isDateRangeInvalid("not-a-date", "2026-08-17")).toBe(false);
+      expect(isDateRangeInvalid("2026-08-17T14:30", "not-a-date")).toBe(false);
+    });
   });
 });

--- a/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
+++ b/assets/react-web-components/src/components/QuickCreate/utils/calendarValidation.ts
@@ -1,15 +1,19 @@
 /**
- * date_start 文字列を Date に変換する。
+ * カレンダーの日時文字列を Date に変換する。
  * `YYYY-MM-DD` のみの場合は ISO 仕様で UTC 解釈されローカル時刻とズレるため、
- * ローカル時刻 0:00 として再構築する。
+ * ローカル時刻として再構築する。
  * `YYYY-MM-DDTHH:MM` 形式（タイムゾーン指定なし）はネイティブのローカル時刻解釈に委ねる。
+ *
+ * @param endOfDay true の場合、日付のみの値をその日の終わり（23:59:59.999）として扱う
  */
-function parseDateStartLocal(dateStart: string): Date {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(dateStart)) {
-    const [y, m, d] = dateStart.split("-").map(Number);
-    return new Date(y, m - 1, d);
+function parseDateTimeLocal(value: string, endOfDay = false): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const [y, m, d] = value.split("-").map(Number);
+    return endOfDay
+      ? new Date(y, m - 1, d, 23, 59, 59, 999)
+      : new Date(y, m - 1, d);
   }
-  return new Date(dateStart);
+  return new Date(value);
 }
 
 /**
@@ -23,7 +27,30 @@ export function isFutureEventHeldInvalid(
 ): boolean {
   if (eventstatus !== "Held") return false;
   if (typeof dateStart !== "string" || !dateStart) return false;
-  const start = parseDateStartLocal(dateStart);
+  const start = parseDateTimeLocal(dateStart);
   if (isNaN(start.getTime())) return false;
   return start.getTime() > now.getTime();
+}
+
+/**
+ * 終了日時（due_date）が開始日時（date_start）より前かを判定する
+ *
+ * ToDo の完了日と終日活動の終了日は日付のみ（`YYYY-MM-DD`）で保持されるため、
+ * その日の終わり（23:59:59.999）まで有効とみなして比較する。
+ * 旧 Edit 画面のバリデータ（Calendar_greaterThanDependentField）と同じ扱い。
+ *
+ * @returns true: 終了日時が開始日時より前で NG（invalid）/ false: それ以外（OK）
+ */
+export function isDateRangeInvalid(
+  dateStart: unknown,
+  dueDate: unknown,
+): boolean {
+  if (typeof dateStart !== "string" || !dateStart) return false;
+  if (typeof dueDate !== "string" || !dueDate) return false;
+
+  const start = parseDateTimeLocal(dateStart);
+  const end = parseDateTimeLocal(dueDate, true);
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return false;
+
+  return start.getTime() > end.getTime();
 }


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1808

##  不具合の内容 / Bug
1. クイック作成メニュー（画面右上の＋ボタン）や、顧客企業などの概要画面から ToDo を追加した場合、開始日時と完了日が同じ日付だと「終了日時は開始日時より後に設定してください」エラーが発生し保存できない（開始時刻が 9:00 以降のとき）。カレンダー画面の「TODOの追加」ボタンやカレンダー上のクリックからは発生しない。
2. カレンダー上の終日エリアをクリックしてクイック作成を開き、ToDo タブに切り替えると、開始日時の時刻入力欄が表示されない。ToDo タブには終日チェックボックスが無いため解除もできない。

##  原因 / Cause
1. `QuickCreate.tsx` の日付範囲チェックが `new Date(dateStart) > new Date(dueDate)` で比較していました。ToDo の完了日（due_date）は仕様上「日付のみ（YYYY-MM-DD）」で保持されますが、JavaScript の `Date` は日付のみの文字列を UTC として解釈するため JST では 9:00 相当となります。開始日時（date_start）は `YYYY-MM-DDTHH:MM` 形式でローカル時刻として解釈されるため、同一日付で開始時刻が 9:00 以降のときに誤判定していました。カレンダー画面から開いた場合は `Calendar.js` が完了日を時刻付きで渡すため発生しませんでした。
2. カレンダーの終日エリアクリック時に渡される `initialData.is_allday = true` を、ToDo タブの初期データにもそのまま展開していました。終日は活動（Events）のみの概念で、ToDo タブには終日チェックボックスが表示されないため、時刻入力欄が非表示のまま解除できなくなっていました。

##  変更内容 / Details of Change
1. `utils/calendarValidation.ts`
   - `parseDateStartLocal` を `parseDateTimeLocal(value, endOfDay)` に汎用化。日付のみの文字列をローカル時刻として解釈し、`endOfDay` 指定時はその日の 23:59:59.999 として扱う
   - `isDateRangeInvalid(dateStart, dueDate)` を追加。完了日が日付のみの場合は「その日の終わり」まで有効として比較（旧 Edit 画面の `Calendar_greaterThanDependentField` と同じ扱い）
2. `QuickCreate.tsx`
   - 日付範囲チェックを `isDateRangeInvalid` に置き換え
   - ToDo タブの初期データから `is_allday` を除外（活動タブ側の終日挙動は従来どおり）
3. テスト追加
   - `utils/calendarValidation.test.ts`: `isDateRangeInvalid` のテスト 17 件（ToDo / 活動 / 終日 / 不正値）
   - `QuickCreate.calendar.test.tsx`（新規）: クイック作成 calendar variant の統合テスト 7 件

## スクリーンショット / Screenshot
別途添付

## 影響範囲  / Affected Area
- クイック作成（Web Components 版）の ToDo / 活動タブの日時バリデーションと時刻入力欄の表示
- 起動経路すべて（画面右上＋ボタン、レコード概要画面、カレンダー画面のクリック・ドラッグ・「TODOの追加」ボタン）
- 活動（Events）の終日挙動、日時逆転時のエラー表示は従来どおり維持
- サーバ側（PHP）および従来の Edit 画面には変更なし

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- テスト結果: `npx vitest --run` で 293 件すべて成功（18 ファイル）。`npm run lint` はエラー 0、`npm run build`（tsc + vite）成功。
- 実機確認（Chrome）:
  - 画面右上＋ → TODO で開始日時 `2026/08/17 18:00`・完了日 `2026/08/17` を保存 → 「レコードを作成しました」で保存成功
  - 完了日を `2026/08/16`（逆転）に変更 → エラー表示され保存されないことを確認
  - カレンダー週表示の終日行をクリック → 活動タブは終日ON・時刻欄なし、ToDo タブに切り替えると開始時刻欄が表示されることを確認
- 言語対応: 既存の翻訳キー `LBL_END_DATE_AFTER_START` を流用しており、`languages/` 配下の変更は発生しないため該当なしです。
- `.gitignore` および `languages/*/custom/` のローカル変更は本 PR に含めていません。