### PR TITLE
Fix/1688-[不具合] WebComponents の text-md が 12px で text-sm と差異なし

### DIFF
--- a/assets/react-web-components/src/components/ActivityList/ActivityList.tsx
+++ b/assets/react-web-components/src/components/ActivityList/ActivityList.tsx
@@ -140,7 +140,7 @@ const ActivityListInner: React.FC<ActivityListProps> = ({
             className="h-12 w-12 text-gray-400 mb-3"
             aria-hidden="true"
           />
-          <p className="text-md text-gray-600">
+          <p className="text-sm text-gray-600">
             {t("LBL_NO_PENDING_ACTIVITIES")}
           </p>
         </div>
@@ -170,7 +170,7 @@ const ActivityListInner: React.FC<ActivityListProps> = ({
             size="lg"
             onClick={loadMore}
             disabled={loading}
-            className="w-full h-8 text-md"
+            className="w-full h-8 text-sm"
           >
             {loading ? (
               <>

--- a/assets/react-web-components/src/components/ActivityList/ActivityListItem.tsx
+++ b/assets/react-web-components/src/components/ActivityList/ActivityListItem.tsx
@@ -126,7 +126,7 @@ const CollapsibleText: React.FC<{ text: string; label?: string }> = ({
       <div
         ref={contentRef}
         className={cn(
-          "whitespace-pre-wrap text-gray-600 text-md",
+          "whitespace-pre-wrap text-gray-600 text-sm",
           !expanded && needsCollapse && "line-clamp-2",
         )}
       >
@@ -196,7 +196,7 @@ export const ActivityListItem: React.FC<ActivityListItemProps> = ({
           {formattedDateTime && (
             <time
               dateTime={`${activity.dateStart}T${activity.timeStart}`}
-              className="text-md text-gray-500"
+              className="text-sm text-gray-500"
             >
               {formattedDateTime}
             </time>
@@ -228,7 +228,7 @@ export const ActivityListItem: React.FC<ActivityListItemProps> = ({
 
         {/* Row 2: 件名 */}
         <div
-          className="font-bold text-gray-900 text-md truncate mb-1"
+          className="font-bold text-gray-900 text-sm truncate mb-1"
           title={activity.subject}
         >
           {activity.subject}

--- a/assets/react-web-components/src/components/ActivityList/ActivityStatusEditor.tsx
+++ b/assets/react-web-components/src/components/ActivityList/ActivityStatusEditor.tsx
@@ -175,7 +175,7 @@ export const ActivityStatusEditor: React.FC<ActivityStatusEditorProps> = ({
       <Badge
         variant={statusVariant}
         className={cn(
-          "px-4 text-md",
+          "px-4 text-sm",
           canEdit && [
             "cursor-pointer",
             "hover:ring-2 hover:ring-offset-1 hover:ring-blue-400",
@@ -210,7 +210,7 @@ export const ActivityStatusEditor: React.FC<ActivityStatusEditorProps> = ({
         disabled={isSaving}
       >
         <SelectTrigger
-          className="h-6 min-w-[120px] text-md"
+          className="h-6 min-w-[120px] text-sm"
           aria-label={`Select ${fieldName}`}
         >
           <SelectValue placeholder="選択..." />

--- a/assets/react-web-components/src/components/CurrencyListField.tsx
+++ b/assets/react-web-components/src/components/CurrencyListField.tsx
@@ -289,7 +289,7 @@ export const CurrencyListField: React.FC<CurrencyListFieldProps> = ({
                 key={option.value}
                 onClick={() => handleSelectOption(option)}
                 className={cn(
-                  "px-3 py-1.5 text-md cursor-pointer hover:bg-blue-50",
+                  "px-3 py-1.5 text-sm cursor-pointer hover:bg-blue-50",
                   value === option.value && "bg-blue-100",
                 )}
               >
@@ -298,7 +298,7 @@ export const CurrencyListField: React.FC<CurrencyListFieldProps> = ({
             ))}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             {t("LBL_NO_MATCHING_CURRENCY")}
           </div>
         )}
@@ -313,7 +313,7 @@ export const CurrencyListField: React.FC<CurrencyListFieldProps> = ({
       {/* ラベル（旧版スタイル：右寄せ） */}
       <span
         className={cn(
-          "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+          "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
           disabled && "text-gray-400",
         )}
       >

--- a/assets/react-web-components/src/components/FieldRenderer.tsx
+++ b/assets/react-web-components/src/components/FieldRenderer.tsx
@@ -228,7 +228,7 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
         <div className="flex items-baseline md:contents">
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
               labelClassName,
             )}
@@ -253,7 +253,7 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
       <>
         <span
           className={cn(
-            "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+            "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
             disabled && "text-gray-400",
           )}
         >
@@ -718,7 +718,7 @@ export const FieldRenderer: React.FC<FieldRendererProps> = ({
           <>
             <span
               className={cn(
-                "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+                "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
                 (disabled || field.readonly) && "text-gray-400",
               )}
             >

--- a/assets/react-web-components/src/components/MultiPicklistField.tsx
+++ b/assets/react-web-components/src/components/MultiPicklistField.tsx
@@ -327,7 +327,7 @@ export const MultiPicklistField: React.FC<MultiPicklistFieldProps> = ({
                 key={option.value}
                 onClick={() => handleSelectOption(option.value)}
                 className={cn(
-                  "px-3 py-1.5 text-md cursor-pointer",
+                  "px-3 py-1.5 text-sm cursor-pointer",
                   index === highlightedIndex
                     ? "bg-blue-100"
                     : "hover:bg-blue-50",
@@ -338,7 +338,7 @@ export const MultiPicklistField: React.FC<MultiPicklistFieldProps> = ({
             ))}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             {selectedValues.length > 0
               ? t("LBL_ALL_OPTIONS_SELECTED")
               : t("LBL_NO_OPTIONS_AVAILABLE")}
@@ -356,7 +356,7 @@ export const MultiPicklistField: React.FC<MultiPicklistFieldProps> = ({
         <div className="flex items-baseline md:contents">
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
               labelClassName,
             )}
@@ -378,7 +378,7 @@ export const MultiPicklistField: React.FC<MultiPicklistFieldProps> = ({
         <>
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
             )}
           >
@@ -434,7 +434,7 @@ export const MultiPicklistField: React.FC<MultiPicklistFieldProps> = ({
             {selectedValues.map((val) => (
               <div
                 key={val}
-                className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-md"
+                className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-sm"
               >
                 <span className="pl-3 pr-6 py-1.5">{getLabel(val)}</span>
                 {!disabled && (

--- a/assets/react-web-components/src/components/MultireferenceField.tsx
+++ b/assets/react-web-components/src/components/MultireferenceField.tsx
@@ -431,7 +431,7 @@ export const MultireferenceField: React.FC<MultireferenceFieldProps> = ({
               key={mod}
               onClick={() => handleModuleSelect(mod)}
               className={cn(
-                "px-3 py-1.5 text-md cursor-pointer hover:bg-blue-50",
+                "px-3 py-1.5 text-sm cursor-pointer hover:bg-blue-50",
                 selectedModule === mod && "bg-blue-100",
               )}
             >
@@ -466,7 +466,7 @@ export const MultireferenceField: React.FC<MultireferenceFieldProps> = ({
         }}
       >
         {isLoading ? (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             検索中...
           </div>
         ) : searchResults.length > 0 ? (
@@ -475,14 +475,14 @@ export const MultireferenceField: React.FC<MultireferenceFieldProps> = ({
               <div
                 key={record.id}
                 onClick={() => handleSelectRecord(record)}
-                className="px-3 py-1.5 text-md cursor-pointer hover:bg-blue-50"
+                className="px-3 py-1.5 text-sm cursor-pointer hover:bg-blue-50"
               >
                 {record.label}
               </div>
             ))}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             {searchTerm
               ? "該当するレコードがありません"
               : "レコードがありません"}
@@ -499,7 +499,7 @@ export const MultireferenceField: React.FC<MultireferenceFieldProps> = ({
       {/* ラベル（旧版スタイル：右寄せ） */}
       <span
         className={cn(
-          "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+          "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
           disabled && "text-gray-400",
         )}
       >
@@ -620,7 +620,7 @@ export const MultireferenceField: React.FC<MultireferenceFieldProps> = ({
             {selectedRecords.map((record) => (
               <div
                 key={record.id}
-                className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-md"
+                className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-sm"
               >
                 <span className="pl-3 pr-6 py-1.5">{record.label}</span>
                 {!disabled && (

--- a/assets/react-web-components/src/components/OwnerField.tsx
+++ b/assets/react-web-components/src/components/OwnerField.tsx
@@ -398,7 +398,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
                       key={`user_${user.id}`}
                       onClick={() => handleSelectOption(user)}
                       className={cn(
-                        "px-3 py-1.5 text-md cursor-pointer",
+                        "px-3 py-1.5 text-sm cursor-pointer",
                         globalIndex === highlightedIndex
                           ? "bg-blue-100"
                           : value === user.id
@@ -426,7 +426,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
                       key={`group_${group.id}`}
                       onClick={() => handleSelectOption(group)}
                       className={cn(
-                        "px-3 py-1.5 text-md cursor-pointer",
+                        "px-3 py-1.5 text-sm cursor-pointer",
                         globalIndex === highlightedIndex
                           ? "bg-blue-100"
                           : value === group.id
@@ -442,7 +442,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
             )}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             {t("LBL_NO_MATCHING_OWNER", "該当する担当者がいません")}
           </div>
         )}
@@ -458,7 +458,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
         <div className="flex items-baseline md:contents">
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
               labelClassName,
             )}
@@ -480,7 +480,7 @@ export const OwnerField: React.FC<OwnerFieldProps> = ({
         <>
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
             )}
           >

--- a/assets/react-web-components/src/components/PicklistField.tsx
+++ b/assets/react-web-components/src/components/PicklistField.tsx
@@ -353,7 +353,7 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
                 key={option.value}
                 onClick={() => handleSelectOption(option)}
                 className={cn(
-                  "px-3 py-1.5 text-md cursor-pointer",
+                  "px-3 py-1.5 text-sm cursor-pointer",
                   index === highlightedIndex
                     ? "bg-blue-100"
                     : value === option.value
@@ -366,7 +366,7 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
             ))}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             該当する選択肢がありません
           </div>
         )}
@@ -382,7 +382,7 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
         <div className="flex items-baseline md:contents">
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
               labelClassName,
             )}
@@ -404,7 +404,7 @@ export const PicklistField: React.FC<PicklistFieldProps> = ({
         <>
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
             )}
           >

--- a/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/CalendarForm.tsx
@@ -548,7 +548,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
         {/* ラベル - FieldRendererと同じスタイル */}
         <label
           className={cn(
-            "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+            "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
             isDisabled && "text-gray-400",
           )}
         >
@@ -702,7 +702,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
           <div className="flex items-start gap-2">
             <label
               className={cn(
-                "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+                "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
                 isDisabled && "text-gray-400",
               )}
             >
@@ -768,7 +768,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                     <div className="flex items-start gap-2">
                       <label
                         className={cn(
-                          "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
+                          "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
                           isDisabled && "text-gray-400",
                         )}
                       >
@@ -796,7 +796,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                           <label
                             htmlFor="reminder_enabled"
                             className={cn(
-                              "text-md text-gray-700 cursor-pointer !mb-0",
+                              "text-sm text-gray-700 cursor-pointer !mb-0",
                               isDisabled && "text-gray-400",
                             )}
                           >
@@ -804,7 +804,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                           </label>
                         </div>
                         {isReminderEnabled && (
-                          <div className="flex flex-wrap items-center gap-2 text-md mt-3 pt-3 pb-3 border-t border-gray-200">
+                          <div className="flex flex-wrap items-center gap-2 text-sm mt-3 pt-3 pb-3 border-t border-gray-200">
                             <span className="text-gray-700">
                               {t("LBL_START")}
                             </span>
@@ -818,7 +818,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                               }
                               disabled={isDisabled}
                               className={cn(
-                                "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                                "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                                 "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                                 "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                               )}
@@ -842,7 +842,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                               }
                               disabled={isDisabled}
                               className={cn(
-                                "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                                "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                                 "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                                 "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                               )}
@@ -866,7 +866,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                               }
                               disabled={isDisabled}
                               className={cn(
-                                "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                                "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                                 "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                                 "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                               )}
@@ -905,7 +905,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                   <div className="flex items-start gap-2">
                     <label
                       className={cn(
-                        "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
+                        "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
                         isDisabled && "text-gray-400",
                       )}
                     >
@@ -933,7 +933,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                         <label
                           htmlFor="reminder_enabled_standalone"
                           className={cn(
-                            "text-md text-gray-700 cursor-pointer !mb-0",
+                            "text-sm text-gray-700 cursor-pointer !mb-0",
                             isDisabled && "text-gray-400",
                           )}
                         >
@@ -941,7 +941,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                         </label>
                       </div>
                       {isReminderEnabled && (
-                        <div className="flex flex-wrap items-center gap-2 text-md mt-3 pt-3 pb-3 border-t border-gray-200">
+                        <div className="flex flex-wrap items-center gap-2 text-sm mt-3 pt-3 pb-3 border-t border-gray-200">
                           <span className="text-gray-700">
                             {t("LBL_START")}
                           </span>
@@ -955,7 +955,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                             }
                             disabled={isDisabled}
                             className={cn(
-                              "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                              "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                               "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                               "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                             )}
@@ -977,7 +977,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                             }
                             disabled={isDisabled}
                             className={cn(
-                              "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                              "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                               "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                               "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                             )}
@@ -1001,7 +1001,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                             }
                             disabled={isDisabled}
                             className={cn(
-                              "w-20 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+                              "w-20 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
                               "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
                               "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
                             )}
@@ -1038,7 +1038,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
               <div className="flex items-start gap-2">
                 <label
                   className={cn(
-                    "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
+                    "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-tight min-h-[54px] pt-[18px] flex items-start justify-end",
                     isDisabled && "text-gray-400",
                   )}
                 >
@@ -1071,7 +1071,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                       placeholder={t("LBL_SEARCH_USERS_PLACEHOLDER")}
                       disabled={isDisabled}
                       className={cn(
-                        "w-full h-[30px] px-3 border rounded-sm shadow-sm text-md",
+                        "w-full h-[30px] px-3 border rounded-sm shadow-sm text-sm",
                         "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500",
                         "disabled:bg-gray-100 disabled:text-gray-500",
                         "border-gray-300",
@@ -1105,7 +1105,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                                   key={user.id}
                                   onClick={() => handleAddInvitee(user.id)}
                                   className={cn(
-                                    "px-3 py-1.5 text-md cursor-pointer",
+                                    "px-3 py-1.5 text-sm cursor-pointer",
                                     index === inviteeHighlightedIndex
                                       ? "bg-blue-100"
                                       : "hover:bg-blue-50",
@@ -1115,13 +1115,13 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                                 </div>
                               ))}
                               {inviteeCandidates.length === 0 && (
-                                <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+                                <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
                                   {t("LBL_ALL_USERS_SELECTED")}
                                 </div>
                               )}
                             </div>
                           ) : (
-                            <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+                            <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
                               {t("LBL_NO_MATCHING_USERS")}
                             </div>
                           )}
@@ -1141,7 +1141,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                         return (
                           <div
                             key={userId}
-                            className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-md"
+                            className="relative inline-flex items-center bg-blue-100 text-blue-800 rounded-md text-sm"
                           >
                             <span className="pl-3 pr-6 py-1.5">
                               {user.name}
@@ -1170,7 +1170,7 @@ export const CalendarForm: React.FC<CalendarFormProps> = ({
                 <label
                   htmlFor="send_mail"
                   className={cn(
-                    "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+                    "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
                     isDisabled && "text-gray-400",
                   )}
                 >

--- a/assets/react-web-components/src/components/QuickCreate/QuickCreateFooter.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreateFooter.tsx
@@ -28,7 +28,7 @@ export const QuickCreateFooter: React.FC<QuickCreateFooterProps> = ({
         variant="outline"
         onClick={onGoToFullForm}
         disabled={isSaving}
-        className="px-6 py-1.5 h-auto text-md font-bold bg-white hover:bg-gray-100 border-gray-300"
+        className="px-6 py-1.5 h-auto text-sm font-bold bg-white hover:bg-gray-100 border-gray-300"
       >
         {t("LBL_GO_TO_FULL_FORM")}
       </Button>
@@ -38,7 +38,7 @@ export const QuickCreateFooter: React.FC<QuickCreateFooterProps> = ({
         type="button"
         onClick={onSave}
         disabled={isSaving || saveDisabled}
-        className="px-6 py-1.5 h-auto text-md font-bold !bg-green-600 hover:!bg-green-700 !text-white"
+        className="px-6 py-1.5 h-auto text-sm font-bold !bg-green-600 hover:!bg-green-700 !text-white"
       >
         {isSaving ? (
           <>
@@ -56,7 +56,7 @@ export const QuickCreateFooter: React.FC<QuickCreateFooterProps> = ({
         variant="link"
         onClick={onCancel}
         disabled={isSaving}
-        className="px-2.5 py-1.5 h-auto text-md !text-red-600 hover:!text-red-800 hover:no-underline"
+        className="px-2.5 py-1.5 h-auto text-sm !text-red-600 hover:!text-red-800 hover:no-underline"
       >
         {t("LBL_CANCEL")}
       </Button>

--- a/assets/react-web-components/src/components/QuickCreate/QuickCreateForm.tsx
+++ b/assets/react-web-components/src/components/QuickCreate/QuickCreateForm.tsx
@@ -58,7 +58,7 @@ export const QuickCreateForm: React.FC<QuickCreateFormProps> = ({
   }
 
   return (
-    <div className="quickcreate-form space-y-3 text-md">
+    <div className="quickcreate-form space-y-3 text-sm">
       {Object.entries(fieldsByBlock).map(([blockName, blockFields]) => (
         <div key={blockName} className="quickcreate-block">
           <h4 className="fieldBlockHeader font-bold leading-[1.1] mt-0 mb-2 pb-1 border-b border-gray-300">

--- a/assets/react-web-components/src/components/ReferenceField.tsx
+++ b/assets/react-web-components/src/components/ReferenceField.tsx
@@ -515,7 +515,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
               key={mod}
               onClick={() => handleModuleSelect(mod)}
               className={cn(
-                "px-3 py-1.5 text-md cursor-pointer",
+                "px-3 py-1.5 text-sm cursor-pointer",
                 index === moduleHighlightedIndex
                   ? "bg-blue-100"
                   : selectedModule === mod
@@ -555,7 +555,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
         }}
       >
         {isLoading ? (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             検索中...
           </div>
         ) : searchResults.length > 0 ? (
@@ -565,7 +565,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
                 key={record.id}
                 onClick={() => handleSelectRecord(record)}
                 className={cn(
-                  "px-3 py-1.5 text-md cursor-pointer",
+                  "px-3 py-1.5 text-sm cursor-pointer",
                   index === highlightedIndex
                     ? "bg-blue-100"
                     : value === record.id
@@ -578,7 +578,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
             ))}
           </div>
         ) : (
-          <div className="px-3 py-1.5 text-md text-gray-500 text-center">
+          <div className="px-3 py-1.5 text-sm text-gray-500 text-center">
             {searchTerm
               ? "該当するレコードがありません"
               : "レコードがありません"}
@@ -596,7 +596,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
         <div className="flex items-baseline md:contents">
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
               labelClassName,
             )}
@@ -618,7 +618,7 @@ export const ReferenceField: React.FC<ReferenceFieldProps> = ({
         <>
           <span
             className={cn(
-              "text-md text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
+              "text-sm text-gray-700 flex-shrink-0 w-[110px] text-right leading-[30px]",
               disabled && "text-gray-400",
             )}
           >

--- a/assets/react-web-components/src/components/ui/button.tsx
+++ b/assets/react-web-components/src/components/ui/button.tsx
@@ -21,9 +21,9 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-[30px] px-3 py-1 text-md has-[>svg]:px-2.5",
-        sm: "h-[26px] rounded-md gap-1.5 px-2.5 text-md has-[>svg]:px-2",
-        lg: "h-9 rounded-md px-4 text-md has-[>svg]:px-3",
+        default: "h-[30px] px-3 py-1 text-sm has-[>svg]:px-2.5",
+        sm: "h-[26px] rounded-md gap-1.5 px-2.5 text-sm has-[>svg]:px-2",
+        lg: "h-9 rounded-md px-4 text-sm has-[>svg]:px-3",
         icon: "size-[30px]",
         "icon-sm": "size-[26px]",
         "icon-lg": "size-9",

--- a/assets/react-web-components/src/components/ui/input.tsx
+++ b/assets/react-web-components/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<
       ref={ref}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-[30px] w-full min-w-0 rounded-sm border bg-transparent px-2 py-1 text-md shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-md file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-[30px] w-full min-w-0 rounded-sm border bg-transparent px-2 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/assets/react-web-components/src/components/ui/select.tsx
+++ b/assets/react-web-components/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-sm border bg-transparent px-2 py-1 text-md whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[30px] data-[size=sm]:h-[26px] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-sm border bg-transparent px-2 py-1 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[30px] data-[size=sm]:h-[26px] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -109,7 +109,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-md outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/assets/react-web-components/src/components/ui/textarea.tsx
+++ b/assets/react-web-components/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-sm border bg-transparent px-2 py-1 text-md shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-sm border bg-transparent px-2 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/assets/react-web-components/src/components/ui/time-combobox.tsx
+++ b/assets/react-web-components/src/components/ui/time-combobox.tsx
@@ -305,7 +305,7 @@ export function TimeComboBox({
         disabled={disabled}
         placeholder={placeholder}
         className={cn(
-          "w-28 h-[30px] px-2 text-md border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
+          "w-28 h-[30px] px-2 text-sm border border-input rounded-sm shadow-xs transition-[color,box-shadow]",
           "focus:outline-none focus:ring-[3px] focus:ring-ring/50 focus:border-ring",
           "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
           error && "border-red-500 bg-red-50",
@@ -338,7 +338,7 @@ export function TimeComboBox({
                   data-index={index}
                   onClick={() => handleOptionClick(option)}
                   className={cn(
-                    "px-3 py-1.5 text-md cursor-pointer",
+                    "px-3 py-1.5 text-sm cursor-pointer",
                     highlightedIndex === index
                       ? "bg-blue-100"
                       : "hover:bg-blue-50",

--- a/assets/react-web-components/src/index.css
+++ b/assets/react-web-components/src/index.css
@@ -17,8 +17,8 @@
   --text-sm--line-height: 1.333;
   --text-base: 14px;
   --text-base--line-height: 1.429;
-  --text-md: 12px;
-  --text-md--line-height: 1.333;
+  --text-md: 16px;
+  --text-md--line-height: 1.5;
   --text-lg: 18px;
   --text-lg--line-height: 1.333;
   --text-xl: 20px;


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1688

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. assets/react-web-components/src/index.css の Tailwind テーマ定義で --text-md が 12pxとなっており、--text-sm と同値。text-md 適用箇所が text-sm と区別不能で、本来のサイズ階層 (xs < sm < base < md < lg ...) 破綻していた。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. --text-md の値が --text-sm と同じ値で定義されていた。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 既存 text-md 使用箇所をすべて text-sm へ置換。
2. index.cssにおいて --text-md を 16px、行間を 1.5 (24px相当) に再定義。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
React Web Componentsのソースコードを修正しているため、反映する際はビルドが必要。