### PR TITLE
ヘッダー(グローバルナビ)のドロップダウンが画面外にめり込む不具合を修正 (#1815)

### DIFF
--- a/layouts/v7/modules/Vtiger/partials/Topbar.tpl
+++ b/layouts/v7/modules/Vtiger/partials/Topbar.tpl
@@ -55,7 +55,11 @@
 							<div class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">
 								<a href="#" id="menubar_quickCreate" class="qc-button fa fa-plus-circle" title="{vtranslate('LBL_QUICK_CREATE',$MODULE)}" aria-hidden="true"></a>
 							</div>
-							<ul class="dropdown-menu quickCreateDropdown" role="menu" aria-labelledby="dropdownMenu1">
+							{* dropdown-menu-right: パネルをトリガーの右端基準で開く(左方向に展開)。
+							   #1815 で #navbar から navbar-right を外し Bootstrap の
+							   `.navbar-right .dropdown-menu{right:0;left:auto}` が外れたため、
+							   float の副作用を持たない dropdown-menu-right で明示する。 *}
+							<ul class="dropdown-menu dropdown-menu-right quickCreateDropdown" role="menu" aria-labelledby="dropdownMenu1">
 								<li class="title" style="padding: 5px 0 0 15px;">
 									<strong>{vtranslate('LBL_QUICK_CREATE',$MODULE)}</strong>
 								</li>
@@ -96,7 +100,7 @@
 																<span class="quick-create-module">{vtranslate($singularLabel,$moduleName)}</span>
 																<i class="fa fa-caret-down quickcreateMoreDropdownAction"></i>
 															</a>
-															<ul class="dropdown-menu quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_{$moduleModel->getName()}">
+															<ul class="dropdown-menu dropdown-menu-right quickcreateMoreDropdown" aria-labelledby="menubar_quickCreate_{$moduleModel->getName()}">
 																<li class="dropdown-header"><i class="fa fa-upload"></i> {vtranslate('LBL_FILE_UPLOAD', $moduleName)}</li>
 																<li id="VtigerAction">
 																	<a href="javascript:Documents_Index_Js.uploadTo('Vtiger')">
@@ -148,7 +152,7 @@
 									  ({$USER_MODEL->get('user_name')})"></span>
 								<span class="link-text-xs-only hidden-lg hidden-md hidden-sm">{$USER_MODEL->getName()}</span>
 							</a>
-							<div class="dropdown-menu logout-content" role="menu">
+							<div class="dropdown-menu dropdown-menu-right logout-content" role="menu">
 								<div class="row">
 									<div class="col-lg-4 col-sm-4">
 										<div class="profile-img-container">


### PR DESCRIPTION
## 概要

#1816 でヘッダー（グローバルナビ）を Flexbox 化した際、`#navbar` から `navbar-right` クラスを外しました。その結果 Bootstrap の

```css
@media (min-width: 768px) {
  .navbar-right .dropdown-menu { right: 0; left: auto; }
}
```

が効かなくなり、グローバルナビのドロップダウンパネルがトリガーの**右方向**へ開いて画面外にめり込むようになっていました。

<!-- スクリーンショット（修正前 / 修正後）をここに添付 -->

## 修正内容

グローバルナビの 3 つのパネルに Bootstrap 標準の `dropdown-menu-right` を付与し、右端揃えを明示します。

| 要素 | セレクタ |
|:--|:--|
| クイック作成 | `.quickCreateDropdown` |
| ドキュメントのサブメニュー | `.quickcreateMoreDropdown` |
| 個人設定メニュー | `.logout-content` |

`dropdown-menu-right` は配信中の TODC Bootstrap（`public/layouts/v7/lib/todc/css/bootstrap.css`）に定義済みで、リポジトリ内の他テンプレート（`DetailViewActions.tpl` / `Documents/ModuleHeader.tpl` / `dashboards/DashBoardHeader.tpl` など）でも使われている確立した書き方です。**CSS の追加・変更はありません。**

### 採らなかった方針

`navbar-right` を戻す方法は `float: right !important` / `margin-right: -15px` を伴い、#1816 の Flexbox 化で意図的に排除した指定を復活させてしまうため採用しませんでした。

## 動作確認

Playwright（headless Chromium）で実 DOM + 実スタイルシートを計測。`getBoundingClientRect()` から `rect.right - window.innerWidth` を算出しています。

### 1280px

| 要素 | 修正前 | 修正後 |
|:--|--:|--:|
| クイック作成 | **+283px はみ出し** | −178px（画面内） |
| 個人設定メニュー | **+297px はみ出し** | −15px（画面内） |

原因も CSS 計算値で確認できています。

| 状態 | `left` | `right` |
|:--|:--|:--|
| `navbar-right` あり（#1816 以前） | `-461px` | `0` |
| #1816 以降（修正前） | `0` | `-461px` |
| 本 PR 適用後 | `-461px` | `0` |

### その他の確認

- **幅 1280 / 992 / 768 / 414px（SP・collapse 展開）すべてで右へのめり込み 0**。左へのはみ出しも 0
- **三角キャレット**が意図どおりトリガー直下に戻る。`style.less` の `.global-actions .dropdown-menu:before/:after` は `right: 13px/14px` とメニュー右端基準で描かれており、元々右揃え前提の設計です
  - 修正前: キャレット x=1543（トリガー 1063–1102 の外）→ 修正後: x=1082（トリガー内）
- **SP 414px は修正前後で同一ジオメトリ**。`@media (max-width: 767px)` の既存指定と競合せず、新たな崩れは発生しません
- **全 7 スキン**（sales / marketing / support / project / inventory / contact / home）で計測値が同一。テンプレートのみの変更なのでスキン非依存です
- Smarty コメントを追加しているため、テンプレートキャッシュを削除した上でパースエラー・HTML への漏れ・JS エラーがないことを確認済み

## 既知の制約（本 PR の対象外）

ドキュメントのサブメニューは `#quickCreateModules .quickcreateMoreDropdown { left: 85% }` の詳細度（id + class）が `.dropdown-menu-right` の `left: auto` に勝つため、**現状はクラスを付与しても位置が変わりません。**

このサブメニューは Documents 項目が 3 カラムグリッドの 3 列目に来た場合に約 22px はみ出しますが、これは `navbar-right` があった #1816 以前でも約 37px 発生していた**既存の不具合**で、Flexbox 化による退行ではありません（右端列を強制して両状態を実測して確認）。

意図を揃えるためクラスは 3 要素に付与し、`left` の上書きは別 Issue として切り出すのが適切と考えています。

## 変更ファイル

- `layouts/v7/modules/Vtiger/partials/Topbar.tpl`（+7 / −3）

Refs #1815, #1816
