### PR TITLE
[修正] #1817 概要ページの活動ペインからのステータス変更で行動種別・公開範囲が上書きされる問題

### DIFF
--- a/assets/react-web-components/src/components/ActivityList/hooks/__tests__/useActivityStatusUpdate.test.ts
+++ b/assets/react-web-components/src/components/ActivityList/hooks/__tests__/useActivityStatusUpdate.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useActivityStatusUpdate } from "../useActivityStatusUpdate";
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/**
+ * CSRFトークン用の hidden input を DOM に用意する
+ */
+const setupCsrfToken = (token = "dummy-token") => {
+  const input = document.createElement("input");
+  input.type = "hidden";
+  input.name = "__vtrftk";
+  input.value = token;
+  document.body.appendChild(input);
+};
+
+/**
+ * fetch に渡された FormData を取得する
+ */
+const getSentFormData = (): FormData => {
+  const [, init] = mockFetch.mock.calls[0];
+  return init.body as FormData;
+};
+
+describe("useActivityStatusUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+    setupCsrfToken();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: {} }),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  describe("activitytype の送信", () => {
+    it("行動(Meeting)のステータス更新時に activitytype を送信する", async () => {
+      const { result } = renderHook(() => useActivityStatusUpdate());
+
+      await act(async () => {
+        await result.current.updateStatus(
+          "165",
+          "eventstatus",
+          "Held",
+          "Meeting",
+        );
+      });
+
+      expect(getSentFormData().get("activitytype")).toBe("Meeting");
+    });
+
+    it("行動(Call)のステータス更新時に activitytype を送信する", async () => {
+      const { result } = renderHook(() => useActivityStatusUpdate());
+
+      await act(async () => {
+        await result.current.updateStatus("160", "eventstatus", "Held", "Call");
+      });
+
+      expect(getSentFormData().get("activitytype")).toBe("Call");
+    });
+
+    it("ToDo(Task)のステータス更新時に activitytype を送信する", async () => {
+      const { result } = renderHook(() => useActivityStatusUpdate());
+
+      await act(async () => {
+        await result.current.updateStatus(
+          "163",
+          "taskstatus",
+          "Completed",
+          "Task",
+        );
+      });
+
+      expect(getSentFormData().get("activitytype")).toBe("Task");
+    });
+  });
+
+  describe("calendarModule の判定", () => {
+    it("Meeting は calendarModule=Events で送信する", async () => {
+      const { result } = renderHook(() => useActivityStatusUpdate());
+
+      await act(async () => {
+        await result.current.updateStatus(
+          "165",
+          "eventstatus",
+          "Held",
+          "Meeting",
+        );
+      });
+
+      expect(getSentFormData().get("calendarModule")).toBe("Events");
+    });
+
+    it("Task は calendarModule=Calendar で送信する", async () => {
+      const { result } = renderHook(() => useActivityStatusUpdate());
+
+      await act(async () => {
+        await result.current.updateStatus(
+          "163",
+          "taskstatus",
+          "Completed",
+          "Task",
+        );
+      });
+
+      expect(getSentFormData().get("calendarModule")).toBe("Calendar");
+    });
+  });
+});

--- a/assets/react-web-components/src/components/ActivityList/hooks/useActivityStatusUpdate.ts
+++ b/assets/react-web-components/src/components/ActivityList/hooks/useActivityStatusUpdate.ts
@@ -95,6 +95,7 @@ export function useActivityStatusUpdate(): UseActivityStatusUpdateResult {
         formData.append("__vtrftk", csrfToken);
         formData.append("module", "Calendar");
         formData.append("calendarModule", calendarModule);
+        formData.append("activitytype", activityType);
         formData.append("action", "SaveAjax");
         formData.append("record", activityId);
         formData.append("field", fieldName);

--- a/e2e/test/activityPane.spec.ts
+++ b/e2e/test/activityPane.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "@playwright/test";
+import { format, addDays } from "date-fns";
+import { login, frCreate, frRetrieve } from "../model/fetcher";
+import { url, generateRandomString } from "../utils/util";
+
+/**
+ * 概要ページ(サマリー)の活動ペインからステータスを変更したときに、
+ * リクエストへ含まれない項目が既定値で上書きされないことを検証する。
+ *
+ * 上書きが起きると「行動(Call/Meeting)がToDo(Task)に変わる」
+ * 「非公開の活動が公開になる」といった不具合になる。
+ */
+
+/** API セッション名 */
+let sessionName = "";
+/** 担当者(admin)の Webservice ID */
+let ownerWsId = "";
+
+/** Webservice ID (`<prefix>x<recordId>`) からレコードIDを取り出す */
+const toRecordId = (webserviceId: string) => webserviceId.split("x")[1];
+
+/** 活動の親となる案件をAPIで作成する */
+const createPotential = async (hash: string) => {
+  const created = await frCreate(sessionName, "Potentials", {
+    potentialname: `E2E活動ペイン_${hash}`,
+    closingdate: format(addDays(new Date(), 30), "yyyy-MM-dd"),
+    assigned_user_id: ownerWsId,
+    sales_stage: "Prospecting",
+  });
+  if (!created) {
+    throw new Error("案件の作成に失敗しました");
+  }
+  return created.id;
+};
+
+/** 行動(電話・非公開)をAPIで作成する */
+const createCall = async (parentId: string, hash: string) => {
+  const day = format(addDays(new Date(), 1), "yyyy-MM-dd");
+  const created = await frCreate(sessionName, "Events", {
+    subject: `E2E行動_${hash}`,
+    assigned_user_id: ownerWsId,
+    date_start: day,
+    time_start: "10:00",
+    due_date: day,
+    time_end: "11:00",
+    duration_hours: "1",
+    eventstatus: "Planned",
+    activitytype: "Call",
+    visibility: "Private",
+    parent_id: parentId,
+  });
+  if (!created) {
+    throw new Error("行動の作成に失敗しました");
+  }
+  return created.id;
+};
+
+/** ToDo(非公開)をAPIで作成する */
+const createTask = async (parentId: string, hash: string) => {
+  const created = await frCreate(sessionName, "Calendar", {
+    subject: `E2EToDo_${hash}`,
+    assigned_user_id: ownerWsId,
+    date_start: format(addDays(new Date(), 1), "yyyy-MM-dd"),
+    time_start: "10:00",
+    due_date: format(addDays(new Date(), 2), "yyyy-MM-dd"),
+    taskstatus: "Not Started",
+    activitytype: "Task",
+    visibility: "Private",
+    parent_id: parentId,
+  });
+  if (!created) {
+    throw new Error("ToDoの作成に失敗しました");
+  }
+  return created.id;
+};
+
+// APIログイン(getchallenge)を同時に走らせるとトークンが競合するため直列で実行する
+test.describe.serial("概要ページの活動ペイン", () => {
+  test.beforeAll(async () => {
+    const response = await login(
+      process.env.E2E_USER_NAME || "",
+      process.env.E2E_USER_ACCESSKEY || ""
+    );
+    if (!response) {
+      throw new Error("API login failed (activityPane)");
+    }
+    sessionName = response.sessionName;
+    ownerWsId = response.userId;
+  });
+
+  test("行動のステータス変更で行動種別と公開範囲が変わらない", async ({
+    page,
+  }) => {
+    const hash = generateRandomString(8);
+    const potentialId = await createPotential(hash);
+    const eventId = await createCall(potentialId, hash);
+
+    await page.goto(
+      url(
+        `index.php?module=Potentials&view=Detail&record=${toRecordId(
+          potentialId
+        )}`
+      )
+    );
+
+    const pane = page.locator("#relatedActivities");
+    await expect(pane.getByTitle(`E2E行動_${hash}`)).toBeVisible();
+
+    // ステータスのバッジをクリックして編集モードにし、「完了」へ変更する
+    await pane
+      .getByRole("button", { name: "計画済み - クリックして編集" })
+      .click();
+    await pane.getByLabel("Select eventstatus").click();
+    await page.getByRole("option", { name: "完了" }).click();
+    await pane.getByRole("button", { name: "保存" }).click();
+
+    // 一覧が再取得され、バッジが「完了」になる
+    await expect(
+      pane.getByRole("button", { name: "完了 - クリックして編集" })
+    ).toBeVisible();
+
+    // 保存値はステータスだけが変わり、行動種別・公開範囲は元のまま
+    const record = (await frRetrieve(sessionName, eventId)) as Record<
+      string,
+      string
+    >;
+    expect(record).toBeTruthy();
+    expect(record.eventstatus).toBe("Held");
+    expect(record.activitytype).toBe("Call");
+    expect(record.visibility).toBe("Private");
+  });
+
+  test("ToDoのステータス変更で行動種別と公開範囲が変わらない", async ({
+    page,
+  }) => {
+    const hash = generateRandomString(8);
+    const potentialId = await createPotential(hash);
+    const taskId = await createTask(potentialId, hash);
+
+    await page.goto(
+      url(
+        `index.php?module=Potentials&view=Detail&record=${toRecordId(
+          potentialId
+        )}`
+      )
+    );
+
+    const pane = page.locator("#relatedActivities");
+    await expect(pane.getByTitle(`E2EToDo_${hash}`)).toBeVisible();
+
+    // ステータスのバッジをクリックして編集モードにし、「完了」へ変更する
+    await pane
+      .getByRole("button", { name: "未着手 - クリックして編集" })
+      .click();
+    await pane.getByLabel("Select taskstatus").click();
+    await page.getByRole("option", { name: "完了" }).click();
+    await pane.getByRole("button", { name: "保存" }).click();
+
+    // 一覧が再取得され、バッジが「完了」になる
+    await expect(
+      pane.getByRole("button", { name: "完了 - クリックして編集" })
+    ).toBeVisible();
+
+    // 保存値はステータスだけが変わり、行動種別・公開範囲は元のまま
+    const record = (await frRetrieve(sessionName, taskId)) as Record<
+      string,
+      string
+    >;
+    expect(record).toBeTruthy();
+    expect(record.taskstatus).toBe("Completed");
+    expect(record.activitytype).toBe("Task");
+    expect(record.visibility).toBe("Private");
+  });
+});

--- a/modules/Calendar/actions/SaveAjax.php
+++ b/modules/Calendar/actions/SaveAjax.php
@@ -134,7 +134,11 @@ class Calendar_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 	public function getRecordModelFromRequest(Vtiger_Request $request) {
 		$recordModel = parent::getRecordModelFromRequest($request);
 
-		$recordModel->set("is_allday", $_REQUEST['is_allday'] == "on" ? true : false);
+		// リクエストに is_allday が含まれない編集（インライン編集など）では、既存の終日設定を変更しない
+		// （set しなければ CRMEntity::setAllDay() は DB の値を読むだけで更新しない）
+		if ($request->has('is_allday')) {
+			$recordModel->set("is_allday", $request->get('is_allday') == "on" ? true : false);
+		}
 
 		$startDate = $request->get('date_start');
 		if(!empty($startDate)) {
@@ -201,11 +205,15 @@ class Calendar_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 
 		$activityType = $request->get('activitytype');
 		$visibility = $request->get('visibility');
-		if(empty($activityType)) {
+		// 編集時にリクエストへ activitytype が含まれない場合、既存の値を保持する
+		// （インライン編集で行動が ToDo に変わってしまう問題への対応）
+		if(empty($activityType) && empty($recordModel->get('activitytype'))) {
 			$recordModel->set('activitytype', 'Task');
 		}
 
-		if(empty($visibility)) {
+		// 編集時にリクエストへ visibility が含まれない場合、既存の値を保持する
+		// （インライン編集で非公開の活動が公開に変わってしまう問題への対応）
+		if(empty($visibility) && empty($recordModel->get('visibility'))) {
 			$assignedUserId = $recordModel->get('assigned_user_id');
 			$sharedType = Calendar_Module_Model::getSharedType($assignedUserId);
 			if($sharedType == 'selectedusers') {
@@ -214,11 +222,12 @@ class Calendar_SaveAjax_Action extends Vtiger_SaveAjax_Action {
 			$recordModel->set('visibility', ucfirst($sharedType));
 		}
 
-		$setReminder = $request->get('set_reminder');
-		if($setReminder) {
-			$_REQUEST['set_reminder'] = 'Yes';
+		// リクエストに set_reminder が含まれない編集（インライン編集など）では、既存のリマインダー設定を変更しない
+		// （Activity::insertIntoReminderTable は 'Yes'/'No' 以外の値では何も処理しない）
+		if($request->has('set_reminder')) {
+			$_REQUEST['set_reminder'] = $request->get('set_reminder') ? 'Yes' : 'No';
 		} else {
-			$_REQUEST['set_reminder'] = 'No';
+			$_REQUEST['set_reminder'] = '';
 		}
 
 		return $recordModel;

--- a/modules/Events/actions/SaveAjax.php
+++ b/modules/Events/actions/SaveAjax.php
@@ -161,7 +161,11 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 			$this->setRecurrenceInfo($recordModel);
 		}
 
-		$recordModel->set("is_allday", $_REQUEST['is_allday'] == "on" ? true : false);
+		// リクエストに is_allday が含まれない編集（インライン編集など）では、既存の終日設定を変更しない
+		// （set しなければ CRMEntity::setAllDay() は DB の値を読むだけで更新しない）
+		if ($request->has('is_allday')) {
+			$recordModel->set("is_allday", $request->get('is_allday') == "on" ? true : false);
+		}
 
 		$startDate = $request->get('date_start');
 		if (!empty($startDate)) {
@@ -200,11 +204,15 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 
 		$activityType = $request->get('activitytype');
 		$visibility = $request->get('visibility');
-		if (empty($activityType)) {
+		// 編集時にリクエストへ activitytype が含まれない場合、既存の値を保持する
+		// （インライン編集で行動が ToDo に変わってしまう問題への対応）
+		if (empty($activityType) && empty($recordModel->get('activitytype'))) {
 			$recordModel->set('activitytype', 'Task');
 		}
 
-		if (empty($visibility)) {
+		// 編集時にリクエストへ visibility が含まれない場合、既存の値を保持する
+		// （インライン編集で非公開の活動が公開に変わってしまう問題への対応）
+		if (empty($visibility) && empty($recordModel->get('visibility'))) {
 			$assignedUserId = $recordModel->get('assigned_user_id');
 			$sharedType = Calendar_Module_Model::getSharedType($assignedUserId);
 			if ($sharedType == 'selectedusers') {
@@ -213,11 +221,12 @@ class Events_SaveAjax_Action extends Events_Save_Action {
 			$recordModel->set('visibility', ucfirst($sharedType));
 		}
 
-		$setReminder = $request->get('set_reminder');
-		if ($setReminder) {
-			$_REQUEST['set_reminder'] = 'Yes';
+		// リクエストに set_reminder が含まれない編集（インライン編集など）では、既存のリマインダー設定を変更しない
+		// （Activity::insertIntoReminderTable は 'Yes'/'No' 以外の値では何も処理しない）
+		if ($request->has('set_reminder')) {
+			$_REQUEST['set_reminder'] = $request->get('set_reminder') ? 'Yes' : 'No';
 		} else {
-			$_REQUEST['set_reminder'] = 'No';
+			$_REQUEST['set_reminder'] = '';
 		}
 
 		return $recordModel;


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1817

##  不具合の内容 / Bug
1. 案件などの概要ページの活動ペインから活動のステータスを変更すると、変更していない項目が初期値で上書きされる。
   - 行動種別（activitytype）: 「電話」「打ち合わせ」が「ToDo」に変わる
   - 公開範囲（visibility）: 「非公開」が「公開」に変わる
   - 終日（allday）: ON が OFF に変わる
   - リマインダー（set_reminder）: 設定済みのリマインダーが解除される

##  原因 / Cause
1. `modules/Calendar/actions/SaveAjax.php` / `modules/Events/actions/SaveAjax.php` の `getRecordModelFromRequest()` が、リクエストに項目が含まれない場合に既存レコードの値を確認せず既定値を設定していた。インライン編集は変更した項目のみを送信するため、編集時にも新規作成と同じ既定値が書き込まれていた。
   - `activitytype`: リクエストが空なら無条件で `'Task'` を設定
   - `visibility`: リクエストが空ならカレンダー共有設定の既定値を設定
   - `is_allday`: `$_REQUEST['is_allday']` を直接参照し、未送信時は常に `false` を設定
   - `set_reminder`: 未送信時は `'No'` を設定するため `Activity::insertIntoReminderTable()` がリマインダーを削除

##  変更内容 / Details of Change
1. `modules/Calendar/actions/SaveAjax.php` / `modules/Events/actions/SaveAjax.php`
   - `activitytype`・`visibility`: リクエストが空かつ既存レコードの値も空の場合のみ既定値を設定するよう変更（編集時は既存値を維持）
   - `is_allday`: `$request->has('is_allday')` の場合のみ `set` するよう変更。未送信時は `set` しないため `Activity::setAllDay()` は DB の値を読むだけで更新しない
   - `set_reminder`: `$request->has('set_reminder')` の場合のみ `'Yes'` / `'No'` を設定し、未送信時は空文字を設定。`Activity::insertIntoReminderTable()` は `'Yes'` / `'No'` 以外では何も処理しないため既存のリマインダーが保持される
1. `assets/react-web-components/.../useActivityStatusUpdate.ts`
   - ステータス更新リクエストに `activitytype` を含めるよう変更
1. テスト追加
   - `useActivityStatusUpdate.test.ts`（vitest）: `activitytype` / `calendarModule` の送信内容を検証（5件）
   - `e2e/test/activityPane.spec.ts`（Playwright）: 概要ページの活動ペインからステータスを変更し、行動・ToDo それぞれで行動種別と公開範囲が変わらないことを検証（2件）

## スクリーンショット / Screenshot
画面表示の変更はないため添付なし。保存値の変化は E2E テストで検証しています。

## 影響範囲  / Affected Area
- 活動（Calendar / Events）の `SaveAjax` 経由の保存全般
  - 概要ページの活動ペインからのステータス変更
  - 詳細画面・一覧画面のインライン編集
  - カレンダー画面でのドラッグ操作による日時変更
- 上記経路では、これまで既定値で上書きされていた行動種別・公開範囲・終日・リマインダーが保持されるようになります。リクエストに項目が含まれる場合（フルフォームの編集画面・クイック編集）の挙動は従来どおりです。
- 新規作成時は既存値が空のため、従来どおり既定値が設定されます。
- `assets/react-web-components` の活動ペイン（ActivityList）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- テスト結果
  - vitest: `src/components/ActivityList` 配下 34件 pass
  - Playwright（E2E）: 追加した2件を含め pass。修正前のコードに戻して実行すると、行動・ToDo の両テストが `Expected: "Private" / Received: "Public"` で失敗することを確認済み
  - 手動検証（SaveAjax を直接呼び出して DB を確認）: 修正前は `Call → Task` / `Private → Public` / `allday 1 → 0` / リマインダー削除が発生。修正後はステータスのみ更新され、招待者・通知設定も保持されることを確認
- 言語対応: 言語ファイルの追加・変更が発生しない修正のため「該当なし」としてチェックしています。
- 副作用の確認として、招待者（`Activity.php` の `loadInvitees()`）・繰り返し設定（`Events_SaveAjax_Action::setRecurrenceInfo()`）・日時項目は既存実装でリクエスト未送信時に既存値を復元しているため、今回の変更対象外としています。