### PR TITLE
Fix/1780　共有カレンダーの操作ボタンのズレを修正

### DIFF
--- a/public/layouts/v7/skins/marketing/style.css
+++ b/public/layouts/v7/skins/marketing/style.css
@@ -3938,11 +3938,18 @@ th {
   color: white;
 }
 .activitytypes .activitytype-indicator {
-  padding: 5%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
   margin: 8px;
   font-size: 80%;
   min-height: 35px;
   word-wrap: break-word;
+}
+.activitytypes .activitytype-indicator:before,
+.activitytypes .activitytype-indicator:after {
+  content: none;
 }
 .calendar-sidebar-tabs .sidebar-widget-header a {
   color: #BDBDBD;
@@ -3967,6 +3974,9 @@ th {
 }
 .activitytypes .activitytype-indicator .activitytype-actions i {
   font-size: 14px !important;
+}
+.activitytypes .activitytype-indicator .activitytype-actions {
+  flex-shrink: 0;
 }
 .activitytypes .activitytype-indicator .activitytype-actions input[type="checkbox"] {
   margin-bottom: -1px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1780 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 共有カレンダーの表示ユーザーを大量に設定時、操作ボタン（チェックボックス、編集ボタン、削除ボタン）が段々とズレて表示される。（画面倍率67％の時のみ）

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 共有カレンダーの各行が float + %指定の余白 で組まれていたため、ブラウザズーム時の端数計算のブレでボタン位置が微妙にずれていた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. .activitytype-indicator の配置を float + %指定paddingから flexbox に変更し、ズーム時の端数計算のブレによる位置ズレを解消
2. .activitytype-actions に flex-shrink: 0 を指定し、ユーザーを大量に追加した際にボタン群が折り返して2行になる問題を解消
3. 個人カレンダーの種別一覧も同じCSSクラスを使用しており、上記のflexbox化によってcontainer-fluidクラス由来の疑似要素（:before/:after）が新たにflexの子要素として扱われてしまい、そちらでも位置ズレが発生。content: none;で疑似要素自体を無効化して解消

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
変更前<img width="113" height="222" alt="image" src="https://github.com/user-attachments/assets/97c5cfb9-0bd5-4b91-b4da-99630e6e77c7" />変更後<img width="101" height="214" alt="image" src="https://github.com/user-attachments/assets/6260cc6b-a9be-483d-8225-c3a95b3e98c6" />


## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->