### PR TITLE
[修正] #1625 #1829 #1830 テンプレート一括削除・iCalインポート・Webフォーム編集の Fatal error を修正

### DIFF
--- a/modules/Calendar/Activity.php
+++ b/modules/Calendar/Activity.php
@@ -1673,6 +1673,10 @@ function insertIntoRecurringTable(& $recurObj)
 	
 
 	function getBeforeAssignedUserID() {
+		// VTEntityDelta は通常 ModTracker のイベントハンドラ経由で読み込まれるが、
+		// iCal インポート等(VTIGER_BULK_SAVE_MODE でハンドラが動かない経路)では
+		// 未ロードのまま到達して Fatal error になるため明示的に読み込む。
+		require_once 'data/VTEntityDelta.php';
 		$vtEntityDelta = new VTEntityDelta();
 		$delta = $vtEntityDelta->getEntityDelta('Events', $this->id, true);
 		if(!is_array($delta))						{	return 0;	}

--- a/modules/EmailTemplates/actions/MassDelete.php
+++ b/modules/EmailTemplates/actions/MassDelete.php
@@ -34,6 +34,7 @@ class EmailTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 	public function process(Vtiger_Request $request) {
 		$moduleName = $request->getModule();
 
+		$systemTemplate = false;
 		$recordModel = new EmailTemplates_Record_Model();
 		$recordModel->setModule($moduleName);
 		$selectedIds = $request->get('selected_ids');
@@ -62,7 +63,13 @@ class EmailTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 		$response->emit();
 	}
 	
-	public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel) {
+	/**
+	 * 親(Vtiger_Mass_Action::getRecordsListFromRequest)は $request のみを取るため、
+	 * $recordModel はオプショナルにして LSP 互換を保つ
+	 * (必須引数のままだと PHP 8 で「must be compatible」の Fatal error になり
+	 *  一括削除が一切動かなくなる)。
+	 */
+	public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel = null) {
 		$selectedIds = $request->get('selected_ids');
 		$excludedIds = $request->get('excluded_ids');
 		
@@ -72,7 +79,8 @@ class EmailTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 			}
 		}
 		if(!empty($excludedIds)){
-			$moduleModel = $recordModel->getModule();
+			$moduleModel = $recordModel ? $recordModel->getModule()
+					: Vtiger_Module_Model::getInstance($request->getModule());
 			$recordIds  = $moduleModel->getRecordIds($excludedIds);
 			return $recordIds;
 		}

--- a/modules/PDFTemplates/actions/MassDelete.php
+++ b/modules/PDFTemplates/actions/MassDelete.php
@@ -34,6 +34,7 @@ class PDFTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 	public function process(Vtiger_Request $request) {
 		$moduleName = $request->getModule();
 
+		$systemTemplate = false;
 		$recordModel = new PDFTemplates_Record_Model();
 		$recordModel->setModule($moduleName);
 		$selectedIds = $request->get('selected_ids');
@@ -62,7 +63,13 @@ class PDFTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 		$response->emit();
 	}
 	
-	public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel) {
+	/**
+	 * 親(Vtiger_Mass_Action::getRecordsListFromRequest)は $request のみを取るため、
+	 * $recordModel はオプショナルにして LSP 互換を保つ
+	 * (必須引数のままだと PHP 8 で「must be compatible」の Fatal error になり
+	 *  一括削除が一切動かなくなる)。
+	 */
+	public function getRecordsListFromRequest(Vtiger_Request $request, $recordModel = null) {
 		$selectedIds = $request->get('selected_ids');
 		$excludedIds = $request->get('excluded_ids');
 		
@@ -72,7 +79,8 @@ class PDFTemplates_MassDelete_Action extends Vtiger_Mass_Action {
 			}
 		}
 		if(!empty($excludedIds)){
-			$moduleModel = $recordModel->getModule();
+			$moduleModel = $recordModel ? $recordModel->getModule()
+					: Vtiger_Module_Model::getInstance($request->getModule());
 			$recordIds  = $moduleModel->getRecordIds($excludedIds);
 			return $recordIds;
 		}

--- a/modules/Settings/Webforms/models/Record.php
+++ b/modules/Settings/Webforms/models/Record.php
@@ -156,6 +156,11 @@ class Settings_Webforms_Record_Model extends Settings_Vtiger_Record_Model {
 	 */
 	public function getSelectedFieldsList($mode='') {
 		if (!$this->selectedFields) {
+			// 初期化しないと、対象モジュール未設定 / 項目が 1 件も無い Webフォームで
+			// 未定義変数のまま $this->selectedFields に代入され null になる。
+			// 呼び出し元のテンプレート(FieldsEditView.tpl)は array_key_exists() に
+			// 渡すため、PHP 8 では TypeError で編集画面が開かなくなる。
+			$selectedFields = array();
 			$targetModule = $this->get('targetmodule');
 			if ($targetModule) {
 				$db = PearDatabase::getInstance();

--- a/setup/migration/scripts/20260828021711_add_missing_webforms_field_table.php
+++ b/setup/migration/scripts/20260828021711_add_missing_webforms_field_table.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * マイグレーション: add_missing_webforms_field_table
+ * 生成日時: 20260828021711
+ */
+
+require_once dirname(__FILE__) . '/../FRMigrationClass.php';
+
+class Migration20260828021711_AddMissingWebformsFieldTable extends FRMigrationClass {
+
+    /**
+     * マイグレーションを実行する
+     */
+    public function process() {
+        // E2E で Webフォームの編集画面(Settings > 自動化 > Webフォーム)を開いたところ
+        // 次の Fatal error になった:
+        //   array_key_exists(): Argument #2 ($array) must be of type array, null given
+        //   in .../Settings/Webforms/FieldsEditView.tpl.php
+        // 原因は vtiger_webforms_field テーブルの欠落。
+        // Settings_Webforms_Record_Model::getSelectedFieldsList() がこのテーブルを
+        // SELECT しており、テーブルが無いとクエリが失敗して選択項目リストが
+        // null のままテンプレートに渡り、上記の Fatal error になる。
+        //
+        // setup/sql/dump_firstinstall.sql および modules/Migration/schema/660_to_700.php
+        // では標準スキーマとして定義されているテーブルで、この環境の DB 構築時に
+        // 欠落したものと判断する(vtiger_cv2role / vtiger_cv2rs と同じ経緯。
+        // 20260709161603_add_missing_cv2role_cv2rs_tables.php を参照)。
+        //
+        // 定義は dump_firstinstall.sql に合わせる。FK は vtiger_webforms(id) のみ張り、
+        // vtiger_field.fieldname は一意ではないため FK ではなくトリガーで追従させる
+        // (dump_firstinstall.sql と同じ扱い)。
+        if (!$this->checkTableExists('vtiger_webforms_field')) {
+            $this->db->query("CREATE TABLE `vtiger_webforms_field` (
+                `id` int NOT NULL AUTO_INCREMENT,
+                `webformid` int NOT NULL,
+                `fieldname` varchar(50) NOT NULL,
+                `neutralizedfield` varchar(50) NOT NULL,
+                `defaultvalue` text,
+                `required` int NOT NULL DEFAULT '0',
+                `sequence` int DEFAULT NULL,
+                `hidden` int DEFAULT NULL,
+                PRIMARY KEY (`id`),
+                KEY `webforms_webforms_field_idx` (`id`),
+                KEY `fk_1_vtiger_webforms_field` (`webformid`),
+                KEY `fk_2_vtiger_webforms_field` (`fieldname`),
+                CONSTRAINT `fk_1_vtiger_webforms_field` FOREIGN KEY (`webformid`)
+                    REFERENCES `vtiger_webforms` (`id`) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+            $this->log("vtiger_webforms_field テーブルを作成しました");
+        } else {
+            $this->log("vtiger_webforms_field は既に存在するためスキップしました");
+        }
+
+        // dump_firstinstall.sql には vtiger_field 削除時に Webフォーム項目を
+        // 掃除するトリガー tr_vtiger_field_delete_webforms_field も含まれるが、
+        // **ここでは作成しない**。
+        // このトリガーがあるとレイアウトエディタからのカスタム項目削除が失敗する
+        // (E2E: tests/5_管理設定/D-02_レイアウト編集「カスタム項目の削除」が
+        //  CI で 3 回連続失敗し、トリガーを外すと green になることを確認した)。
+        // Webフォーム編集画面が開けるようにするという本マイグレーションの目的は
+        // テーブルの存在だけで満たせる。トリガー無しで残るのは
+        // 「削除済み項目を参照する vtiger_webforms_field の行」だけで、
+        // 参照側は array_key_exists($fieldName, $allFields) で弾かれる
+        // (Settings_Webforms_Record_Model::getSelectedFieldsList)。
+        $this->db->query("DROP TRIGGER IF EXISTS `tr_vtiger_field_delete_webforms_field`");
+        $this->log("トリガー tr_vtiger_field_delete_webforms_field は作成しません(項目削除を阻害するため)");
+    }
+}


### PR DESCRIPTION
##  関連Issue / Related Issue
- fix #1625
- fix #1829
- fix #1830

##  不具合の内容 / Bug
1. **#1625 メール・PDFテンプレートの一括削除が動作しない**
   一覧でレコードを選択して一括削除を実行し、確認ダイアログで「Yes」を押しても
   レコードが削除されない。画面上にエラーは表示されない。
2. **#1829 iCal(.ics)インポートが動作しない**
   カレンダー（活動）の iCal インポートを実行すると Fatal error が画面に表示され、
   予定が登録されない。
3. **#1830 Webフォームの編集画面が開かない**
   システム設定 > 自動化 > Webフォーム で作成したフォームを編集しようとすると、
   編集画面が表示されず Fatal error になる。

##  原因 / Cause
1. **#1625**: `EmailTemplates_MassDelete_Action` / `PDFTemplates_MassDelete_Action` の
   `getRecordsListFromRequest()` が、親 `Vtiger_Mass_Action` のシグネチャ（`$request` のみ）に対し
   `$recordModel` を **既定値なしの必須引数**として追加していた。PHP 8 の LSP チェックに
   引っかかり、クラス読み込み時点で Fatal error になる。

       Declaration of EmailTemplates_MassDelete_Action::getRecordsListFromRequest(
         Vtiger_Request $request, $recordModel) must be compatible with
         Vtiger_Mass_Action::getRecordsListFromRequest(Vtiger_Request $request)

   Ajax 経由の呼び出しのため、画面にはエラーが出ず「押しても何も起きない」ように見える。

2. **#1829**: `VTEntityDelta` は通常 ModTracker のイベントハンドラ
   （`modules/ModTracker/ModTrackerHandler.php` の `require_once 'data/VTEntityDelta.php'`）
   経由で読み込まれるが、インポート処理は `$VTIGER_BULK_SAVE_MODE = true` で
   イベントハンドラが動作しないため、未ロードのまま `Activity::getBeforeAssignedUserID()` に到達する。

       Uncaught Error: Class "VTEntityDelta" not found in modules/Calendar/Activity.php:1676

3. **#1830**: `Settings_Webforms_Record_Model::getSelectedFieldsList()` が選択項目リストとして
   null を返し、テンプレート（FieldsEditView.tpl）の `array_key_exists()` に渡っていた。
   null になる経路が 2 つある。
   - `vtiger_webforms_field` テーブルの欠落。同メソッドはこのテーブルを SELECT しており、
     欠落するとクエリが失敗する。`setup/sql/dump_firstinstall.sql` および
     `modules/Migration/schema/660_to_700.php` では標準スキーマとして定義されているが、
     環境によって欠落している（`vtiger_cv2role` / `vtiger_cv2rs` と同じ経緯）。
   - 同メソッドのローカル変数 `$selectedFields` が未初期化。テーブルが存在する環境でも、
     項目が 1 件も無い Webフォームではループが 1 度も回らず、未定義変数のまま代入されて null になる。

##  変更内容 / Details of Change
1. **#1625** `modules/{EmailTemplates,PDFTemplates}/actions/MassDelete.php`
   - `getRecordsListFromRequest()` の `$recordModel` をオプショナル（`= null`）にして親互換にする
   - `$recordModel` が null の場合は `Vtiger_Module_Model::getInstance()` でモジュールを引く
   - 未初期化のまま参照していた `$systemTemplate` を `false` で初期化する
2. **#1829** `modules/Calendar/Activity.php`
   - `getBeforeAssignedUserID()` の先頭で `data/VTEntityDelta.php` を明示的に読み込む
3. **#1830**
   - `modules/Settings/Webforms/models/Record.php`: `$selectedFields` を `array()` で初期化する
   - `setup/migration/scripts/20260828021711_add_missing_webforms_field_table.php`（新規）:
     欠落している `vtiger_webforms_field` テーブルを `dump_firstinstall.sql` の定義に合わせて作成する

## スクリーンショット / Screenshot
各 Issue に発生時のエラー内容を記載しています（#1829 / #1830）。

## 影響範囲  / Affected Area
- メールテンプレート / PDFテンプレートの一括削除（`EmailTemplates` / `PDFTemplates` の MassDelete）
  - 一括削除以外の経路（詳細画面からの削除など）は変更していません
- カレンダーの iCal インポート
  - `Activity::getBeforeAssignedUserID()` への `require_once` 追加のみで、通常保存経路の挙動は変わりません
- Webフォームの編集画面（`Settings/Webforms`）
- マイグレーション追加により、`vtiger_webforms_field` が無い環境では同テーブルが新規作成されます
  （既に存在する環境ではスキップします）

## チェックリスト / Check List
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [x] 言語対応（日・英）を行った

## 備考 / Remarks
- **テスト根拠**: 3 件とも E2E（Playwright）で修正前に失敗することを確認し、本修正で成功することを確認しました。
  検証用の spec は E2E 拡充 PR (#1702) 側に含まれます（`4-7_テンプレート` / `4-8_カレンダー/9_iCal` /
  `5_管理設定/E-01_Webフォーム`）。同 PR の CI は本修正込みで green です。
- **言語対応**: 本修正は言語ファイルを変更しないため該当なしとしています（`languages/` 配下の差分はありません）。
- **`dump_firstinstall.sql` のトリガーについて**: 同ファイルには `vtiger_field` の AFTER DELETE トリガー
  `tr_vtiger_field_delete_webforms_field` も含まれますが、本マイグレーションでは **作成していません**。
  このトリガーがあるとレイアウトエディタからのカスタム項目削除が失敗するためです
  （E2E の「カスタム項目の削除」が 3 回連続で失敗し、トリガーを外すと成功することを確認）。
  トリガー無しで残るのは「削除済み項目を参照する `vtiger_webforms_field` の行」だけで、
  参照側の `getSelectedFieldsList()` が `array_key_exists($fieldName, $allFields)` で弾くため実害はありません。
- **関連**: #1523 で同種の「テンプレート削除ボタンが機能しない」が報告されクローズされていますが、
  本 PR で修正した一括削除の経路は未解決のままでした（#1625）。