### PR TITLE
文字数オーバー時の修正

### DIFF
--- a/languages/en_us/Vtiger.php
+++ b/languages/en_us/Vtiger.php
@@ -53,6 +53,7 @@ $languageStrings = array(
 	'LBL_EDIT_MAILSCANNER' => 'Mail Converter',
 	'LBL_RECORD_DELETE' => 'The record you are trying to view has been deleted.',
 	'LBL_RECORD_NOT_FOUND' => 'Record you are trying to access is not found',
+	'LBL_FIELD_EXCEEDS_MAX_LENGTH' => '%s cannot exceed %d characters.',
 	'LBL_EDIT_REASON' => 'Edit reason',
 	'Result' => 'Result',
 	//'LBL_EDIT_CURRENT_FILTER' => 'Edit Current Filter',

--- a/languages/ja_jp/Vtiger.php
+++ b/languages/ja_jp/Vtiger.php
@@ -53,6 +53,7 @@ $languageStrings = array(
 	'LBL_EDIT_MAILSCANNER' => 'メールコンバーター',
 	'LBL_RECORD_DELETE' => '指定したレコードは削除されています。',
 	'LBL_RECORD_NOT_FOUND' => 'Record you are trying to access is not found',
+	'LBL_FIELD_EXCEEDS_MAX_LENGTH' => '%s は %d 文字以内で入力してください。',
 	'LBL_EDIT_REASON' => '編集の理由',
 	'Result' => "リザルト",
 	//'LBL_EDIT_CURRENT_FILTER' => 'Edit Current Filter',

--- a/layouts/v7/modules/Vtiger/uitypes/Email.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Email.tpl
@@ -18,6 +18,7 @@
 <input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement" name="{$FIELD_NAME}" type="text"
  value="{$FIELD_MODEL->get('fieldvalue')}" {if $MODE eq 'edit' && $FIELD_MODEL->get('uitype') eq '106'} readonly {/if} {if !empty($SPECIAL_VALIDATOR)}data-validator="{Zend_Json::encode($SPECIAL_VALIDATOR)}"{/if}
 {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if} data-rule-email="true" data-rule-illegal="true"
+{if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Password.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Password.tpl
@@ -18,6 +18,7 @@
 		name="{$FIELD_MODEL->getFieldName()}" value="{$FIELD_MODEL->get('fieldvalue')}"
         {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if} 
         {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+        {if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
         {if php7_count($FIELD_INFO['validator'])} 
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Phone.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Phone.tpl
@@ -18,6 +18,7 @@
 <input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" type="text" class="inputElement" name="{$FIELD_NAME}"
 value="{$FIELD_MODEL->get('fieldvalue')}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
 {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+{if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/String.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/String.tpl
@@ -26,6 +26,7 @@
 		{/if}
 		{if !empty($SPECIAL_VALIDATOR)}data-validator="{Zend_Json::encode($SPECIAL_VALIDATOR)}"{/if}
 		{if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+		{if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
 		{if !empty($FIELD_INFO['validator']) && (php7_count($FIELD_INFO['validator']))}
 			data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 		{/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Text.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Text.tpl
@@ -18,6 +18,7 @@
 {if $FIELD_MODEL->get('uitype') eq '19' || $FIELD_MODEL->get('uitype') eq '20'}
     <textarea style="height:250px; max-width: initial; width:100%;{if $FIELD_MODEL->isReadonlyEditView() eq true}background-color:#d3d3d3;opacity:0.8;{/if}" rows="3" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement textAreaElement col-lg-12 {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
         {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+        {if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
         {if php7_count($FIELD_INFO['validator'])}
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}
@@ -28,6 +29,7 @@
 {else}
     <textarea style="height:250px{if $FIELD_MODEL->isReadonlyEditView() eq true}background-color:#d3d3d3;opacity:0.8;{/if}"rows="5" id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" class="inputElement {if $FIELD_MODEL->isNameField()}nameField{/if}" name="{$FIELD_NAME}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
         {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+        {if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
         {if php7_count($FIELD_INFO['validator'])}
             data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
         {/if}

--- a/layouts/v7/modules/Vtiger/uitypes/Url.tpl
+++ b/layouts/v7/modules/Vtiger/uitypes/Url.tpl
@@ -18,6 +18,7 @@
 <input id="{$MODULE}_editView_fieldName_{$FIELD_NAME}" type="text" class="inputElement" name="{$FIELD_NAME}"
  value="{$FIELD_MODEL->get('fieldvalue')}" {if !empty($SPECIAL_VALIDATOR)}data-validator='{Zend_Json::encode($SPECIAL_VALIDATOR)}'{/if}
  {if $FIELD_INFO["mandatory"] eq true} data-rule-required="true" {/if}
+{if !empty($FIELD_INFO['maxlength'])} data-rule-maxlength="{$FIELD_INFO['maxlength']}" {/if}
 {if php7_count($FIELD_INFO['validator'])}
     data-specific-rules='{ZEND_JSON::encode($FIELD_INFO["validator"])}'
 {/if}

--- a/modules/Vtiger/models/Field.php
+++ b/modules/Vtiger/models/Field.php
@@ -411,13 +411,50 @@ class Vtiger_Field_Model extends Vtiger_Field {
 		return $mandatory=='M' ? true:false;
 	}
 
+	protected static $tableColumnsMetaCache = array();
+
 	/**
 	 * Function to get the maximum field length
-	 * @return <String> max length of the field
+	 * @return <int|null> max length of the field
 	 */
 	public function getMaxFieldLength() {
-		list($type,$mandatory,$LE,$maxlength)= explode('~',$this->get('typeofdata'));
-		return $maxlength;
+		$typeOfData = explode('~', (string)$this->get('typeofdata'));
+		if (isset($typeOfData[2]) && $typeOfData[2] === 'LE' && isset($typeOfData[3]) && is_numeric($typeOfData[3])) {
+			return (int)$typeOfData[3];
+		}
+
+		$maxlength = $this->get('maximumlength');
+		if (!empty($maxlength) && is_numeric($maxlength) && $maxlength > 0) {
+			return (int)$maxlength;
+		}
+
+		$uiType = (int)$this->get('uitype');
+		if (in_array($uiType, array(19, 20))) {
+			return null;
+		}
+
+		$tableName = $this->get('table');
+		$columnName = $this->get('column');
+		if (!empty($tableName) && !empty($columnName)) {
+			if (!isset(self::$tableColumnsMetaCache[$tableName])) {
+				$db = PearDatabase::getInstance();
+				if (isset($db->database) && method_exists($db->database, 'MetaColumns')) {
+					$metaColumns = $db->database->MetaColumns($tableName);
+					self::$tableColumnsMetaCache[$tableName] = $metaColumns ? array_change_key_case($metaColumns, CASE_UPPER) : array();
+				} else {
+					self::$tableColumnsMetaCache[$tableName] = array();
+				}
+			}
+			$upperCol = strtoupper($columnName);
+			if (isset(self::$tableColumnsMetaCache[$tableName][$upperCol])) {
+				$colMeta = self::$tableColumnsMetaCache[$tableName][$upperCol];
+				if (isset($colMeta->max_length) && $colMeta->max_length > 0 && in_array(strtolower($colMeta->type), array('varchar', 'char', 'string', 'var_string'))) {
+					return (int)$colMeta->max_length;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -837,6 +874,11 @@ class Vtiger_Field_Model extends Vtiger_Field {
 
 		if($this->getFieldDataType() == 'reference') {
 			$this->fieldInfo['referencemodules'] = $this->getReferenceList();
+		}
+
+		$maxlength = $this->getMaxFieldLength();
+		if (!empty($maxlength)) {
+			$this->fieldInfo['maxlength'] = (int)$maxlength;
 		}
 
 		$this->fieldInfo['validator'] = $this->getValidator();

--- a/modules/Vtiger/models/Module.php
+++ b/modules/Vtiger/models/Module.php
@@ -147,6 +147,7 @@ class Vtiger_Module_Model extends Vtiger_Module {
 	 * @param Vtiger_Record_Model $recordModel
 	 */
 	public function saveRecord(Vtiger_Record_Model $recordModel) {
+		$recordModel->validate();
 		$moduleName = $this->get('name');
 		$focus = $recordModel->getEntity();
 		$fields = $focus->column_fields;

--- a/modules/Vtiger/models/Record.php
+++ b/modules/Vtiger/models/Record.php
@@ -259,6 +259,40 @@ class Vtiger_Record_Model extends Vtiger_Base_Model {
 	}
 
 	/**
+	 * Function to validate the current Record Model
+	 * @return boolean true on success, throws AppException on failure
+	 */
+	public function validate() {
+		$moduleModel = $this->getModule();
+		if (!$moduleModel) {
+			return true;
+		}
+		$fieldModelList = $moduleModel->getFields();
+		foreach ($fieldModelList as $fieldName => $fieldModel) {
+			$value = $this->get($fieldName);
+			if ($value === null || is_array($value) || is_object($value)) {
+				continue;
+			}
+			$maxLength = $fieldModel->getMaxFieldLength();
+			if ($maxLength !== null && $maxLength > 0) {
+				$strValue = (string)$value;
+				$length = mb_strlen($strValue, 'UTF-8');
+				if ($length > $maxLength) {
+					$fieldLabel = vtranslate($fieldModel->get('label'), $moduleModel->getName());
+					$translatedFormat = vtranslate('LBL_FIELD_EXCEEDS_MAX_LENGTH', $moduleModel->getName());
+					if ($translatedFormat !== 'LBL_FIELD_EXCEEDS_MAX_LENGTH' && !empty($translatedFormat)) {
+						$msg = sprintf($translatedFormat, $fieldLabel, $maxLength);
+					} else {
+						$msg = sprintf('%s cannot exceed %d characters.', $fieldLabel, $maxLength);
+					}
+					throw new AppException($msg);
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Function to save the current Record Model
 	 */
 	public function save() {

--- a/public/layouts/v7/modules/Vtiger/resources/validation.js
+++ b/public/layouts/v7/modules/Vtiger/resources/validation.js
@@ -6,6 +6,10 @@
  * Portions created by vtiger are Copyright (C) vtiger.
  * All Rights Reserved.
  *************************************************************************************/
+jQuery.extend(jQuery.validator.messages, {
+	maxlength: jQuery.validator.format(app.vtranslate('JS_MAX_ALLOWED_CHARACTERS') + ' {0}')
+});
+
 jQuery.validator.addMethod("date", function(value, element, params) {
 		try {
 			if(value) {
@@ -684,11 +688,11 @@ jQuery.validator.addMethod("documentsFolder", function(value, element, params) {
 );
 
 jQuery.validator.addMethod("maximumlength", function(value, element, params) {
-		if(value > params) {
+		if(value && value.length > params) {
 			return false;
 		}
 		return true;
-	}, jQuery.validator.format(app.vtranslate('JS_LENGTH_SHOULD_BE_LESS_THAN_EQUAL_TO') + ' {0}')
+	}, jQuery.validator.format(app.vtranslate('JS_MAX_ALLOWED_CHARACTERS') + ' {0}')
 );
 
 jQuery.validator.addMethod("maxsize", function(value, element, params) {
@@ -834,6 +838,9 @@ function calculateValidationRules(form,params,meta){
 				if(params.ignoreTypes.indexOf('mandatory') === -1){
 					rules[ruleFieldName]['required'] = true;
 				}
+			}
+			if(fieldBasicInfo['maxlength']) {
+				rules[ruleFieldName]['maxlength'] = parseInt(fieldBasicInfo['maxlength']);
 			}
 			if(fieldBasicInfo['type'] in jQuery.validator.methods){
 				rules[ruleFieldName][fieldBasicInfo['type']] = true;

--- a/vtlib/Vtiger/FieldBasic.php
+++ b/vtlib/Vtiger/FieldBasic.php
@@ -72,6 +72,7 @@ class Vtiger_FieldBasic {
 		$this->readonly      = $valuemap['readonly'];
 		$this->presence      = $valuemap['presence'];
 		$this->defaultvalue  = $valuemap['defaultvalue'];
+		$this->maximumlength = isset($valuemap['maximumlength']) ? $valuemap['maximumlength'] : null;
 		$this->quickcreate = $valuemap['quickcreate'];
 		$this->sequence = $valuemap['sequence'];
 		$this->summaryfield = $valuemap['summaryfield'];


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1764

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. テキスト項目やテキストエリア項目等において、許容最大文字数を超える文字列を入力して保存した際に、エラーや警告が表示されず末尾の文字が自動的に切り捨てられて保存されてしまう。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 各入力テンプレート（String.tpl, Text.tpl, Email.tpl など）に最大文字数のバリデーションルール（data-rule-maxlength）が付与されていなかった。
2. Vtiger_Record_Model / Vtiger_Module_Model の保存フローにおいて、項目の文字長制限をチェックする共通処理が存在しなかった。カラム長を超えた文字列が暗黙的に切り捨てられていた。
3. Field_Model::getMaxFieldLength() が typeofdata の一部フォーマットにしか対応しておらず、maximumlength カラムや DBカラム定義長（MetaColumns）から長さを正しく解決できていなかった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. サーバーサイド：DBカラム定義長（VARCHAR等）や項目設定から最大文字数を自動判定・キャッシュ。 保存直前に全項目の文字数をチェックし、超過時は AppException で保存を中断。
2. フロントエンド：テキスト系入力欄（テキスト、テキストエリア、メール等）に data-rule-maxlength を追加。超過時に「最大文字数は {0}」と警告。
3. 言語ファイル：サーバーエラー文言を追加。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="470" height="77" alt="2026-08-17" src="https://github.com/user-attachments/assets/45ed7d4f-79a9-45e6-9061-69be2004a2d4" />

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->