### PR TITLE
Fix/1834　タグに空白付きで入力すると同名タグが重複作成される

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -786,6 +786,13 @@ class CRMEntity {
 			$explodetagName[0] = $implodeTagName;
 		}
 
+		// 「タグA, タグB」のようにカンマ+空白区切りの場合に前後の空白が残ると
+		// 同名タグが重複作成されるため, 正規化した上で重複を除去する
+		$explodetagName = array_map(array('Vtiger_Tag_Model', 'normalizeName'), $explodetagName);
+		$explodetagName = array_values(array_unique(array_filter($explodetagName, function($tagName) {
+			return $tagName !== '';
+		})));
+
 		foreach($explodetagName as $tagName){
 			if(Vtiger_Tag_Model::checkTagExistence(array('tagName' => $tagName))){ // 新規作成
 				$id = $db->getUniqueId('vtiger_freetags');
@@ -800,9 +807,11 @@ class CRMEntity {
 				}else{
 					$DBTagsValue = Vtiger_Cache::get('DBTags', 'DBTagsValue'); // Vtiger_Tag_Model::checkTagExistence()にてキャッシュが用意される
 					$otherTagsWithSameName = array_filter($DBTagsValue, function($item) use ($tagName, $userId) {
-						if($item['tag'] == $tagName && $item['owner'] == $userId){
+						// DB側も正規化して比較する(Vtiger_Tag_Model::checkTagExistence()と同じ規則)
+						$DBTagName = Vtiger_Tag_Model::normalizeName($item['tag']);
+						if($DBTagName == $tagName && $item['owner'] == $userId){
 							return true;
-						}elseif($item['tag'] == $tagName && $item['visibility'] == 'public'){
+						}elseif($DBTagName == $tagName && $item['visibility'] == 'public'){
 							return true;
 						}
 						return false;

--- a/modules/Vtiger/actions/TagCloud.php
+++ b/modules/Vtiger/actions/TagCloud.php
@@ -92,7 +92,7 @@ class Vtiger_TagCloud_Action extends Vtiger_Mass_Action {
 
 		$tagsList = $request->get('tagsList');
 		$newTags = $tagsList['new'];
-		if(empty($newTags)) {
+		if(empty($newTags) || !is_array($newTags)) {
 			$newTags = array();
 		}
 		$existingTags = $tagsList['existing'];
@@ -109,6 +109,13 @@ class Vtiger_TagCloud_Action extends Vtiger_Mass_Action {
 		if(!is_array($existingTags)) {
 			$existingTags = array();
 		}
+
+		// 「タグA, タグB」のようにカンマ+空白区切りで入力された場合に前後の空白が残ると
+		// 同名タグが重複作成されるため, 正規化した上で重複を除去する
+		$newTags = array_map(array('Vtiger_Tag_Model', 'normalizeName'), $newTags);
+		$newTags = array_values(array_unique(array_filter($newTags, function($tagName) {
+			return $tagName !== '';
+		})));
 
 		$result = array();
 		$invalidTagName = array();
@@ -159,7 +166,7 @@ class Vtiger_TagCloud_Action extends Vtiger_Mass_Action {
 	public function update(Vtiger_Request $request) {
 		$module = $request->get('module');
 		$tagId = $request->get('id');
-		$tagName = $request->get('name');
+		$tagName = Vtiger_Tag_Model::normalizeName($request->get('name'));
 		$visibility = $request->get('visibility');
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 

--- a/modules/Vtiger/models/Tag.php
+++ b/modules/Vtiger/models/Tag.php
@@ -63,7 +63,7 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 
 	public function create(){
 		$db = PearDatabase::getInstance();
-		$tagName = $this->getName();
+		$tagName = self::normalizeName($this->getName());
 		$visibility = $this->getType();
 		$currentUser = Users_Record_Model::getCurrentUserModel();
 		$id = $db->getUniqueId('vtiger_freetags');
@@ -75,7 +75,8 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 	public function update() {
 		$db = PearDatabase::getInstance();
 		$query = "UPDATE vtiger_freetags SET tag=?, raw_tag=?, visibility=? WHERE id=?";
-		$db->pquery($query, array($this->getName(), $this->getName(), $this->getType(), $this->getId()));
+		$tagName = self::normalizeName($this->getName());
+		$db->pquery($query, array($tagName, $tagName, $this->getType(), $this->getId()));
 		return true;
 	}
 
@@ -269,6 +270,7 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 
 	public static function getInstanceByName($name, $userId, $excludedTagId = false) {
 		$db = PearDatabase::getInstance();
+		$name = self::normalizeName($name);
 		$query = "SELECT * FROM vtiger_freetags WHERE (tag=? OR raw_tag=?) AND (owner=? OR visibility=?)";
 		$params = array($name, $name, $userId, self::PUBLIC_TYPE);
 		if($excludedTagId !== false) {
@@ -293,6 +295,22 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 		//TODO : check for module specific delete query as well 
 		$result = $db->pquery($checkQuery, array($tagId, $userIdToExclude));
 		return $db->num_rows($result) > 0 ? true : false;
+	}
+
+	/**
+	 * タグ名を正規化する（前後の半角・全角スペースや改行等を除去）
+	 * 「タグA, タグB」のようにカンマ+空白区切りで入力された場合に,
+	 * 空白付きの名前が別タグとして扱われ重複作成されるのを防ぐ
+	 * @param string $tagName
+	 * @return string 正規化したタグ名
+	 */
+	public static function normalizeName($tagName) {
+		if(!is_string($tagName)) {
+			return $tagName;
+		}
+		$normalizedName = preg_replace('/^[\s\x{3000}]+|[\s\x{3000}]+$/u', '', $tagName);
+		// 不正な文字コード等でpreg_replaceが失敗した場合は半角空白のみ除去する
+		return ($normalizedName === null) ? trim($tagName) : $normalizedName;
 	}
 
 	/*
@@ -321,7 +339,7 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 			Vtiger_Cache::set('DBTags', 'DBTagsValue', $DBTagsValue);
 		}
 
-		$tagName = $tagValue['tagName'];
+		$tagName = self::normalizeName($tagValue['tagName']);
 		$tagId = isset($tagValue['tagId']) ? $tagValue['tagId'] : '';
 		$previousVisibility = '';
 		$otherTagsWithSameName = array_filter($DBTagsValue, function($item) use ($tagName, $tagId, &$previousVisibility) {
@@ -329,7 +347,9 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 				$previousVisibility = $item['visibility'];
 				return false;
 			}
-			return $item['tag'] == $tagName;
+			// DB側も正規化して比較する. 既に空白付きで保存されてしまったタグが
+			// 同名チェックをすり抜けて重複を増やし続けるのを防ぐ
+			return self::normalizeName($item['tag']) == $tagName;
 		});
 		$otherTagsWithSameName = array_values($otherTagsWithSameName);
 
@@ -360,7 +380,7 @@ class Vtiger_Tag_Model extends Vtiger_Base_Model {
 		$DBTagsValue = Vtiger_Cache::get('DBTags', 'DBTagsValue');
 		$DBTagsValue[] = array(
 			'id' => $tagValue['tagId'],
-			'tag' => $tagValue['tagName'],
+			'tag' => self::normalizeName($tagValue['tagName']),
 			'owner' => $tagValue['owner'],
 			'visibility' => $tagValue['visibility']
 		);


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1834

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. タグ生成するとき、同じ文字列で最後に空白をつけると、同じ名前のタグが作れてしまう（文字列の前の空白でも同様）

##  原因 / Cause
<!-- バグの原因を記述 -->
1. タグ名の前後の空白を除去する処理がなかった

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
タグ名の前後の空白を除去
1. modules/Vtiger/actions/TagCloud.phpで配列単位で空白除去
2. modules/Vtiger/models/Tag.phpで一件ごと（文字列ごと）で空白除去
3. data/CRMEntity.phpでインポート時の空白除去

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="205" height="96" alt="image" src="https://github.com/user-attachments/assets/6288b793-b635-4b38-98ba-0b36eff89421" />
<br>変更前は上図のように空白付きで同名のタグが生成できたが、変更後は生成できなくなった

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
タグの新規作成・リネーム・インポート

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->