### PR TITLE
Fix/1573 詳細画面の「次のページ」「前のページ」の取得ロジックを改善

### DIFF
--- a/include/ListView/ListViewSession.php
+++ b/include/ListView/ListViewSession.php
@@ -182,6 +182,43 @@ class ListViewSession {
 		return $recordNavigationInfo;
 	}
 
+	/**
+	 * getListViewNavigation()が返すページ単位のレコードID一覧から、指定レコードの前後のレコードIDを求める。
+	 * @param <Array> $navigationInfo - getListViewNavigation()の戻り値
+	 * @param <Number> $currentRecordId
+	 * @return <Array> - array($prevRecordId, $nextRecordId) 該当が無い場合はnullを返す
+	 */
+	public static function resolveAdjacentRecordIds($navigationInfo, $currentRecordId){
+		$prevRecordId = null;
+		$nextRecordId = null;
+		$found = false;
+		if($navigationInfo){
+			foreach($navigationInfo as $page=>$pageInfo) {
+				foreach($pageInfo as $index=>$record) {
+					//If record found then next record in the interation
+					//will be next record
+					if($found) {
+						$nextRecordId = $record;
+						break;
+					}
+					if($record == $currentRecordId) {
+						$found = true;
+					}
+					//If record not found then we are assiging previousRecordId
+					//assuming next record will get matched
+					if(!$found) {
+						$prevRecordId = $record;
+					}
+				}
+				//if record is found and next record is not calculated we need to perform iteration
+				if($found && !empty($nextRecordId)) {
+					break;
+				}
+			}
+		}
+		return array($prevRecordId, $nextRecordId);
+	}
+
 	function getRequestCurrentPage($currentModule, $query, $viewid, $queryMode = false) {
 		global $list_max_entries_per_page, $adb;
 		$start = 1;

--- a/layouts/v7/modules/Vtiger/ListViewContents.tpl
+++ b/layouts/v7/modules/Vtiger/ListViewContents.tpl
@@ -140,7 +140,7 @@
 				<tbody class="overflow-y">
 					{foreach item=LISTVIEW_ENTRY from=$LISTVIEW_ENTRIES name=listview}
 						{assign var=DATA_ID value=$LISTVIEW_ENTRY->getId()}
-						{assign var=DATA_URL value=$LISTVIEW_ENTRY->getDetailViewUrl()}
+						{assign var=DATA_URL value=$LISTVIEW_ENTRY->getDetailViewUrl()|cat:"&firstId="|cat:$LISTVIEW_FIRST_ID|cat:"&lastId="|cat:$LISTVIEW_LAST_ID}
 						{if $SEARCH_MODE_RESULTS && $LISTVIEW_ENTRY->getModuleName() == "ModComments"}
 							{assign var=RELATED_TO value=$LISTVIEW_ENTRY->get('related_to_model')}
 							{assign var=DATA_ID value=$RELATED_TO->getId()}
@@ -164,7 +164,7 @@
 							<span class="fieldValue">
 								<span class="value">
 									{if ($LISTVIEW_HEADER->isNameField() eq true or $LISTVIEW_HEADER->get('uitype') eq '4') and $MODULE_MODEL->isListViewNameFieldNavigationEnabled() eq true }
-										<a href="{$LISTVIEW_ENTRY->getDetailViewUrl()}&app={$SELECTED_MENU_CATEGORY}">{$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}</a>
+										<a href="{$LISTVIEW_ENTRY->getDetailViewUrl()}&app={$SELECTED_MENU_CATEGORY}&firstId={$LISTVIEW_FIRST_ID}&lastId={$LISTVIEW_LAST_ID}">{$LISTVIEW_ENTRY->get($LISTVIEW_HEADERNAME)}</a>
 										{if $MODULE eq 'Products' &&$LISTVIEW_ENTRY->isBundle()}
 											&nbsp;-&nbsp;<i class="mute">{vtranslate('LBL_PRODUCT_BUNDLE', $MODULE)}</i>
 										{/if}

--- a/modules/Vtiger/models/ListView.php
+++ b/modules/Vtiger/models/ListView.php
@@ -291,6 +291,138 @@ class Vtiger_ListView_Model extends Vtiger_Base_Model {
 	}
 
 	/**
+	 * 検索条件・並び順を適用した結果セット全体の先頭・末尾レコードIDを取得する(現在ページ内ではなく全体)。
+	 * 現在ページが先頭ページ/最終ページであれば取得済みのページデータからIDを読み取り、
+	 * 判明しない側だけ "ORDER BY ... LIMIT 1" で取得する。
+	 * order by用のJOINが登録済みである必要があるため getListViewEntries() の後に呼ぶこと。
+	 * @param <Array> $listViewEntries - getListViewEntries()が返した現在ページのレコード(レコードIDをキーとし一覧の並び順)
+	 * @param Vtiger_Paging_Model $pagingModel - 上記と同じ呼び出しで使用したページングモデル
+	 * @return <Array> - array($firstRecordId, $lastRecordId) 結果が0件の場合はnullを返す
+	 */
+	public function getFirstAndLastRecordId($listViewEntries = array(), $pagingModel = null) {
+		$firstRecordId = null;
+		$lastRecordId = null;
+
+		if (!empty($listViewEntries)) {
+			$entryIds = array_keys($listViewEntries);
+			if ($pagingModel && $pagingModel->getStartIndex() == 0) {
+				// 先頭ページなので取得済みデータの1件目が結果セット全体の先頭
+				$firstRecordId = $entryIds[0];
+			}
+			if ($pagingModel && !$pagingModel->isNextPageExists()) {
+				// 最終ページなので取得済みデータの最終件が結果セット全体の末尾
+				$lastRecordId = $entryIds[php7_count($entryIds)-1];
+			}
+		}
+
+		if ($firstRecordId !== null && $lastRecordId !== null) {
+			return array($firstRecordId, $lastRecordId);
+		}
+
+		$db = PearDatabase::getInstance();
+		$moduleName = $this->getModule()->get('name');
+		$queryGenerator = $this->get('query_generator');
+
+		$meta = $queryGenerator->getMeta($moduleName);
+		$columnIndex = $meta->getObectIndexColumn();
+		$baseTable = $meta->getEntityBaseTable();
+
+		$listQuery = $this->getQuery();
+		$position = stripos($listQuery, ' from ');
+		if (!$position) {
+			return array($firstRecordId, $lastRecordId);
+		}
+		$split = preg_split('/ from /i', $listQuery);
+		$splitCount = php7_count($split);
+		$narrowedQuery = "SELECT $baseTable.$columnIndex AS recordid ";
+		for ($i=1; $i<$splitCount; $i++) {
+			$narrowedQuery = $narrowedQuery. ' FROM ' .$split[$i];
+		}
+
+		list($normalOrderBy, $reverseOrderBy) = $this->buildBoundaryOrderByClauses();
+
+		if ($firstRecordId === null) {
+			$firstResult = $db->pquery($narrowedQuery.$normalOrderBy.' LIMIT 1', array());
+			$firstRecordId = $db->num_rows($firstResult) ? $db->query_result($firstResult, 0, 'recordid') : null;
+		}
+
+		if ($lastRecordId === null) {
+			$lastResult = $db->pquery($narrowedQuery.$reverseOrderBy.' LIMIT 1', array());
+			$lastRecordId = $db->num_rows($lastResult) ? $db->query_result($lastResult, 0, 'recordid') : null;
+		}
+
+		return array($firstRecordId, $lastRecordId);
+	}
+
+	/**
+	 * 一覧表示と同じORDER BY句と、その昇順降順を逆にした句を組み立てる(getListViewEntries()と同じ条件分岐)。
+	 * ソート対象の値が重複していても先頭/末尾が一意に決まるよう、IDカラムを最後の並び替え条件として付与する。
+	 * @return <Array> - array($normalOrderBy, $reversedOrderBy) いずれも先頭に " ORDER BY " を含む
+	 */
+	private function buildBoundaryOrderByClauses() {
+		$moduleName = $this->getModule()->get('name');
+		$moduleFocus = CRMEntity::getInstance($moduleName);
+		$queryGenerator = $this->get('query_generator');
+
+		$meta = $queryGenerator->getMeta($moduleName);
+		$columnIndex = $meta->getObectIndexColumn();
+		$baseTable = $meta->getEntityBaseTable();
+		$idColumn = $baseTable.'.'.$columnIndex;
+
+		$orderBy = $this->getForSql('orderby');
+		$sortOrder = $this->getForSql('sortorder');
+		$orderByFieldModel = null;
+		if (!empty($orderBy)) {
+			$fieldModels = $queryGenerator->getModuleFields();
+			$orderByFieldModel = $fieldModels[$orderBy];
+		}
+
+		$sortColumns = array();
+		$normalDirection = !empty($sortOrder) ? strtoupper($sortOrder) : 'ASC';
+
+		if (!empty($orderBy) && $orderByFieldModel) {
+			if ($orderBy == 'roleid' && $moduleName == 'Users') {
+				$sortColumns[] = 'vtiger_role.rolename';
+			} else {
+				$sortColumns[] = $queryGenerator->getOrderByColumn($orderBy);
+			}
+			if ($orderBy == 'first_name' && $moduleName == 'Users') {
+				$sortColumns[] = 'last_name';
+				$sortColumns[] = 'email1';
+			}
+		} else if ($moduleName != 'Users') {
+			// ソート未指定時に getListViewEntries() が適用するデフォルトの並び順に合わせる
+			$defaultTable = $moduleFocus->table_name;
+			if (empty($defaultTable)) {
+				$defaultTable = 'vtiger_crmentity';
+			}
+			$sortColumns[] = $defaultTable.'.modifiedtime';
+			$normalDirection = 'DESC';
+		} else {
+			// Usersはソート未指定時に一覧側でORDER BYが付かず順序が不定のため、本メソッド内でのみIDカラムで代用する
+			$sortColumns[] = $idColumn;
+		}
+		if (!in_array($idColumn, $sortColumns)) {
+			$sortColumns[] = $idColumn;
+		}
+
+		$reverseDirection = ($normalDirection == 'ASC') ? 'DESC' : 'ASC';
+
+		return array(
+			$this->buildOrderByClause($sortColumns, $normalDirection),
+			$this->buildOrderByClause($sortColumns, $reverseDirection),
+		);
+	}
+
+	private function buildOrderByClause($columns, $direction) {
+		$parts = array();
+		foreach ($columns as $column) {
+			$parts[] = $column.' '.$direction;
+		}
+		return ' ORDER BY '.implode(', ', $parts);
+	}
+
+	/**
 	 * Function to get the list view entries
 	 * @param Vtiger_Paging_Model $pagingModel
 	 * @return <Array> - Associative array of record id mapped to Vtiger_Record_Model instance.

--- a/modules/Vtiger/views/Detail.php
+++ b/modules/Vtiger/views/Detail.php
@@ -73,10 +73,39 @@ class Vtiger_Detail_View extends Vtiger_Index_View {
 	}
 
 	function preProcess(Vtiger_Request $request, $display=true) {
-		parent::preProcess($request, false);
-
 		$recordId = $request->get('record');
 		$moduleName = $request->getModule();
+		$navigateDirection = $request->get('navigate');
+
+		if (!empty($navigateDirection)) {
+			// 前後ボタンが実際に押された時のみ、一覧同等のSQLで隣のレコードを特定して遷移する
+			$navigationInfo = ListViewSession::getListViewNavigation($recordId);
+			list($prevRecordId, $nextRecordId) = ListViewSession::resolveAdjacentRecordIds($navigationInfo, $recordId);
+			$targetRecordId = ($navigateDirection == 'previous') ? $prevRecordId : $nextRecordId;
+
+			$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
+			// 一覧表示後に隣のレコードが削除された等で見つからない場合は現在のレコードに留まる
+			$loadUrl = !empty($targetRecordId) ? $moduleModel->getDetailViewUrl($targetRecordId) : $moduleModel->getDetailViewUrl($recordId);
+
+			$firstId = $request->isEmpty('firstId') ? null : $request->get('firstId');
+			$lastId = $request->isEmpty('lastId') ? null : $request->get('lastId');
+			if ($firstId !== null) {
+				$loadUrl .= '&firstId='.$firstId;
+			}
+			if ($lastId !== null) {
+				$loadUrl .= '&lastId='.$lastId;
+			}
+			$appName = $request->get('app');
+			if (!empty($appName)) {
+				$loadUrl .= '&app='.$appName;
+			}
+
+			header("Location: $loadUrl");
+			exit;
+		}
+
+		parent::preProcess($request, false);
+
 		if(!$this->record){
 			$this->record = Vtiger_DetailView_Model::getInstance($moduleName, $recordId);
 		}
@@ -93,47 +122,36 @@ class Vtiger_Detail_View extends Vtiger_Index_View {
 		$detailViewLinkParams = array('MODULE'=>$moduleName,'RECORD'=>$recordId);
 
 		$detailViewLinks = $this->record->getDetailViewLinks($detailViewLinkParams);
-		$navigationInfo = ListViewSession::getListViewNavigation($recordId);
 
 		$viewer = $this->getViewer($request);
 		$viewer->assign('RECORD', $recordModel);
-		$viewer->assign('NAVIGATION', $navigationInfo);
-
-		//Intially make the prev and next records as null
-		$prevRecordId = null;
-		$nextRecordId = null;
-		$found = false;
-		if ($navigationInfo) {
-			foreach($navigationInfo as $page=>$pageInfo) {
-				foreach($pageInfo as $index=>$record) {
-					//If record found then next record in the interation
-					//will be next record
-					if($found) {
-						$nextRecordId = $record;
-						break;
-					}
-					if($record == $recordId) {
-						$found = true;
-					}
-					//If record not found then we are assiging previousRecordId
-					//assuming next record will get matched
-					if(!$found) {
-						$prevRecordId = $record;
-					}
-				}
-				//if record is found and next record is not calculated we need to perform iteration
-				if($found && !empty($nextRecordId)) {
-					break;
-				}
-			}
-		}
 
 		$moduleModel = Vtiger_Module_Model::getInstance($moduleName);
-		if(!empty($prevRecordId)) {
-			$viewer->assign('PREVIOUS_RECORD_URL', $moduleModel->getDetailViewUrl($prevRecordId));
-		}
-		if(!empty($nextRecordId)) {
-			$viewer->assign('NEXT_RECORD_URL', $moduleModel->getDetailViewUrl($nextRecordId));
+		$firstId = $request->isEmpty('firstId') ? null : $request->get('firstId');
+		$lastId = $request->isEmpty('lastId') ? null : $request->get('lastId');
+
+		if ($firstId !== null && $lastId !== null) {
+			// 一覧から先頭/末尾IDを受け取っている場合はID比較のみで前後ボタンの活性を判定する(SQLを実行しない)
+			// appパラメータはテンプレート側で付与されるためここでは付けない
+			$navParams = '&firstId='.$firstId.'&lastId='.$lastId;
+			if ($recordId != $firstId) {
+				$viewer->assign('PREVIOUS_RECORD_URL', $moduleModel->getDetailViewUrl($recordId).'&navigate=previous'.$navParams);
+			}
+			if ($recordId != $lastId) {
+				$viewer->assign('NEXT_RECORD_URL', $moduleModel->getDetailViewUrl($recordId).'&navigate=next'.$navParams);
+			}
+		} else {
+			// URL直接アクセス等で先頭/末尾IDが無い場合は従来通り隣のレコードを都度取得する
+			$navigationInfo = ListViewSession::getListViewNavigation($recordId);
+			$viewer->assign('NAVIGATION', $navigationInfo);
+			list($prevRecordId, $nextRecordId) = ListViewSession::resolveAdjacentRecordIds($navigationInfo, $recordId);
+
+			if(!empty($prevRecordId)) {
+				$viewer->assign('PREVIOUS_RECORD_URL', $moduleModel->getDetailViewUrl($prevRecordId));
+			}
+			if(!empty($nextRecordId)) {
+				$viewer->assign('NEXT_RECORD_URL', $moduleModel->getDetailViewUrl($nextRecordId));
+			}
 		}
 
 		$viewer->assign('MODULE_MODEL', $this->record->getModule());

--- a/modules/Vtiger/views/List.php
+++ b/modules/Vtiger/views/List.php
@@ -16,6 +16,8 @@ class Vtiger_List_View extends Vtiger_Index_View {
 	protected $noOfEntries = false;
 	protected $pagingModel = false;
 	protected $listViewModel = false;
+	protected $firstRecordId = false;
+	protected $lastRecordId = false;
 	function __construct() {
 		parent::__construct();
 	}
@@ -340,6 +342,11 @@ class Vtiger_List_View extends Vtiger_Index_View {
 		if(!$this->listViewEntries){
 			$this->listViewEntries = $listViewModel->getListViewEntries($pagingModel);
 		}
+		if($this->firstRecordId === false && $this->lastRecordId === false){
+			list($this->firstRecordId, $this->lastRecordId) = $listViewModel->getFirstAndLastRecordId($this->listViewEntries, $pagingModel);
+		}
+		$viewer->assign('LISTVIEW_FIRST_ID', $this->firstRecordId);
+		$viewer->assign('LISTVIEW_LAST_ID', $this->lastRecordId);
 		//if list view entries restricted to show, paging should not fail
 		if(!$this->noOfEntries) {
 			$this->noOfEntries = $pagingModel->get('_listcount');


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #1573 

##  不具合の内容 / Bug
<!-- バグ,要望やIssue内容を簡潔に記述 -->
1. 詳細画面の「次のページ」」「前のページ」の取得ロジックを改善してほしい

##  原因 / Cause
<!-- バグの原因を記述 -->
1. 詳細画面の「前のレコード」「次のレコード」ボタンの活性/非活性判定が、画面を開くたびに一覧取得と同等のSQLを実行していた

##  変更内容 / Details of Change
<!-- 行った修正を記述 -->
1. 一覧表示時に、検索条件・並び順を適用した結果セット全体の先頭・末尾レコードIDを取得し、詳細画面へURLパラメータで引き渡す
   - `modules/Vtiger/models/ListView.php`: 先頭・末尾IDを返す `getFirstAndLastRecordId()` を追加。
     現在のページが先頭ページ/最終ページであれば取得済みのページデータから読み取り、
     判明しない側のみ `ORDER BY ... LIMIT 1` で取得する
   - `modules/Vtiger/views/List.php`: 上記を呼び出し、テンプレートへ渡す
   - `layouts/v7/modules/Vtiger/ListViewContents.tpl`: 一覧各行の詳細画面リンクに `firstId` / `lastId` を付与

2. 詳細画面では受け取ったIDとの比較のみでボタンの活性/非活性を判定し、SQLを実行しないようにした
   - `modules/Vtiger/views/Detail.php`: 現在のレコードIDと `firstId` / `lastId` を比較するだけの判定に変更
   
3. 実際の隣接レコードの特定は、ボタンが押された時点で初めて実行する（遅延実行）
   - `modules/Vtiger/views/Detail.php`: `navigate` パラメータ付きでアクセスされた場合のみ
     隣接レコードを特定し、該当レコードの詳細画面へリダイレクトする処理を追加
   - `include/ListView/ListViewSession.php`: 隣接レコードの特定ロジックを
     `resolveAdjacentRecordIds()` として切り出し（ロジック自体は変更なし）

4. 先頭/末尾IDが渡されない場合（URL直接アクセス等）は従来通りの動作にフォールバック
   - `modules/Vtiger/views/Detail.php`: 従来通り隣接レコードを都度取得する処理を残した

## スクリーンショット / Screenshot
<!-- 変更のスクリーンショットを添付 -->

## 影響範囲  / Affected Area
<!-- このプルリクエストにより、影響が想定される範囲を記述 -->

## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った
- [] 言語対応（日・英）を行った

## 備考 / Remarks
<!-- その他、特記すべき事項を記述 -->