### PR TITLE
ヘッダー(グローバルナビ)のレイアウトをFlexboxで書き直す (#1815)

### DIFF
--- a/assets/react-web-components/src/components/AppMenu.tsx
+++ b/assets/react-web-components/src/components/AppMenu.tsx
@@ -36,9 +36,12 @@ const ModuleIcon: React.FC<{ iconHtml: string }> = ({ iconHtml }) => {
 // スタイル定義（コンポーネント内で完結）
 // ※ triggerの色はTailwind preflightが無効なため、インラインスタイルで直接指定
 const styles = {
-  root: "flex items-center border-0 bg-transparent h-[42px] gap-0",
+  // ヘッダーが Flexbox の 1 行レイアウトなので、min-w-0 で縮めるようにしておく
+  // (これが無いとカスタム要素の中身が縮まず、ヘッダーを押し広げてしまう)
+  root: "flex items-center border-0 bg-transparent h-[42px] gap-0 min-w-0",
   trigger: cn(
     "cursor-pointer flex items-center px-3 py-2 text-[13px] font-normal rounded-none transition-colors",
+    "min-w-0 max-w-full",
     "text-[#b3c0ce] hover:text-white hover:bg-transparent",
     "data-[state=open]:bg-transparent data-[state=open]:text-white",
     "outline-none select-none",
@@ -62,15 +65,18 @@ export const AppMenu: React.FC<AppMenuProps> = ({ appMenus }) => {
 
   return (
     <NavigationMenuPrimitive.Root className={styles.root}>
-      <NavigationMenuPrimitive.List className="flex items-center gap-0 list-none m-0 p-0 h-[42px] ">
+      <NavigationMenuPrimitive.List className="flex flex-nowrap items-center gap-0 list-none m-0 p-0 h-[42px] min-w-0">
         {menus.map((app) => (
-          <NavigationMenuPrimitive.Item key={app.name} className="relative">
+          <NavigationMenuPrimitive.Item
+            key={app.name}
+            className="relative min-w-0"
+          >
             <NavigationMenuPrimitive.Trigger
               className={styles.trigger}
               style={{ color: "#333" }}
             >
-              {app.label}
-              <ChevronDown className="ml-1 h-3 w-3 opacity-90" />
+              <span className="truncate">{app.label}</span>
+              <ChevronDown className="ml-1 h-3 w-3 shrink-0 opacity-90" />
             </NavigationMenuPrimitive.Trigger>
             <NavigationMenuPrimitive.Content className={styles.content}>
               {app.modules.map((module) => (

--- a/layouts/v7/modules/Vtiger/partials/Topbar.tpl
+++ b/layouts/v7/modules/Vtiger/partials/Topbar.tpl
@@ -12,189 +12,183 @@
 
 	{assign var=APP_IMAGE_MAP value=Vtiger_MenuStructure_Model::getAppIcons()}
 	<nav class="navbar navbar-inverse navbar-fixed-top app-fixed-navbar">
+		{* ヘッダーは Flexbox の 1 行レイアウト。カラム落ちを防ぐため col-* / pull-* / float は使わず、
+		   幅の調整は skins/vtiger/style.less 側の flex / gap / margin-inline-start に寄せている *}
 		<div class="container-fluid global-nav">
-			<div class="row">
-				<div class="col-lg-2 col-md-3 col-sm-2 col-xs-8 app-navigator-container">
-					<div class="row">
-						<div id="appnavigator" class="col-sm-2 col-xs-2 cursorPointer app-switcher-container" data-app-class="{if $MODULE eq 'Home' || !$MODULE}fa-dashboard{else}{$APP_IMAGE_MAP[$SELECTED_MENU_CATEGORY]}{/if}">
-							<div class="row app-navigator">
-								<span class="app-icon fa fa-bars"></span>
-							</div>
-						</div>
-						<div class="logo-container col-sm-3 col-xs-9">
-							<div class="row">
-								<a href="index.php" class="company-logo">
-									<img src="{$COMPANY_LOGO->get('imagepath')}" alt="{$COMPANY_LOGO->get('alt')}"/>
-								</a>
-							</div>
-						</div>  
+			<div class="app-navigator-container">
+				<div id="appnavigator" class="cursorPointer app-switcher-container" data-app-class="{if $MODULE eq 'Home' || !$MODULE}fa-dashboard{else}{$APP_IMAGE_MAP[$SELECTED_MENU_CATEGORY]}{/if}">
+					<div class="app-navigator">
+						<span class="app-icon fa fa-bars"></span>
 					</div>
 				</div>
-				<div class="navbar-header paddingTop5">
-					<button type="button" class="navbar-toggle collapsed border0" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
-						<i class="fa fa-th"></i>
-					</button>
-					<button type="button" class="navbar-toggle collapsed border0" data-toggle="collapse" data-target="#search-links-container" aria-expanded="false">
-						<i class="fa fa-search"></i>
-					</button>
+				<div class="logo-container">
+					<a href="index.php" class="company-logo">
+						<img src="{$COMPANY_LOGO->get('imagepath')}" alt="{$COMPANY_LOGO->get('alt')}"/>
+					</a>
 				</div>
+			</div>
+			<div class="navbar-header paddingTop5">
+				<button type="button" class="navbar-toggle collapsed border0" data-toggle="collapse" data-target="#navbar" aria-expanded="false">
+					<i class="fa fa-th"></i>
+				</button>
+				<button type="button" class="navbar-toggle collapsed border0" data-toggle="collapse" data-target="#search-links-container" aria-expanded="false">
+					<i class="fa fa-search"></i>
+				</button>
+			</div>
 
-				<div class="col-sm-5 hidden-xs hidden-sm app-list">
-					{* @assets/react-web-components/src/components/AppMenu.tsx *}
-					<app-menu app-menus="{$HEADER_MENU_APP_MENUS_JSON|escape:'html'}"></app-menu>
-				</div>
+			<div class="hidden-xs hidden-sm app-list">
+				{* @assets/react-web-components/src/components/AppMenu.tsx *}
+				<app-menu app-menus="{$HEADER_MENU_APP_MENUS_JSON|escape:'html'}"></app-menu>
+			</div>
 
-				<div class="col-sm-3">
-					<div id="search-links-container" class="search-links-container collapse navbar-collapse">
-						<div class="search-link">
-							<span class="fa fa-search" aria-hidden="true"></span>
-							<input class="keyword-input" type="text" placeholder="{vtranslate('LBL_TYPE_SEARCH')}" value="{$GLOBAL_SEARCH_VALUE}">
-							<span id="adv-search" class="adv-search fa fa-chevron-circle-down pull-right cursorPointer" aria-hidden="true"></span>
-						</div>
-					</div>
+			<div id="search-links-container" class="search-links-container collapse navbar-collapse">
+				<div class="search-link">
+					<span class="fa fa-search" aria-hidden="true"></span>
+					<input class="keyword-input" type="text" placeholder="{vtranslate('LBL_TYPE_SEARCH')}" value="{$GLOBAL_SEARCH_VALUE}">
+					<span id="adv-search" class="adv-search fa fa-chevron-circle-down cursorPointer" aria-hidden="true"></span>
 				</div>
-				<div id="navbar" class="col-sm-3 col-xs-12 collapse navbar-collapse navbar-right global-actions">
-					<ul class="nav navbar-nav">
-						<li>
-							<div class="dropdown pull-left">
-								<div class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">
-									<a href="#" id="menubar_quickCreate" class="qc-button fa fa-plus-circle" title="{vtranslate('LBL_QUICK_CREATE',$MODULE)}" aria-hidden="true"></a>
-								</div>
-								<ul class="dropdown-menu quickCreateDropdown" role="menu" aria-labelledby="dropdownMenu1">
-									<li class="title" style="padding: 5px 0 0 15px;">
-										<strong>{vtranslate('LBL_QUICK_CREATE',$MODULE)}</strong>
-									</li>
-									<hr/>
-									<li id="quickCreateModules" style="padding: 0 5px;">
-										<div class="quickCreateModulesGrid">
-											{foreach key=moduleName item=moduleModel from=$QUICK_CREATE_MODULES}
-												{if $moduleModel->isPermitted('CreateView') || $moduleModel->isPermitted('EditView')}
-													{assign var='quickCreateModule' value=$moduleModel->isQuickCreateSupported()}
-													{assign var='singularLabel' value=$moduleModel->getSingularLabelKey()}
-													{assign var=hideDiv value={!$moduleModel->isPermitted('CreateView') && $moduleModel->isPermitted('EditView')}}
-													{if $quickCreateModule == '1'}
-														{* Calendar: Event + Task *}
-														{if $singularLabel == 'SINGLE_Calendar'}
-															<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
-																<a id="menubar_quickCreate_Events" class="quickCreateModule" data-name="Events"
-																   data-url="index.php?module=Events&view=QuickCreateAjax" href="javascript:void(0)"
-																   title="{vtranslate('LBL_EVENT',$moduleName)}">
-																	{$moduleModel->getModuleIcon('Event')}
-																	<span class="quick-create-module">{vtranslate('LBL_EVENT',$moduleName)}</span>
-																</a>
-															</div>
-															<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
-																<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModule" data-name="{$moduleModel->getName()}"
-																   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
-																   title="{vtranslate('LBL_TASK',$moduleName)}">
-																	{$moduleModel->getModuleIcon('Task')}
-																	<span class="quick-create-module">{vtranslate('LBL_TASK',$moduleName)}</span>
-																</a>
-															</div>
-														{* Documents: Dropdown *}
-														{else if $singularLabel == 'SINGLE_Documents'}
-															<div class="quickCreateModuleItem dropdown{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
-																<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModuleSubmenu dropdown-toggle" data-name="{$moduleModel->getName()}" data-toggle="dropdown"
-																   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
-																   title="{vtranslate($singularLabel,$moduleName)}">
-																	{$moduleModel->getModuleIcon()}
-																	<span class="quick-create-module">{vtranslate($singularLabel,$moduleName)}</span>
-																	<i class="fa fa-caret-down quickcreateMoreDropdownAction"></i>
-																</a>
-																<ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_{$moduleModel->getName()}">
-																	<li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', $moduleName)}</li>
-																	<li id="VtigerAction">
-																		<a href="javascript:Documents_Index_Js.uploadTo('Vtiger')">
-																			<img style="margin-top: -3px; margin-right: 10px; margin-left: 3px; width: 15px; height: 15px;" title="F-RevoCRM" alt="F-RevoCRM" src="layouts/v7/skins//images/Vtiger.png">
-																			{vtranslate('LBL_TO_SERVICE', $moduleName, {vtranslate('LBL_VTIGER', $moduleName)})}
-																		</a>
-																	</li>
-																	<li class="dropdown-header"><i class="fa fa-link"></i> {vtranslate('LBL_LINK_EXTERNAL_DOCUMENT', $moduleName)}</li>
-																	<li id="shareDocument"><a href="javascript:Documents_Index_Js.createDocument('E')">&nbsp;<i class="fa fa-external-link"></i>&nbsp;&nbsp; {vtranslate('LBL_FROM_SERVICE', $moduleName, {vtranslate('LBL_FILE_URL', $moduleName)})}</a></li>
-																	<li role="separator" class="divider"></li>
-																	<li id="createDocument"><a href="javascript:Documents_Index_Js.createDocument('W')"><i class="fa fa-file-text"></i> {vtranslate('LBL_CREATE_NEW', $moduleName, {vtranslate('SINGLE_Documents', $moduleName)})}</a></li>
-																</ul>
-															</div>
-														{* Other modules *}
-														{else}
-															<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
-																<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModule" data-name="{$moduleModel->getName()}"
-																   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
-																   title="{vtranslate($singularLabel,$moduleName)}">
-																	{$moduleModel->getModuleIcon()}
-																	<span class="quick-create-module">{vtranslate($singularLabel,$moduleName)}</span>
-																</a>
-															</div>
-														{/if}
+			</div>
+			<div id="navbar" class="collapse navbar-collapse global-actions">
+				<ul class="nav navbar-nav">
+					<li>
+						<div class="dropdown">
+							<div class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">
+								<a href="#" id="menubar_quickCreate" class="qc-button fa fa-plus-circle" title="{vtranslate('LBL_QUICK_CREATE',$MODULE)}" aria-hidden="true"></a>
+							</div>
+							<ul class="dropdown-menu quickCreateDropdown" role="menu" aria-labelledby="dropdownMenu1">
+								<li class="title" style="padding: 5px 0 0 15px;">
+									<strong>{vtranslate('LBL_QUICK_CREATE',$MODULE)}</strong>
+								</li>
+								<hr/>
+								<li id="quickCreateModules" style="padding: 0 5px;">
+									<div class="quickCreateModulesGrid">
+										{foreach key=moduleName item=moduleModel from=$QUICK_CREATE_MODULES}
+											{if $moduleModel->isPermitted('CreateView') || $moduleModel->isPermitted('EditView')}
+												{assign var='quickCreateModule' value=$moduleModel->isQuickCreateSupported()}
+												{assign var='singularLabel' value=$moduleModel->getSingularLabelKey()}
+												{assign var=hideDiv value={!$moduleModel->isPermitted('CreateView') && $moduleModel->isPermitted('EditView')}}
+												{if $quickCreateModule == '1'}
+													{* Calendar: Event + Task *}
+													{if $singularLabel == 'SINGLE_Calendar'}
+														<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
+															<a id="menubar_quickCreate_Events" class="quickCreateModule" data-name="Events"
+															   data-url="index.php?module=Events&view=QuickCreateAjax" href="javascript:void(0)"
+															   title="{vtranslate('LBL_EVENT',$moduleName)}">
+																{$moduleModel->getModuleIcon('Event')}
+																<span class="quick-create-module">{vtranslate('LBL_EVENT',$moduleName)}</span>
+															</a>
+														</div>
+														<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
+															<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModule" data-name="{$moduleModel->getName()}"
+															   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
+															   title="{vtranslate('LBL_TASK',$moduleName)}">
+																{$moduleModel->getModuleIcon('Task')}
+																<span class="quick-create-module">{vtranslate('LBL_TASK',$moduleName)}</span>
+															</a>
+														</div>
+													{* Documents: Dropdown *}
+													{else if $singularLabel == 'SINGLE_Documents'}
+														<div class="quickCreateModuleItem dropdown{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
+															<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModuleSubmenu dropdown-toggle" data-name="{$moduleModel->getName()}" data-toggle="dropdown"
+															   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
+															   title="{vtranslate($singularLabel,$moduleName)}">
+																{$moduleModel->getModuleIcon()}
+																<span class="quick-create-module">{vtranslate($singularLabel,$moduleName)}</span>
+																<i class="fa fa-caret-down quickcreateMoreDropdownAction"></i>
+															</a>
+															<ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_{$moduleModel->getName()}">
+																<li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', $moduleName)}</li>
+																<li id="VtigerAction">
+																	<a href="javascript:Documents_Index_Js.uploadTo('Vtiger')">
+																		<img style="margin-top: -3px; margin-right: 10px; margin-left: 3px; width: 15px; height: 15px;" title="F-RevoCRM" alt="F-RevoCRM" src="layouts/v7/skins//images/Vtiger.png">
+																		{vtranslate('LBL_TO_SERVICE', $moduleName, {vtranslate('LBL_VTIGER', $moduleName)})}
+																	</a>
+																</li>
+																<li class="dropdown-header"><i class="fa fa-link"></i> {vtranslate('LBL_LINK_EXTERNAL_DOCUMENT', $moduleName)}</li>
+																<li id="shareDocument"><a href="javascript:Documents_Index_Js.createDocument('E')">&nbsp;<i class="fa fa-external-link"></i>&nbsp;&nbsp; {vtranslate('LBL_FROM_SERVICE', $moduleName, {vtranslate('LBL_FILE_URL', $moduleName)})}</a></li>
+																<li role="separator" class="divider"></li>
+																<li id="createDocument"><a href="javascript:Documents_Index_Js.createDocument('W')"><i class="fa fa-file-text"></i> {vtranslate('LBL_CREATE_NEW', $moduleName, {vtranslate('SINGLE_Documents', $moduleName)})}</a></li>
+															</ul>
+														</div>
+													{* Other modules *}
+													{else}
+														<div class="quickCreateModuleItem{if $hideDiv} create_restricted_{$moduleModel->getName()} hide{/if}">
+															<a id="menubar_quickCreate_{$moduleModel->getName()}" class="quickCreateModule" data-name="{$moduleModel->getName()}"
+															   data-url="{$moduleModel->getQuickCreateUrl()}" href="javascript:void(0)"
+															   title="{vtranslate($singularLabel,$moduleName)}">
+																{$moduleModel->getModuleIcon()}
+																<span class="quick-create-module">{vtranslate($singularLabel,$moduleName)}</span>
+															</a>
+														</div>
 													{/if}
 												{/if}
-											{/foreach}
-										</div>
-									</li>
-								</ul>
-							</div>
-						</li>
-						{assign var=USER_PRIVILEGES_MODEL value=Users_Privileges_Model::getCurrentUserPrivilegesModel()}
-						{assign var=CALENDAR_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Calendar')}
-						{if $USER_PRIVILEGES_MODEL->hasModulePermission($CALENDAR_MODULE_MODEL->getId())}
-							<li><div><a href="index.php?module=Calendar&view={$CALENDAR_MODULE_MODEL->getDefaultViewName()}&lastViewDate=default" class="fa fa-calendar" title="{vtranslate('Calendar','Calendar')}" aria-hidden="true"></a></div></li>  
-						{/if}
-						{assign var=REPORTS_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Reports')}
-						{if $USER_PRIVILEGES_MODEL->hasModulePermission($REPORTS_MODULE_MODEL->getId())}
-							<li><div><a href="index.php?module=Reports&view=List" class="fa fa-bar-chart" title="{vtranslate('Reports','Reports')}" aria-hidden="true"></a></div></li>
-						{/if}
-						{if $USER_PRIVILEGES_MODEL->hasModulePermission($CALENDAR_MODULE_MODEL->getId())}
-							<li><div><a href="#" class="taskManagement vicon vicon-task" title="{vtranslate('Tasks','Vtiger')}" aria-hidden="true"></a></div></li>
-						{/if}
-						<li class="dropdown">
-							<div>
-								<a href="#" class="userName dropdown-toggle pull-right" data-toggle="dropdown" role="button">
-									<span class="fa fa-user" aria-hidden="true" title="{$USER_MODEL->get('last_name')} {$USER_MODEL->get('first_name')}
-										  ({$USER_MODEL->get('user_name')})"></span>
-									<span class="link-text-xs-only hidden-lg hidden-md hidden-sm">{$USER_MODEL->getName()}</span>
-								</a>
-								<div class="dropdown-menu logout-content" role="menu">
-									<div class="row">
-										<div class="col-lg-4 col-sm-4">
-											<div class="profile-img-container">
-												{assign var=IMAGE_DETAILS value=$USER_MODEL->getImageDetails()}
-												{if $IMAGE_DETAILS neq '' && $IMAGE_DETAILS[0] neq '' && $IMAGE_DETAILS[0].path eq ''}
-													<i class='vicon-vtigeruser' style="font-size:90px"></i>
-												{else}
-													{foreach item=IMAGE_INFO from=$IMAGE_DETAILS}
-														{if !empty($IMAGE_INFO.url)}
-															<img src="{$IMAGE_INFO.url}" width="100px" height="100px">
-														{/if}
-													{/foreach}
-												{/if}
-											</div>
-										</div>
-										<div class="col-lg-8 col-sm-8">
-											<div class="profile-container">
-												<h4>{$USER_MODEL->get('last_name')} {$USER_MODEL->get('first_name')}</h4>
-												<h5 class="textOverflowEllipsis" title='{$USER_MODEL->get('user_name')}'>{$USER_MODEL->get('user_name')}</h5>
-												<p>{vtranslate($USER_MODEL->getUserRoleName())}</p>
-											</div>
+											{/if}
+										{/foreach}
+									</div>
+								</li>
+							</ul>
+						</div>
+					</li>
+					{assign var=USER_PRIVILEGES_MODEL value=Users_Privileges_Model::getCurrentUserPrivilegesModel()}
+					{assign var=CALENDAR_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Calendar')}
+					{if $USER_PRIVILEGES_MODEL->hasModulePermission($CALENDAR_MODULE_MODEL->getId())}
+						<li><div><a href="index.php?module=Calendar&view={$CALENDAR_MODULE_MODEL->getDefaultViewName()}&lastViewDate=default" class="fa fa-calendar" title="{vtranslate('Calendar','Calendar')}" aria-hidden="true"></a></div></li>  
+					{/if}
+					{assign var=REPORTS_MODULE_MODEL value=Vtiger_Module_Model::getInstance('Reports')}
+					{if $USER_PRIVILEGES_MODEL->hasModulePermission($REPORTS_MODULE_MODEL->getId())}
+						<li><div><a href="index.php?module=Reports&view=List" class="fa fa-bar-chart" title="{vtranslate('Reports','Reports')}" aria-hidden="true"></a></div></li>
+					{/if}
+					{if $USER_PRIVILEGES_MODEL->hasModulePermission($CALENDAR_MODULE_MODEL->getId())}
+						<li><div><a href="#" class="taskManagement vicon vicon-task" title="{vtranslate('Tasks','Vtiger')}" aria-hidden="true"></a></div></li>
+					{/if}
+					<li class="dropdown">
+						<div>
+							<a href="#" class="userName dropdown-toggle" data-toggle="dropdown" role="button">
+								<span class="fa fa-user" aria-hidden="true" title="{$USER_MODEL->get('last_name')} {$USER_MODEL->get('first_name')}
+									  ({$USER_MODEL->get('user_name')})"></span>
+								<span class="link-text-xs-only hidden-lg hidden-md hidden-sm">{$USER_MODEL->getName()}</span>
+							</a>
+							<div class="dropdown-menu logout-content" role="menu">
+								<div class="row">
+									<div class="col-lg-4 col-sm-4">
+										<div class="profile-img-container">
+											{assign var=IMAGE_DETAILS value=$USER_MODEL->getImageDetails()}
+											{if $IMAGE_DETAILS neq '' && $IMAGE_DETAILS[0] neq '' && $IMAGE_DETAILS[0].path eq ''}
+												<i class='vicon-vtigeruser' style="font-size:90px"></i>
+											{else}
+												{foreach item=IMAGE_INFO from=$IMAGE_DETAILS}
+													{if !empty($IMAGE_INFO.url)}
+														<img src="{$IMAGE_INFO.url}" width="100px" height="100px">
+													{/if}
+												{/foreach}
+											{/if}
 										</div>
 									</div>
-									<div id="logout-footer" class="logout-footer clearfix">
-										<hr style="margin: 10px 0 !important">
-										<div class="">
-											<span class="pull-left">
-												<span class="fa fa-cogs"></span>
-												<a id="menubar_item_right_LBL_MY_PREFERENCES" href="{$USER_MODEL->getPreferenceDetailViewUrl()}">{vtranslate('LBL_MY_PREFERENCES')}</a>
-											</span>
-											<span class="pull-right">
-												<span class="fa fa-power-off"></span>
-												<a id="menubar_item_right_LBL_SIGN_OUT" href="index.php?module=Users&action=Logout">{vtranslate('LBL_SIGN_OUT')}</a>
-											</span>
+									<div class="col-lg-8 col-sm-8">
+										<div class="profile-container">
+											<h4>{$USER_MODEL->get('last_name')} {$USER_MODEL->get('first_name')}</h4>
+											<h5 class="textOverflowEllipsis" title='{$USER_MODEL->get('user_name')}'>{$USER_MODEL->get('user_name')}</h5>
+											<p>{vtranslate($USER_MODEL->getUserRoleName())}</p>
 										</div>
 									</div>
 								</div>
+								<div id="logout-footer" class="logout-footer clearfix">
+									<hr style="margin: 10px 0 !important">
+									<div class="">
+										<span class="pull-left">
+											<span class="fa fa-cogs"></span>
+											<a id="menubar_item_right_LBL_MY_PREFERENCES" href="{$USER_MODEL->getPreferenceDetailViewUrl()}">{vtranslate('LBL_MY_PREFERENCES')}</a>
+										</span>
+										<span class="pull-right">
+											<span class="fa fa-power-off"></span>
+											<a id="menubar_item_right_LBL_SIGN_OUT" href="index.php?module=Users&action=Logout">{vtranslate('LBL_SIGN_OUT')}</a>
+										</span>
+									</div>
+								</div>
 							</div>
-						</li>
-					</ul>
-				</div>
+						</div>
+					</li>
+				</ul>
 			</div>
 		</div>
 {/strip}

--- a/public/layouts/v7/skins/contact/style.css
+++ b/public/layouts/v7/skins/contact/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/inventory/style.css
+++ b/public/layouts/v7/skins/inventory/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/marketing/style.css
+++ b/public/layouts/v7/skins/marketing/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -235,16 +235,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -260,20 +265,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -323,16 +493,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/marketing_and_sales/style.css
+++ b/public/layouts/v7/skins/marketing_and_sales/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/project/style.css
+++ b/public/layouts/v7/skins/project/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/sales/style.css
+++ b/public/layouts/v7/skins/sales/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/support/style.css
+++ b/public/layouts/v7/skins/support/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/tools/style.css
+++ b/public/layouts/v7/skins/tools/style.css
@@ -81,8 +81,15 @@ body > .mCSB_inside > .mCSB_container {
   margin-bottom: 0;
   border-top: 0;
 }
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
 .global-nav {
   position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
 .global-nav .global-actions {
   padding-right: 15px;
@@ -113,13 +120,6 @@ body > .mCSB_inside > .mCSB_container {
   min-height: inherit;
 }
 @media (min-width: 992px) {
-  .global-nav .logo-container {
-    display: inline-block;
-    width: 150px;
-    z-index: 2;
-    padding-left: 6%;
-    margin-top: 1px;
-  }
   .app-nav .module-action-bar {
     padding-left: 42px;
     top: 0px;
@@ -212,16 +212,21 @@ body > .mCSB_inside > .mCSB_container {
 /**********************************/
 /******** Navigation styles *******/
 /**********************************/
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
 .company-logo {
   height: 40px;
-  width: 180px;
-  margin: 0 0;
-  display: inline-block;
-  margin-left: 1px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
 .company-logo img {
-  max-height: 100%;
+  max-height: 40px;
   max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 .navbar .fa {
   font-size: 15px;
@@ -237,20 +242,185 @@ body > .mCSB_inside > .mCSB_container {
 .global-nav .navbar-nav > li div a {
   padding: 13px;
 }
-#navbar > ul > li > div > div > a {
-  float: left;
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
+.global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
 }
-#navbar > ul > li > div > a {
-  float: left;
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
 }
-.global-nav > ul {
-  margin-right: 20px;
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
 }
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
 .global-nav .search-links-container {
   padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
 }
-.global-nav .app-navigator-container {
-  height: 42px;
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
+    height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only {
   padding: 0px 15px;
@@ -300,16 +470,8 @@ body > .mCSB_inside > .mCSB_container {
   .module-action-bar .navbar-right .nav > li a {
     padding: 0 10px;
   }
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
 }
 @media (max-width: 991px) {
-  .global-nav .logo-container {
-    border-bottom: 0;
-    width: 150px;
-  }
   .notificationMessageHolder {
     padding-left: 45%;
   }

--- a/public/layouts/v7/skins/vtiger/style.less
+++ b/public/layouts/v7/skins/vtiger/style.less
@@ -91,11 +91,18 @@ body > .mCSB_inside > .mCSB_container{
     margin-bottom: 0;
     border-top: 0;
 }
-.global-nav{
-    position: relative;
+/* ヘッダー(グローバルナビ)は Bootstrap のグリッド/float をやめ、Flexbox の 1 行レイアウトにする。
+   カラム落ちを防ぐため flex-wrap: nowrap を基本とし、各要素は min-width: 0 で縮められるようにする。 */
+.global-nav {
+  position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  min-height: 42px;
+  padding: 0;
 }
-.global-nav .global-actions{
-    padding-right:15px;
+.global-nav .global-actions {
+  padding-right: 15px;
 }
 .app-nav{
     position: relative;
@@ -123,13 +130,6 @@ body > .mCSB_inside > .mCSB_container{
     min-height: inherit;
 }
 @media (min-width: 992px) {
-    .global-nav .logo-container{
-        display: inline-block;
-        width: 150px;
-        z-index: 2;
-        padding-left: 6%;
-        margin-top: 1px;
-    }
     .app-nav .module-action-bar {
         padding-left: 42px;
         top:0px;
@@ -224,17 +224,21 @@ body > .mCSB_inside > .mCSB_container{
 /******** Navigation styles *******/
 /**********************************/
 
-.company-logo{
-    height: 40px;
-    width: 180px;
-    margin: 0 0;
-    display: inline-block;
-    margin-left: 1px;
+/* ロゴは固定幅をやめ、上限だけ決めて縦横比を保ったまま収める */
+.company-logo {
+  height: 40px;
+  max-width: 180px;
+  margin: 0 0 0 1px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
 }
-
-.company-logo img{
-	max-height: 100%;
-	max-width: 100%;
+.company-logo img {
+  max-height: 40px;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 
 .navbar .fa{
@@ -253,23 +257,185 @@ body > .mCSB_inside > .mCSB_container{
 .global-nav .navbar-nav > li div a{
     padding : 13px;
 }
-#navbar > ul > li > div > div > a{
-    float: left;
-}
-
-#navbar > ul > li > div > a{
-    float: left;
-}
-
-.global-nav>ul{
-    margin-right: 20px;
-}
-
-.global-nav .search-links-container{
-    padding-right:15px;
-}
+/* 左端: アプリスイッチャー + ロゴ。縮まないが、はみ出しもしない */
 .global-nav .app-navigator-container {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-width: 0;
+  height: 42px;
+}
+.global-nav .app-switcher-container {
+  flex: 0 0 42px;
+  width: 42px;
+  height: 42px;
+}
+.global-nav .app-switcher-container .app-navigator {
+  height: 42px;
+}
+.global-nav .app-switcher-container .app-icon {
+  line-height: 42px;
+}
+.global-nav .logo-container {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  padding: 0 12px;
+}
+/* アプリメニュー(Web コンポーネント <app-menu>): 余った幅を吸収する。
+   min-width: 0 が無いとカスタム要素の中身が縮まず親を押し広げてしまう。
+   狭いときはコンポーネント側でラベルを ellipsis 省略する(AppMenu.tsx)。
+   ドロップダウンを切らないため、ここでは overflow: hidden を掛けない。 */
+.global-nav .app-list {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.global-nav .app-list app-menu,
+.global-nav .app-list .web-components-wrapper {
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+/* Radix NavigationMenu は Root(nav) と List(ul) の間に class の無い div を挟む。
+   これは min-width: auto のままだとメニューの min-content 幅で突っ張ってしまい、
+   ヘッダーを押し広げるので明示的に 0 にする。 */
+.global-nav .app-list app-menu nav > div {
+  min-width: 0;
+}
+/* Bootstrap は .navbar > .container-fluid 直下の .navbar-header / .navbar-collapse に
+   margin-left/right: -15px を当てて container の左右 padding を打ち消している。
+   .global-nav の padding を 0 にしたので、この負マージンは 15px のはみ出しになる。 */
+.global-nav .navbar-header,
+.global-nav .search-links-container,
+.global-nav .global-actions {
+  margin-left: 0;
+  margin-right: 0;
+}
+/* グローバル検索: 基準幅 300px から縮む。.search-link は Workflows 画面でも
+   使い回されているため、ヘッダー側だけ .global-nav で限定して上書きする。 */
+.global-nav .search-links-container {
+  padding-right: 15px;
+  flex: 0 6 300px;
+  min-width: 0;
+}
+/* アプリメニューを出す幅(>=992px)では、検索欄が潰れきらないよう下限を持たせる。
+   アプリメニューのラベルが先に省略されるより検索欄が狭くなるほうがまし、という優先順位。
+   991px 以下はアプリメニュー自体を出さないので下限は不要(アイコンが増えた場合に効く)。 */
+@media (min-width: 992px) {
+  .global-nav .search-links-container {
+    min-width: 130px;
+  }
+}
+.global-nav .search-link {
+  display: flex;
+  align-items: center;
+  float: none;
+  flex: 1 1 auto;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  margin: 0;
+}
+.global-nav .search-link .keyword-input {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0 0 0 5px;
+}
+.global-nav .search-link .adv-search {
+  flex: 0 0 auto;
+  margin-top: 0;
+  margin-inline-start: auto;
+  padding-left: 5px;
+}
+/* 右端: グローバルアクション。pull-right / float ではなく margin-inline-start:auto で右寄せ */
+.global-nav .global-actions {
+  flex: 0 0 auto;
+  min-width: 0;
+  margin-inline-start: auto;
+}
+/* スマホ用トグル(虫めがね / アプリ)。こちらも auto マージンで右寄せ */
+.global-nav .navbar-header {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+}
+/* アイコン列。元は li 内の a を float: left して横並びにしていた(li の高さが 0 に
+   潰れる作り)ので、flex に置き換える。スマホでトグルを開いたときも横 1 列を保つため、
+   これは @media で囲わず全幅で効かせる。 */
+.global-nav .global-actions .navbar-nav {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  float: none;
+  margin: 0;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+}
+.global-nav .global-actions .navbar-nav > li > div > a,
+.global-nav .global-actions .navbar-nav > li > div > div > a {
+  display: flex;
+  align-items: center;
+  float: none;
+  min-height: 42px;
+  padding: 0 13px;
+}
+/* デスクトップ: collapse 対象の 2 ブロックも 1 行の flex アイテムとして並べる。
+   Bootstrap の .navbar-collapse.collapse{display:block!important} を上書きする必要がある。 */
+@media (min-width: 768px) {
+  .global-nav .search-links-container.collapse,
+  .global-nav .global-actions.collapse {
+    display: flex !important;
+    align-items: center;
+    width: auto;
+  }
+  .global-nav .global-actions .navbar-nav {
+    flex-wrap: nowrap;
     height: 42px;
+  }
+  .global-nav .global-actions .navbar-nav > li {
+    height: 42px;
+  }
+  /* li の中の入れ物も flex にして高さを揃える。.dropdown-menu を除外するのは、
+     display: flex が Bootstrap の display: none(閉じた状態)を打ち消してしまうため。
+     スマホ幅では Bootstrap が開いた .dropdown-menu を position: static にするので、
+     ここを flex にするとパネルがトリガーの横に並んでしまう。よってデスクトップ限定。 */
+  .global-nav .global-actions .navbar-nav > li > div:not(.dropdown-menu),
+  .global-nav .global-actions .navbar-nav > li > div > div:not(.dropdown-menu) {
+    display: flex;
+    align-items: center;
+    height: 42px;
+  }
+}
+/* スマホ: トグルで開く 2 ブロックだけは行を分ける(collapse の開閉挙動を維持するため)。
+   ユーザー名の項目は元が pull-right だったので、auto マージンで右端に寄せる。 */
+@media (max-width: 767px) {
+  .global-nav {
+    flex-wrap: wrap;
+  }
+  .global-nav .search-links-container,
+  .global-nav .global-actions {
+    flex: 1 0 100%;
+    margin-inline-start: 0;
+  }
+  .global-nav .global-actions .navbar-nav > li.dropdown:last-child {
+    margin-inline-start: auto;
+  }
+  /* 開いたドロップダウンが static になって li が縦に伸びても、
+     他のアイコンが釣られて中央寄せにならないようにする */
+  .global-nav .global-actions .navbar-nav {
+    align-items: flex-start;
+  }
 }
 .link-text-xs-only{
     padding: 0px 15px;
@@ -320,16 +486,8 @@ body > .mCSB_inside > .mCSB_container{
     .module-action-bar .navbar-right .nav>li a{
         padding: 0 10px;
     }
-    .global-nav .logo-container{
-        border-bottom: 0;
-        width: 150px;
-    }
 }
 @media (max-width: 991px) {
-    .global-nav .logo-container{
-        border-bottom: 0;
-        width: 150px;
-    }
     .notificationMessageHolder {
         padding-left: 45%;
     }

--- a/public/resources/styles.css
+++ b/public/resources/styles.css
@@ -380,14 +380,6 @@ div.detailview-content.container-fluid span.value img {
 .textOverflowTest{
 	width: 600px;
 }
-@media all and (min-width:992px) and (max-width: 1290px) {
-    .global-nav .app-list {
-        display: none;
-    }
-}
-.app-navigator-container {
-  width: 222px;
-}
 /*
  * カスタム項目編集画面
  */


### PR DESCRIPTION
Close #1815

## 概要

ヘッダー(グローバルナビ)を Bootstrap 3 のグリッド／float ベースから **Flexbox ベースに書き直しました**。

`.global-nav > .row` 直下の `col-sm-*` が 2+5+3+3=**13** で 12 を超えていたため、表示情報が増えると仕様どおり折り返してカラム落ちしていました。個別に幅や `@media` を足して都度対処するのをやめ、レイアウトの組み方自体を置き換えています。

## 変更内容

| ファイル | 内容 |
|---|---|
| `layouts/v7/modules/Vtiger/partials/Topbar.tpl` | `.global-nav` 直下を 5 つの flex アイテムに平坦化。`col-*` / `.row` ラッパー / `pull-left` / `pull-right` / `navbar-right` を撤去 |
| `public/layouts/v7/skins/vtiger/style.less` | ヘッダーの flex 定義本体 |
| `public/layouts/v7/skins/{contact,inventory,marketing,marketing_and_sales,project,sales,support,tools}/style.css` | 上記と**同一内容**をコンパイル済み CSS へ反映 |
| `public/resources/styles.css` | 崩れ打ち消し用の `@media` と固定幅を撤去 |
| `assets/react-web-components/src/components/AppMenu.tsx` | `min-w-0` を通し、ラベルを ellipsis 省略 |

### レイアウト

`.global-nav` を `display:flex` + `flex-wrap:nowrap` にし、直下を 5 つのアイテムにしました。

```
[アプリスイッチャー+ロゴ] [トグル] [アプリメニュー] [検索] [グローバルアクション]
 flex:0 0 auto            xs のみ   flex:1 1 auto    flex:0 6 300px  flex:0 0 auto
                                    min-width:0      min-width:0     margin-inline-start:auto
```

- 右寄せは `pull-right` / `float` ではなく `margin-inline-start: auto`
- `#navbar > ul > li > div > a` 等の `float:left` を削除し flex に置き換え
- セレクタが実際には一致していなかった dead rule `.global-nav>ul` を削除

### 固定幅・打ち消し `@media` の整理

- ロゴの固定幅 `150px` と、それを 3 箇所の `@media`(min-992 / max-768 / max-991)で打ち消していた指定を撤去し、`max-width` / `max-height` の上限指定に置き換え
- `styles.css` の **992〜1290px でアプリメニューを丸ごと非表示にしていた打ち消し**を撤去。この幅でもラベルを省略して表示されるようになります
- `styles.css` のヘッダー左端の固定幅 `.app-navigator-container { width: 222px }` を撤去

### 省略(ellipsis)による収まり

アプリメニューは Web コンポーネントなので `AppMenu.tsx` 側も対応しました。

- ホストが Flexbox になったため `min-w-0` を通す(これが無いとカスタム要素の中身が縮まず親を押し広げます)
- ラベルは折り返さず `truncate` で省略
- **`overflow: hidden` はラベルの span だけに掛けています。** 祖先に掛けるとドロップダウンが切られるためです
- Radix `NavigationMenu` が Root(nav) と List(ul) の間に挟む class の無い div が `min-width: auto` で突っ張るため、CSS 側で `min-width: 0` を明示しています

## 維持している挙動

- スマホ幅の `navbar-toggle` / `collapse`(`#navbar`, `#search-links-container`)の開閉。**開いたときのアイコン列も横 1 列**(元は `li` 内の `a` の `float:left` による横並び)
  - このためアイコン列の flex 化は `@media` で囲わず全幅で効かせています。ただし `li` 内側の入れ物の flex 化だけはデスクトップ限定です。スマホでは Bootstrap が開いた `.dropdown-menu` を `position:static` にするため、そこを flex にするとパネルがトリガーの横に並んでラベルが潰れます
- サイドバー開閉時のヘッダー表示
- JS が参照しているセレクタ(`.global-nav`, `.taskManagement`, `.search-link .keyword-input`, `#adv-search`, `#appnavigator`, `.app-icon`, `.app-navigator`, `#quickCreateModules` 等)
- `#page { padding-top: 84px }` の前提となる 42px 行高
- `.search-link` は Workflows 設定画面でも使い回されているため、ヘッダー側の上書きは `.global-nav` で限定

## コンパイル済み CSS を同時に更新している理由

`includes/runtime/Theme.php::getStylePath()` は `style.css` があればそれを返します。`skins/vtiger/` に `style.css` は無い一方、8 つのアプリスキンには commit された `style.css` があり、`$SELECTED_MENU_CATEGORY` は必ずそのいずれかに解決されるため、**実行時に配信されるのは常に `skins/<app>/style.css`** です(配信 HTML でも確認しました)。LESS だけ修正しても画面は変わりません。

リポジトリに LESS のビルド経路が無いため、既存コミット(`ffce48e8` など)と同様に LESS と 8 スキンの CSS へ同一内容を反映しています。`lessc` での再生成は無関係な巨大 diff になるため行わず、`.css.map` も従来どおり触っていません(既存も `C:/xampp/...` を指す stale な状態です)。

## 動作確認

Docker + Playwright で実測しました。ヘッダー直下の各要素の矩形を取得し、**行落ち・要素の重なり・はみ出し**を機械的に判定しています。

### カラム落ちの解消

375 / 768 / 992 / 1200 / 1440px × 6 シナリオ(通常 / アプリメニュー多数かつ長名 / 大きいロゴ / 縦長ロゴ / アイコン増加 / 全部同時)の **全 30 組**で、1 行維持・重なり無し・右端が viewport 幅と一致(はみ出し無し)・横スクロール無しを確認。

| ケース | 変更前のヘッダー高 | 変更後 |
|---|---|---|
| 通常 | 85px | 84〜85px |
| アイコン増加(768〜1440px) | **127〜129px (2段組み)** | 84〜85px |
| アプリメニュー多数かつ長名(1440px) | ラベルが3行に折り返して溢れる | 1行・ellipsis で省略 |

### レスポンシブ・その他

- 大きいロゴ 900×150、縦長ロゴ 200×500 のいずれも縦横比を保って 42px 行内に収まる
- スマホ collapse: 閉 85px → アプリトグル開 128px(アイコン横1列) → 検索トグル開 118px
- アプリメニューのドロップダウンが切れない(1440px で高さ 200px、992px で 52px、クリップしている祖先なし)
- 全スキン(MARKETING / SALES / SUPPORT / INVENTORY / PROJECT / TOOLS)で 1 行維持、サイドバー開閉時も維持
- 機能回帰: クイック作成・ユーザーメニュー・タスク管理オーバーレイ(矢印の追従位置まで)・詳細検索・サイドバーアプリメニュー(`#appnavigator`、e2e と同等)・スマホのドロップダウン・`.search-link` を使い回している Workflows 設定画面 — いずれも正常
- web-components: `npm run lint` エラー 0、`npm run build` 成功、**vitest 293 件全パス**
- 8 スキンの CSS 変更内容がすべて同一であることを確認

## レビューで見ていただきたい点

1. コンパイル済み `style.css` を手で反映する方針(`.css.map` は更新しない)で問題ないか
2. 1200px 前後でアプリメニューのラベルが省略されます。従来はこの幅でメニュー自体が非表示だったので改善ではありますが、省略より非表示のほうが良いというご意見があれば調整します
3. **既知の制約**: ヘッダー右のアイコンが入りきらないほど増えた場合、折り返さない代わりに右端で切れます(アプリメニュー→検索欄の順に幅を譲るため実運用の構成では発生しません)。恒久対応にはグローバルアクション側のオーバーフローメニューが必要で、レイアウト修正ではなく機能追加になるため本 PR のスコープ外としています

## 未確認

- 目視確認は Chromium のみです(Safari / Firefox は未確認)。`margin-inline-start` と `:not()` を使用しています
- グローバル検索の Enter が結果を表示しない事象がありましたが、**変更前のコードでも同一の挙動**でした(同じスクリプトで比較済み)。この検証環境固有か既存不具合かは切り分けていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
