### PR TITLE
Fix/1020　製品インポート時、マージすると単価が0になる不具合を修正

### DIFF
--- a/modules/Import/actions/Data.php
+++ b/modules/Import/actions/Data.php
@@ -333,7 +333,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 
 							if ($mergeType == Import_Utils_Helper::$AUTO_MERGE_OVERWRITE) {
 								try {
-									$fieldData = $this->transformForImport($fieldData, $moduleMeta, $cache);
+									$fieldData = $this->transformForImport($fieldData, $moduleMeta, $cache, true, true, $baseRecordId);
 									$fieldData['id'] = $baseEntityId;
 									$entityInfo = $this->importRecord($fieldData, 'update');
 									if ($entityInfo) {
@@ -375,7 +375,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 								}
 
 								try {
-									$filteredFieldData = $this->transformForImport($filteredFieldData, $moduleMeta, $cache, $fillDefault, $mandatoryValueChecks);
+									$filteredFieldData = $this->transformForImport($filteredFieldData, $moduleMeta, $cache, $fillDefault, $mandatoryValueChecks, $baseRecordId);
 									$filteredFieldData['id'] = $baseEntityId;
 									if ($userPriviligesModel->hasModuleActionPermission($tabId, 'EditView')) {
 										$entityInfo = $this->importRecord($filteredFieldData, 'revise');
@@ -502,7 +502,7 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 		return true;
 	}
 
-	public function transformForImport($fieldData, $moduleMeta, $cache, $fillDefault = true, $checkMandatoryFieldValues = true) {
+	public function transformForImport($fieldData, $moduleMeta, $cache, $fillDefault = true, $checkMandatoryFieldValues = true, $existingRecordId = null) {
 		global $current_user;
 		$adb = PearDatabase::getInstance();
 		$moduleImportableFields = array();
@@ -770,6 +770,24 @@ class Import_Data_Action extends Vtiger_Action_Controller {
 				$_REQUEST['cur_'.$this->lineitem_currency_id.'_check'] = 1;
 			}
 			$fieldData['currency_id'] = $this->lineitem_currency_id;
+
+			// マージで既存レコードを更新する場合、VtigerProductOperation::sanitizeCurrency()が
+			// $element(=$fieldData)の'currency{通貨ID}'キーを見て$_REQUESTの通貨別チェック状態を
+			// 再構築するため、インポートで触れていない通貨は補完しないと単価が消えてしまう。
+			// 既存の通貨別単価を'currency{通貨ID}'として$fieldDataに補完して保持する。
+			if (!empty($existingRecordId) && isset($moduleFields['unit_price'])) {
+				$existingCurrencyRows = $adb->pquery(
+					'SELECT currencyid, actual_price FROM vtiger_productcurrencyrel WHERE productid = ? AND currencyid != ?',
+					array($existingRecordId, $this->lineitem_currency_id)
+				);
+				for ($i = 0; $i < $adb->num_rows($existingCurrencyRows); $i++) {
+					$existingCurrencyId = $adb->query_result($existingCurrencyRows, $i, 'currencyid');
+					$existingActualPrice = $adb->query_result($existingCurrencyRows, $i, 'actual_price');
+					if ($existingActualPrice !== null && $existingActualPrice !== '') {
+						$fieldData['currency'.$existingCurrencyId] = $existingActualPrice;
+					}
+				}
+			}
 		}
 
 		$skippedCalendarFields = array('contact_id', 'duration_hours', 'duration_minutes', 'recurringtype', 'reminder_time', 'smcreatorid');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1020 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. インポートでマージするときのバグ
2. インポートで単価を設定しないと全部の通貨のチェック状態が外れて０になる
3. インポートで特定の通貨で単価をマージすると、保存されていた他の通貨のチェック状態が外れる

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 全ての通貨のチェック状態が一括で管理されていた（単価の通貨ごとのチェック状態が保存されない）
2. 通貨別単価の保存処理は「保存のたびに既存の通貨別単価を全削除し、リクエストでチェックが入っている通貨だけ作り直す」という設計になっている。
3. 通常の編集画面はフォーム送信で全通貨のチェック状態を毎回送ってくるためこれで問題ないが、インポートは「今回操作した1通貨分の情報」しか持っていないため、他の通貨は「チェックが外れた」と誤認識され、削除されたまま復元されない。

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
マージ前の通貨ごとの単価の状態を保持できるようにした
1. インポートで単価がなかったら、既存の値をそのまま保存
4. インポートで指定されたときだけ、新しい値で上書き（デフォルトの通貨のみ）

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->
<img width="298" height="110" alt="image" src="https://github.com/user-attachments/assets/a8ebcb32-61db-4d8a-8d07-929b05b6ccd4" />
<br>変更により単価が保持されるようになった

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->
製品・サービス（Products/Services）モジュールで、複数通貨の単価を保存済みの既存レコードに対してマージインポート（上書き／項目ごとにマージ）を行う場合

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->
通貨を指定してインポートする仕組みはないため、デフォルトの通貨のみ値が更新される
他の通貨はデフォルトの通貨から換算して保存されるが、デフォルトの通貨が変わっても更新されない（ブラウザでの編集も同様）