### PR TITLE
#1825 Web API（webservice.php）のCORS対応（許可オリジンを設定可能に）

### DIFF
--- a/config.template.php
+++ b/config.template.php
@@ -194,7 +194,8 @@ $maxListFieldsSelectionSize = 15;
 // Web API（public/webservice.php）で CORS を許可するオリジンのホワイトリスト
 // 別オリジンのブラウザアプリから Web API を呼び出す場合に、許可するオリジンを列挙する
 // 例: $webservice_cors_allowed_origins = array('https://example.com');
-// 空配列・未設定の場合は CORS ヘッダを一切返さない（既定）
+// ここに指定したオリジンは、製品の組み込み既定値
+// （include/Webservices/Utils.php の vtws_getDefaultCORSOrigins）に追加される
 // セキュリティ上 '*'（ワイルドカード）は指定できない
 $webservice_cors_allowed_origins = array();
 

--- a/config.template.php
+++ b/config.template.php
@@ -191,5 +191,12 @@ $email_tracking = 'Yes';
 //Maximum Listview Fields Selection Size
 $maxListFieldsSelectionSize = 15;
 
+// Web API（public/webservice.php）で CORS を許可するオリジンのホワイトリスト
+// 別オリジンのブラウザアプリから Web API を呼び出す場合に、許可するオリジンを列挙する
+// 例: $webservice_cors_allowed_origins = array('https://example.com');
+// 空配列・未設定の場合は CORS ヘッダを一切返さない（既定）
+// セキュリティ上 '*'（ワイルドカード）は指定できない
+$webservice_cors_allowed_origins = array();
+
 include_once 'config.security.php';
 ?>

--- a/include/Webservices/Utils.php
+++ b/include/Webservices/Utils.php
@@ -1353,10 +1353,25 @@ function vtws_getAllowedCORSOrigin($origin, $allowedOrigins) {
 }
 
 /**
+ * 製品として既定で許可するオリジンを返す。
+ *
+ * 「F-RevoCRM Data Connector」（Excel アドイン）は下記オリジンでホストされており、
+ * サイトごとの設定なしで利用できるよう既定で許可する。
+ *
+ * @return array 既定で許可するオリジンの配列
+ */
+function vtws_getDefaultCORSOrigins() {
+    return array(
+        // F-RevoCRM Data Connector（Excel アドイン）
+        'https://fr-excel-addin.azurewebsites.net',
+    );
+}
+
+/**
  * Web API（webservice.php）のレスポンスに CORS ヘッダを送出する。
  *
- * $webservice_cors_allowed_origins（config.inc.php）が未設定・空配列の場合は
- * 何も送出しない（＝現行動作を維持する）。
+ * 許可オリジンは vtws_getDefaultCORSOrigins() の組み込み既定値と、
+ * $webservice_cors_allowed_origins（config.inc.php）の設定値を合わせたものになる。
  *
  * 認証は sessionName リクエストパラメータ方式で Cookie に依存しないため、
  * Access-Control-Allow-Credentials は送出しない。
@@ -1364,7 +1379,11 @@ function vtws_getAllowedCORSOrigin($origin, $allowedOrigins) {
 function vtws_sendCORSHeaders() {
     global $webservice_cors_allowed_origins;
 
-    if (empty($webservice_cors_allowed_origins) || !is_array($webservice_cors_allowed_origins)) {
+    $allowedOrigins = vtws_getDefaultCORSOrigins();
+    if (!empty($webservice_cors_allowed_origins) && is_array($webservice_cors_allowed_origins)) {
+        $allowedOrigins = array_merge($allowedOrigins, $webservice_cors_allowed_origins);
+    }
+    if (empty($allowedOrigins)) {
         return;
     }
 
@@ -1372,7 +1391,7 @@ function vtws_sendCORSHeaders() {
     header('Vary: Origin', false);
 
     $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';
-    $allowedOrigin = vtws_getAllowedCORSOrigin($origin, $webservice_cors_allowed_origins);
+    $allowedOrigin = vtws_getAllowedCORSOrigin($origin, $allowedOrigins);
     if ($allowedOrigin !== null) {
         header('Access-Control-Allow-Origin: ' . $allowedOrigin);
     }

--- a/include/Webservices/Utils.php
+++ b/include/Webservices/Utils.php
@@ -1318,4 +1318,64 @@ function vtws_getAttachmentRecordId($attachmentId) {
     }
     return $crmid;
 }
+/**
+ * リクエストの Origin が許可オリジンのホワイトリストに一致するか判定する。
+ *
+ * セキュリティ上、ワイルドカード（*）は許可しない。webservice.php は
+ * 全モジュールの読み書きが可能なエンドポイントのため、完全一致のみを許可する。
+ *
+ * @param string $origin リクエストの Origin ヘッダの値
+ * @param array $allowedOrigins 許可オリジンのホワイトリスト
+ * @return string|null 一致したオリジン。一致しない場合は null
+ */
+function vtws_getAllowedCORSOrigin($origin, $allowedOrigins) {
+    if (!is_string($origin) || !is_array($allowedOrigins)) {
+        return null;
+    }
+    $origin = trim($origin);
+    // ヘッダインジェクション防止のため、エコーバックする値の形式を検証する
+    if (!preg_match('#^https?://[A-Za-z0-9._\-]+(:[0-9]{1,5})?$#i', $origin)) {
+        return null;
+    }
+    foreach ($allowedOrigins as $allowedOrigin) {
+        if (!is_string($allowedOrigin)) {
+            continue;
+        }
+        $allowedOrigin = rtrim(trim($allowedOrigin), '/');
+        if ($allowedOrigin === '' || $allowedOrigin === '*') {
+            continue;
+        }
+        if (strcasecmp($origin, $allowedOrigin) === 0) {
+            return $origin;
+        }
+    }
+    return null;
+}
+
+/**
+ * Web API（webservice.php）のレスポンスに CORS ヘッダを送出する。
+ *
+ * $webservice_cors_allowed_origins（config.inc.php）が未設定・空配列の場合は
+ * 何も送出しない（＝現行動作を維持する）。
+ *
+ * 認証は sessionName リクエストパラメータ方式で Cookie に依存しないため、
+ * Access-Control-Allow-Credentials は送出しない。
+ */
+function vtws_sendCORSHeaders() {
+    global $webservice_cors_allowed_origins;
+
+    if (empty($webservice_cors_allowed_origins) || !is_array($webservice_cors_allowed_origins)) {
+        return;
+    }
+
+    // オリジンによってレスポンスが変わるため、不一致時もキャッシュ汚染を防ぐ目的で常に送出する
+    header('Vary: Origin', false);
+
+    $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';
+    $allowedOrigin = vtws_getAllowedCORSOrigin($origin, $webservice_cors_allowed_origins);
+    if ($allowedOrigin !== null) {
+        header('Access-Control-Allow-Origin: ' . $allowedOrigin);
+    }
+}
+
 ?>

--- a/public/webservice.php
+++ b/public/webservice.php
@@ -37,6 +37,9 @@
 
 	$API_VERSION = "0.22";
 
+	// 許可オリジンが設定されている場合のみ CORS ヘッダを返す（未設定時は現行動作）
+	vtws_sendCORSHeaders();
+
 	global $seclog,$log;
 	$seclog =Logger::getLogger('SECURITY');
 	$log = Logger::getLogger('webservice');

--- a/public/webservice.php
+++ b/public/webservice.php
@@ -37,7 +37,7 @@
 
 	$API_VERSION = "0.22";
 
-	// 許可オリジンが設定されている場合のみ CORS ヘッダを返す（未設定時は現行動作）
+	// リクエストの Origin が許可オリジンに一致する場合のみ CORS ヘッダを返す
 	vtws_sendCORSHeaders();
 
 	global $seclog,$log;


### PR DESCRIPTION
close #1825

## 概要

Web API のエンドポイント `public/webservice.php` が CORS ヘッダを一切返さないため、別オリジンでホストされたブラウザアプリから Web API を呼び出せませんでした。

許可オリジンのホワイトリストを設定できるようにし、リクエストの `Origin` が一致した場合のみ `Access-Control-Allow-Origin` を返します。あわせて、弊社提供の「F-RevoCRM Data Connector」（Excel アドイン）のオリジンを組み込み既定値として許可します。

## 変更内容

| ファイル | 内容 |
|---|---|
| `config.template.php` | `$webservice_cors_allowed_origins`（既定は空配列）を追加 |
| `include/Webservices/Utils.php` | `vtws_getAllowedCORSOrigin()` / `vtws_getDefaultCORSOrigins()` / `vtws_sendCORSHeaders()` を追加 |
| `public/webservice.php` | 上記の送出関数を呼び出し |

### 許可オリジンの決まり方

組み込み既定値 + `config.inc.php` の設定値、のマージです。

```php
// include/Webservices/Utils.php（製品の組み込み既定値）
function vtws_getDefaultCORSOrigins() {
    return array(
        // F-RevoCRM Data Connector（Excel アドイン）
        'https://fr-excel-addin.azurewebsites.net',
    );
}
```

```php
// config.inc.php（サイトごとの追加設定・複数指定可）
$webservice_cors_allowed_origins = array(
    'https://app-a.example.com',
    'https://app-b.example.com',
    'http://localhost:5173',
);
```

`Access-Control-Allow-Origin` は CORS の仕様上「1リクエストにつき1値」しか持てませんが、**ホワイトリストには何個でも登録できます**。リクエストの `Origin` に一致した1つを選んで返すため、`*` を使わずに複数オリジンを許可できます。

サイトの設定を `config.customize.php` ではなく `config.inc.php` に置いたのは、`config.customize.php` がリポジトリ管理下の配布物であり、`.htaccess` と同様にバージョンアップで上書きされてしまうためです。`config.inc.php` はサイト固有ファイルのため設定が失われません。

Excel アドインのオリジンをテンプレートの既定値ではなくコード側に置いたのは、テンプレートは新規インストール時にのみ `config.inc.php` へ展開されるため、既存サイトのアップグレードでは効かないからです。

## ⚠️ アップグレード時の注意

**`.htaccess` や vhost 設定で `Header always set Access-Control-Allow-Origin "https://fr-excel-addin.azurewebsites.net"` を記述して Excel アドインを利用しているサイトは、その記述を削除してください。**

削除しないと `Access-Control-Allow-Origin` が2つ返り、ブラウザが CORS を拒否してアドインが動かなくなります。mod_headers の `always` 系は `err_headers_out`、PHP の `header()` は `headers_out` と別テーブルで動くため互いを上書きせず、両方が出力されるためです。ヘッダの値が同一でもブラウザは拒否します（実ブラウザで確認済み）。

本 PR がこの回避策を製品機能として置き換えるため、記述は不要になります。

影響範囲は以下のとおりで、それ以外のサイトに影響はありません。

| 既存設定 | 影響 |
|---|---|
| `Header always set` で**アドインのオリジン**を許可 | **要対応**（該当行を削除） |
| `Header set`（`always` なし）で許可 | 影響なし（Apache 側の値が使われる） |
| 自社アプリのオリジンのみ許可 | 影響なし |
| CORS 設定なし | 影響なし |

## 仕様

- 判定は**オリジン文字列の完全一致**。ドメインのサフィックス一致はしないため、許可されるのは `https://fr-excel-addin.azurewebsites.net` ちょうど1つで、`azurewebsites.net` 配下の他のホストは許可されない
- **ワイルドカード（`*`）は指定できない**。`webservice.php` は全モジュールの読み書きが可能なエンドポイントのため
- 認証は `sessionName` リクエストパラメータ方式で Cookie に依存しないため、`Access-Control-Allow-Credentials` は送出しない
- 一般的なクライアント実装は simple request となるため、プリフライト（`OPTIONS`）専用の応答は実装していない
- `Vary: Origin` は**一致・不一致にかかわらず常に**返す。不一致時に `Vary` が無いと、共有キャッシュが「CORS ヘッダ無しのレスポンス」を許可オリジン向けに誤配信し得るため
- エコーバックする `Origin` の値は形式を検証してから使用する（ヘッダインジェクション対策）

組み込み既定値を持つ設計のため、Issue に記載した「未設定時は CORS ヘッダを返さない＝現行動作を完全に維持」は成り立ちません。全インストールで `webservice.php` が常に `Vary: Origin` を返します。`Access-Control-Allow-Origin` が許可オリジン以外へ出ることはありません。

## 動作確認

**複数オリジンの同時許可（実 HTTP）**

`app-a` / `app-b` / `localhost:5173` を設定した状態で、4オリジン（組み込み既定値のアドイン含む）がそれぞれ自身の値を受け取り、未登録オリジンは `Access-Control-Allow-Origin` なしになることを確認。

**ヘッダ送出（実 HTTP）**

| 設定 | リクエスト | 結果 |
|---|---|---|
| 設定なし | Excel アドインのオリジン | `Access-Control-Allow-Origin` + `Vary: Origin` |
| 設定なし | `https://other.azurewebsites.net` | `Vary: Origin` のみ |
| 設定なし | `Origin` ヘッダなし（curl 直叩き） | `Vary: Origin` のみ |
| 設定なし | `OPTIONS` + アドイン | `Access-Control-Allow-Origin` 付きで 200 |
| 設定あり | 設定したオリジン | `Access-Control-Allow-Origin` + `Vary: Origin` |
| 設定あり | Excel アドインのオリジン | `Access-Control-Allow-Origin` + `Vary: Origin` |
| 設定あり | 非許可オリジン | `Vary: Origin` のみ |

**判定ロジック**

完全一致 / 大文字小文字無視 / ポート付き / ホワイトリスト側の末尾スラッシュ / 非許可オリジン / 前方一致もどき（`https://example.com.evil.com`）/ スキーム違い / `null` オリジン / 空文字 / `*` / ヘッダインジェクション（CRLF）/ パス付き / ホワイトリストが `*` のみ

組み込み既定値のスコープ: apex ドメイン（`https://azurewebsites.net`）/ 別サブドメイン / 前方に文字を足したサブドメイン / 後方に足した偽装ドメイン / 配下のサブドメイン / スキーム違い / ポート違い — いずれも拒否

**mod_headers との併用（独立した Apache インスタンスで実測）**

`Header always set` との併用で `Access-Control-Allow-Origin` が2個になること、`Header set`（`always` なし）では1個になることを確認。また PHP の `headers_list()` から Apache 側のヘッダは見えないため、PHP 側での自動回避は不可能であることも確認。

**ブラウザ挙動（google-chrome headless）**

`Access-Control-Allow-Origin` が1個なら成功、2個なら**値が同一でも**ブロックされることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)