### PR TITLE
Fix/1781-[不具合]モバイル機_カレンダークイック操作 

### DIFF
--- a/assets/react-web-components/src/components/OwnerField.tsx
+++ b/assets/react-web-components/src/components/OwnerField.tsx
@@ -351,7 +351,9 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     setIsOpen(true);
     const currentValue = valueRef.current;
     if (currentValue) {
-      const selectedIndex = allOptions.findIndex((opt) => opt.id === currentValue);
+      const selectedIndex = allOptions.findIndex(
+        (opt) => opt.id === currentValue,
+      );
       setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
     } else {
       setHighlightedIndex(0);

--- a/assets/react-web-components/src/components/OwnerField.tsx
+++ b/assets/react-web-components/src/components/OwnerField.tsx
@@ -78,6 +78,13 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputContainerRef = useRef<HTMLDivElement>(null);
+  const isSelectingRef = useRef<boolean>(false);
+  const valueRef = useRef<string | undefined>(value);
+
+  // valueRefを最新のvalueに同期
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   // ドロップダウンの位置
   const [dropdownPosition, setDropdownPosition] = useState<{
@@ -212,11 +219,13 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
       const selected = allOptions.find((opt) => opt.id === value);
       if (selected) {
         setDisplayLabel(selected.name);
+      } else if (!isOpen) {
+        setDisplayLabel("");
       }
-    } else {
+    } else if (!isOpen) {
       setDisplayLabel("");
     }
-  }, [value, allOptions]);
+  }, [value, allOptions, isOpen]);
 
   /**
    * 検索入力変更
@@ -232,6 +241,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     }
 
     // ドロップダウンを開く
+    updateDropdownPosition();
     setIsOpen(true);
   };
 
@@ -239,10 +249,15 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
    * オプション選択
    */
   const handleSelectOption = (option: OwnerOption) => {
+    isSelectingRef.current = true;
+    valueRef.current = option.id;
     setDisplayLabel(option.name);
     setSearchTerm("");
     setIsOpen(false);
     onChange(name, option.id);
+    setTimeout(() => {
+      isSelectingRef.current = false;
+    }, 200);
   };
 
   /**
@@ -287,6 +302,21 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
     },
     [isOpen, filteredOptions, highlightedIndex],
   );
+  /**
+   * 表示状態のリセット/復元
+   */
+  const resetOrRestoreDisplay = useCallback(() => {
+    if (isSelectingRef.current) return;
+    setIsOpen(false);
+    setSearchTerm("");
+    const currentValue = valueRef.current;
+    if (currentValue) {
+      const selected = allOptions.find((opt) => opt.id === currentValue);
+      setDisplayLabel(selected ? selected.name : "");
+    } else {
+      setDisplayLabel("");
+    }
+  }, [allOptions]);
 
   /**
    * 選択をクリア
@@ -313,11 +343,29 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
   }, []);
 
   /**
-   * フォーカス時にドロップダウンを開く
+   * フォーカス時またはクリック時にドロップダウンを開く（検索語をリセットして全選択肢を表示）
    */
-  const handleFocus = () => {
+  const openDropdown = useCallback(() => {
     updateDropdownPosition();
+    setSearchTerm("");
     setIsOpen(true);
+    const currentValue = valueRef.current;
+    if (currentValue) {
+      const selectedIndex = allOptions.findIndex((opt) => opt.id === currentValue);
+      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    } else {
+      setHighlightedIndex(0);
+    }
+  }, [allOptions, updateDropdownPosition]);
+
+  const handleFocus = () => {
+    openDropdown();
+  };
+
+  const handleClick = () => {
+    if (!isOpen) {
+      openDropdown();
+    }
   };
 
   /**
@@ -330,18 +378,13 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
       const isInsideInput = inputContainerRef.current?.contains(target);
 
       if (!isInsideDropdown && !isInsideInput) {
-        setIsOpen(false);
-        // 選択されていない場合は入力をクリア
-        if (!value && displayLabel) {
-          setDisplayLabel("");
-          setSearchTerm("");
-        }
+        resetOrRestoreDisplay();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [value, displayLabel]);
+  }, [resetOrRestoreDisplay]);
 
   /**
    * スクロール・リサイズ時にドロップダウンの位置を更新
@@ -393,16 +436,22 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
                 </div>
                 {filteredUsers.map((user, i) => {
                   const globalIndex = i;
+                  const isSelected = value === user.id;
+                  const isHighlighted = globalIndex === highlightedIndex;
+
                   return (
                     <div
                       key={`user_${user.id}`}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                      }}
                       onClick={() => handleSelectOption(user)}
                       className={cn(
                         "px-3 py-1.5 text-md cursor-pointer",
-                        globalIndex === highlightedIndex
-                          ? "bg-blue-100"
-                          : value === user.id
-                            ? "bg-blue-100"
+                        isSelected
+                          ? "bg-blue-100 text-blue-900 font-medium"
+                          : isHighlighted
+                            ? "bg-gray-100"
                             : "hover:bg-blue-50",
                       )}
                     >
@@ -421,16 +470,22 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
                 </div>
                 {filteredGroups.map((group, i) => {
                   const globalIndex = filteredUsers.length + i;
+                  const isSelected = value === group.id;
+                  const isHighlighted = globalIndex === highlightedIndex;
+
                   return (
                     <div
                       key={`group_${group.id}`}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                      }}
                       onClick={() => handleSelectOption(group)}
                       className={cn(
                         "px-3 py-1.5 text-md cursor-pointer",
-                        globalIndex === highlightedIndex
-                          ? "bg-blue-100"
-                          : value === group.id
-                            ? "bg-blue-100"
+                        isSelected
+                          ? "bg-blue-100 text-blue-900 font-medium"
+                          : isHighlighted
+                            ? "bg-gray-100"
                             : "hover:bg-blue-50",
                       )}
                     >
@@ -508,11 +563,14 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
               value={displayLabel}
               onChange={handleSearchChange}
               onFocus={handleFocus}
+              onClick={handleClick}
               onKeyDown={handleKeyDown}
               onBlur={() => {
                 // Tab離脱等の blur でドロップダウンを閉じる
                 // 候補クリック時の選択処理を妨げないよう150ms遅延
-                setTimeout(() => setIsOpen(false), 150);
+                setTimeout(() => {
+                  resetOrRestoreDisplay();
+                }, 150);
               }}
               disabled={disabled}
               placeholder={t("LBL_PLACEHOLDER_SEARCH", label)}
@@ -527,12 +585,31 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
                   type="button"
                   onClick={handleClear}
                   disabled={disabled}
-                  className="p-1 hover:bg-gray-100 rounded"
+                  className="p-1 hover:bg-gray-100 rounded cursor-pointer"
+                  aria-label="クリア"
                 >
                   <X className="w-4 h-4 text-gray-400" />
                 </button>
               ) : (
-                <ChevronDown className="w-4 h-4 text-gray-400" />
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!disabled) {
+                      if (isOpen) {
+                        setIsOpen(false);
+                      } else {
+                        openDropdown();
+                        inputRef.current?.focus();
+                      }
+                    }
+                  }}
+                  disabled={disabled}
+                  tabIndex={-1}
+                  className="p-1 hover:bg-gray-100 rounded cursor-pointer text-gray-400"
+                  aria-label="選択肢を表示"
+                >
+                  <ChevronDown className="w-4 h-4" />
+                </button>
               )}
             </div>
           </div>

--- a/assets/react-web-components/src/components/PicklistField.tsx
+++ b/assets/react-web-components/src/components/PicklistField.tsx
@@ -86,6 +86,13 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputContainerRef = useRef<HTMLDivElement>(null);
+  const isSelectingRef = useRef<boolean>(false);
+  const valueRef = useRef<string | undefined>(value);
+
+  // valueRefを最新のvalueに同期
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
 
   // ドロップダウンの位置
   const [dropdownPosition, setDropdownPosition] = useState<{
@@ -168,11 +175,13 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
       const selected = options.find((opt) => opt.value === value);
       if (selected) {
         setDisplayLabel(selected.label);
+      } else if (!isOpen) {
+        setDisplayLabel("");
       }
-    } else {
+    } else if (!isOpen) {
       setDisplayLabel("");
     }
-  }, [value, options]);
+  }, [value, options, isOpen]);
 
   /**
    * 検索入力変更
@@ -185,9 +194,13 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
     // 既存の選択をクリア
     if (value) {
       onChange(name, "");
+      if (isRecordTypeField && onRecordTypeChange) {
+        onRecordTypeChange(name, "");
+      }
     }
 
     // ドロップダウンを開く
+    updateDropdownPosition();
     setIsOpen(true);
   };
 
@@ -195,6 +208,8 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
    * オプション選択
    */
   const handleSelectOption = (option: PicklistOption) => {
+    isSelectingRef.current = true;
+    valueRef.current = option.value;
     setDisplayLabel(option.label);
     setSearchTerm("");
     setIsOpen(false);
@@ -204,6 +219,9 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
     if (isRecordTypeField && onRecordTypeChange) {
       onRecordTypeChange(name, option.value);
     }
+    setTimeout(() => {
+      isSelectingRef.current = false;
+    }, 200);
   };
 
   /**
@@ -247,6 +265,21 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
     },
     [isOpen, filteredOptions, highlightedIndex],
   );
+  /**
+   * 表示状態のリセット/復元
+   */
+  const resetOrRestoreDisplay = useCallback(() => {
+    if (isSelectingRef.current) return;
+    setIsOpen(false);
+    setSearchTerm("");
+    const currentValue = valueRef.current;
+    if (currentValue) {
+      const selected = options.find((opt) => opt.value === currentValue);
+      setDisplayLabel(selected ? selected.label : "");
+    } else {
+      setDisplayLabel("");
+    }
+  }, [options]);
 
   /**
    * 選択をクリア
@@ -255,6 +288,9 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
     setDisplayLabel("");
     setSearchTerm("");
     onChange(name, "");
+    if (isRecordTypeField && onRecordTypeChange) {
+      onRecordTypeChange(name, "");
+    }
     inputRef.current?.focus();
   };
 
@@ -273,11 +309,30 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
   }, []);
 
   /**
-   * フォーカス時にドロップダウンを開く
+   * フォーカス時またはクリック時にドロップダウンを開く（検索語をリセットして全選択肢を表示）
    */
-  const handleFocus = () => {
+  const openDropdown = useCallback(() => {
     updateDropdownPosition();
+    setSearchTerm("");
     setIsOpen(true);
+    // 現在選択されている項目にハイライトを合わせる
+    const currentValue = valueRef.current;
+    if (currentValue) {
+      const selectedIndex = options.findIndex((opt) => opt.value === currentValue);
+      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    } else {
+      setHighlightedIndex(0);
+    }
+  }, [options, updateDropdownPosition]);
+
+  const handleFocus = () => {
+    openDropdown();
+  };
+
+  const handleClick = () => {
+    if (!isOpen) {
+      openDropdown();
+    }
   };
 
   /**
@@ -290,18 +345,13 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
       const isInsideInput = inputContainerRef.current?.contains(target);
 
       if (!isInsideDropdown && !isInsideInput) {
-        setIsOpen(false);
-        // 選択されていない場合は入力をクリア
-        if (!value && displayLabel) {
-          setDisplayLabel("");
-          setSearchTerm("");
-        }
+        resetOrRestoreDisplay();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [value, displayLabel]);
+  }, [resetOrRestoreDisplay]);
 
   /**
    * スクロール・リサイズ時にドロップダウンの位置を更新
@@ -348,22 +398,30 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
       >
         {filteredOptions.length > 0 ? (
           <div className="py-1">
-            {filteredOptions.map((option, index) => (
-              <div
-                key={option.value}
-                onClick={() => handleSelectOption(option)}
-                className={cn(
-                  "px-3 py-1.5 text-md cursor-pointer",
-                  index === highlightedIndex
-                    ? "bg-blue-100"
-                    : value === option.value
-                      ? "bg-blue-100"
-                      : "hover:bg-blue-50",
-                )}
-              >
-                {option.label}
-              </div>
-            ))}
+            {filteredOptions.map((option, index) => {
+              const isSelected = value === option.value;
+              const isHighlighted = index === highlightedIndex;
+
+              return (
+                <div
+                  key={option.value}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                  }}
+                  onClick={() => handleSelectOption(option)}
+                  className={cn(
+                    "px-3 py-1.5 text-md cursor-pointer",
+                    isSelected
+                      ? "bg-blue-100 text-blue-900 font-medium"
+                      : isHighlighted
+                        ? "bg-gray-100"
+                        : "hover:bg-blue-50",
+                  )}
+                >
+                  {option.label}
+                </div>
+              );
+            })}
           </div>
         ) : (
           <div className="px-3 py-1.5 text-md text-gray-500 text-center">
@@ -432,11 +490,14 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
               value={displayLabel}
               onChange={handleSearchChange}
               onFocus={handleFocus}
+              onClick={handleClick}
               onKeyDown={handleKeyDown}
               onBlur={() => {
                 // Tab離脱等の blur でドロップダウンを閉じる
                 // 候補クリック時の選択処理を妨げないよう150ms遅延
-                setTimeout(() => setIsOpen(false), 150);
+                setTimeout(() => {
+                  resetOrRestoreDisplay();
+                }, 150);
               }}
               disabled={disabled}
               placeholder={t("LBL_PLACEHOLDER_SEARCH", label)}
@@ -455,12 +516,31 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
                   type="button"
                   onClick={handleClear}
                   disabled={disabled}
-                  className="p-1 hover:bg-gray-100 rounded"
+                  className="p-1 hover:bg-gray-100 rounded cursor-pointer"
+                  aria-label="クリア"
                 >
                   <X className="w-4 h-4 text-gray-400" />
                 </button>
               ) : (
-                <ChevronDown className="w-4 h-4 text-gray-400" />
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!disabled) {
+                      if (isOpen) {
+                        setIsOpen(false);
+                      } else {
+                        openDropdown();
+                        inputRef.current?.focus();
+                      }
+                    }
+                  }}
+                  disabled={disabled}
+                  tabIndex={-1}
+                  className="p-1 hover:bg-gray-100 rounded cursor-pointer text-gray-400"
+                  aria-label="選択肢を表示"
+                >
+                  <ChevronDown className="w-4 h-4" />
+                </button>
               )}
             </div>
           </div>

--- a/assets/react-web-components/src/components/PicklistField.tsx
+++ b/assets/react-web-components/src/components/PicklistField.tsx
@@ -318,7 +318,9 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
     // 現在選択されている項目にハイライトを合わせる
     const currentValue = valueRef.current;
     if (currentValue) {
-      const selectedIndex = options.findIndex((opt) => opt.value === currentValue);
+      const selectedIndex = options.findIndex(
+        (opt) => opt.value === currentValue,
+      );
       setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
     } else {
       setHighlightedIndex(0);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1781

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. カレンダーのクイック作成画面で、選択肢項目の選択をして削除するとドロップダウンに直前に選んでいた選択肢しか表示されない。
2. この不具合が起こっていない「優先度」項目において、現在選択されている項目以外もハイライト（青色表示）されていてわかりづらい。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 入力欄の文字を削除・編集した際、内部の検索状態（searchTerm）に入力途中の文字列が保持されていた。
2. ドロップダウンを開いた際の「先頭項目（カーソル位置）」と「現在選択中の項目」の両方に同じ青色のスタイルが適用されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 入力欄をタップ/クリックした際に、前回の文字削除などで内部に残っていた検索キーワードを確実にリセットし、常に
2. すべての選択肢が一覧で開くように修正。
3. ドロップダウンを開いた際、現在選ばれている項目だけが青色で表示されるように修正。
4. すでに値が選ばれている状態の入力欄をクリックした際にも、ドロップダウンが開くように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
一度削除した後もすべての選択肢を表示
<img width="401" height="119" alt="image" src="https://github.com/user-attachments/assets/e5ca5cd0-68f9-45ab-9777-a1f2659e957f" />

現在選択しているもののみを青く表示
<img width="405" height="118" alt="image" src="https://github.com/user-attachments/assets/d5e257e6-54ae-4e57-a752-283c11384980" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
React Web Componentsのソースコードを修正しているため、反映する際はビルドが必要。