### PR TITLE
Fix/1581-[不具合]コメントで添付された画像の描写が怪しい

### DIFF
--- a/include/utils/VtlibUtils.php
+++ b/include/utils/VtlibUtils.php
@@ -702,6 +702,7 @@ function vtlib_purify($input, $ignore = false) {
             $config->set('CSS.AllowTricky', true);
             $config->set('URI.AllowedSchemes', $allowedSchemes);
             $config->set('Attr.EnableID', true);
+            $config->set('Attr.DefaultImageAlt', '');
 
             $__htmlpurifier_instance = new HTMLPurifier($config);
         }
@@ -713,8 +714,30 @@ function vtlib_purify($input, $ignore = false) {
                     $value[$k] = vtlib_purify($v, $ignore);
                 }
             } else { // Simple type
+                // 1. Temporarily strip base64 data in img src to avoid HTMLPurifier stripping them and prevent XSS (exclude SVG to prevent XSS)
+                $tmp_markers = array();
+                if (!is_array($input) && (stripos($input, 'data:image/') !== false) && (stripos($input, ';base64,') !== false)) {
+                    $input = preg_replace_callback(
+                        '/(["\'])(data:image\/(?!svg)[^;]+;base64,[^"\']+?)\1/i',
+                        function($matches) use (&$tmp_markers) {
+                            $marker = "VTIGERB64STRIPMARKER_" . md5(uniqid(mt_rand(), true)) . "_" . count($tmp_markers);
+                            $tmp_markers[$marker] = $matches[2];
+                            return $matches[1] . $marker . $matches[1];
+                        },
+                        $input
+                    );
+                }
+
+                // 2. Perform HTML sanitization on the cleaned HTML
                 $value = $__htmlpurifier_instance->purify($input);
                 $value = purifyHtmlEventAttributes($value, true);
+
+                // 3. Restore the stripped base64 data after sanitization is complete
+                if ($tmp_markers) {
+                    foreach ($tmp_markers as $marker => $original_data) {
+                        $value = str_replace($marker, $original_data, $value);
+                    }
+                }
             }
         }
         if ($encryptInput != null) {

--- a/layouts/v7/modules/Documents/FilePreview.tpl
+++ b/layouts/v7/modules/Documents/FilePreview.tpl
@@ -53,7 +53,7 @@
                         {else if $PDF_FILE_TYPE eq 'yes'}
                             <iframe id='viewer' src="libraries/jquery/pdfjs/web/viewer.html?file={$SITE_URL}/{$DOWNLOAD_URL|escape:'url'}" height="100%" width="100%"></iframe>
                         {else if $IMAGE_FILE_TYPE eq 'yes'}
-                            <div style="overflow:auto;height:100%;width:100%;float:left;background-image: url({$DOWNLOAD_URL});background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block; background-size: contain;"></div>
+                            <div style="overflow:auto;height:100%;width:100%;float:left;background-image: url('{$DOWNLOAD_URL}');background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block; background-size: contain;"></div>
                         {else if $AUDIO_FILE_TYPE eq 'yes'}
                             <div style="overflow:auto;height:100%;width:100%;float:left;background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block;text-align: center;">
                                 <div style="display: inline-block;margin-top : 10%;">

--- a/layouts/v7/modules/ModComments/FilePreview.tpl
+++ b/layouts/v7/modules/ModComments/FilePreview.tpl
@@ -54,7 +54,7 @@
                         {else if $PDF_FILE_TYPE eq 'yes'}
                             <iframe id='viewer' src="libraries/jquery/pdfjs/web/viewer.html?file={$SITE_URL}/{$DOWNLOAD_URL|escape:'url'}" height="100%" width="100%"></iframe>
                         {else if $IMAGE_FILE_TYPE eq 'yes'}
-                            <div style="overflow:auto;height:100%;width:100%;float:left;background-image: url({$DOWNLOAD_URL});background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block; background-size: contain;"></div>
+                            <div style="overflow:auto;height:100%;width:100%;float:left;background-image: url('{$DOWNLOAD_URL}');background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block; background-size: contain;"></div>
                         {else if $AUDIO_FILE_TYPE eq 'yes'}
                             <div style="overflow:auto;height:100%;width:100%;float:left;background-color: #EEEEEE;background-position: center 25%;background-repeat: no-repeat;display: block;text-align: center;">
                                 <div style="display: inline-block;margin-top : 10%;">

--- a/modules/ModComments/views/FilePreview.php
+++ b/modules/ModComments/views/FilePreview.php
@@ -52,11 +52,11 @@ class ModComments_FilePreview_View extends Vtiger_IndexAjax_View {
 		$contents = $fileContent;
 		$filename = $fileDetails['name'];
 		$parts = explode('.', $filename);
-		if ($recordModel->get('filename')) {
-                    $fileDetails = $recordModel->getFileNameAndDownloadURL($recordId, $attachmentId);
-                    $downloadUrl =  $recordModel->getDownloadFileURL($attachmentId);
-                    $trimmedFileName = $fileDetails[0]['trimmedFileName'];
-                }
+		if (!empty($fileDetails)) {
+					$attachmentDetails = $recordModel->getFileNameAndDownloadURL($recordId, $attachmentId);
+					$downloadUrl = $recordModel->getDownloadFileURL($attachmentId);
+					$trimmedFileName = $attachmentDetails[0]['trimmedFileName'];
+				}
 
 		//support for plain/text document
 		$extn = 'txt';

--- a/vtlib/Vtiger/Functions.php
+++ b/vtlib/Vtiger/Functions.php
@@ -799,7 +799,7 @@ class Vtiger_Functions {
             }
         }
 
-        if ($saveimage && in_array($filetype, ['svg+xml', $mimeSubtype])) {
+        if ($saveimage && ($filetype === 'svg' || $mimeSubtype === 'svg+xml' || $file_details['type'] === 'image/svg+xml')) {
             // Remove malicious HTML attributes with values from the contents.
             $imageContents = purifyHtmlEventAttributes($imageContents, true);
             file_put_contents($tmpFileName, $imageContents);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1581

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. コメントにて画像データを添付・保存したあと、その画像を開くとうまく描写されない。

##  原因 / Cause
<!-- バグの原因を記述 -->
1. SVGファイルにはスクリプトが仕込めるため、サニタイズを行う仕様になっていたが、その判定条件に誤りがあり、ほかのファイル形式に対してもサニタイズ処理をしてしまっていた。
2. Base64化された非常に長いURL文字列を怪しいコードなどと誤判定し、画像タグごと削除してしまう可能性があった。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. SVGファイルである場合のみサニタイズ処理を実行するように条件式を修正。
2. SVGファイル以外において、画像データを一時マーカー文字列に置き換えるように修正。
3. 画像を表示する際のCSSにとシングルクォートを追加し、ファイル名にスペースや特殊文字が含まれていた場合でも正しくプレビュー表示されるように修正。

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
修正前
<img width="1096" height="941" alt="image" src="https://github.com/user-attachments/assets/744696da-71f1-4196-bc2c-6d4ca78ef82a" />

修正後
<img width="1045" height="703" alt="image" src="https://github.com/user-attachments/assets/e7256408-7723-4cf3-b8e9-c63f98b19cba" />
## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->